### PR TITLE
Changed getElements() return type

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -15,13 +15,13 @@ function start(){
 	var STARTING_LINE = 30;
 	for(var i=STARTING_LINE; i<lines.length; i++){
 		var multiplearray = [getElements(i)];
-		while(multiplearray[0][0] == nextChar(i+1)){
+		while(multiplearray[0].traditional == nextChar(i+1)){
 			multiplearray.push(getElements(i+1));
 			i++;
 		}
 
-		dictionarysimplified[multiplearray[0][1]] = multiplearray;
-		dictionarytraditional[multiplearray[0][0]] = multiplearray;
+		dictionarysimplified[multiplearray[0].simplified] = multiplearray;
+		dictionarytraditional[multiplearray[0].traditional] = multiplearray;
 	}
 
 	function nextChar(j){
@@ -43,7 +43,12 @@ function start(){
 		var elements = lines[i].split(" ");
 		var traditional = elements[0];
 		var simplified = elements[1];
-		return [traditional, simplified, pinyin, definition];
+		return {
+			traditional: traditional,
+			simplified: simplified,
+			pinyin: pinyin,
+			definition: definition
+		};
 	}
 }
 
@@ -235,8 +240,8 @@ function getPinyin(character, scripttype){
 		if("undefined" == typeof dictionarysimplified[character]){
 			return "nof";
 		}
-		if(dictionarysimplified[character][2]!=null){
-			return dictionarysimplified[character][2];
+		if(dictionarysimplified[character].pinyin!=null){
+			return dictionarysimplified[character].pinyin;
 		}
 		else{
 			return "nof";


### PR DESCRIPTION
Now `getElements()` returns an object. I find that's cleaner to use 

```
console.log(hanzi.definitionLookup('㝵')[0].definition);
```

than

```
console.log(hanzi.definitionLookup('㝵')[0][3]);
```
