### PR TITLE
Both radical and graphical decomposition return a single array

### DIFF
--- a/lib/hanzidecomposer.js
+++ b/lib/hanzidecomposer.js
@@ -93,7 +93,7 @@ var decompose = function(character, typeOfDecomposition){
 			var components = getComponents(character);
 			if(components.length==2){
 				for(var j=0; j<2; j++){
-					final_array.push(radicalDecomposition(components[j]));
+					final_array = final_array.concat(radicalDecomposition(components[j]));
 				}
 			}
 			else{
@@ -109,7 +109,7 @@ var decompose = function(character, typeOfDecomposition){
 		//console.log("components length: "+ components.length);
 		if(components.length == 2){
 			for(var j=0; j<2; j++){
-				final_array.push(graphicalDecomposition(components[j]));
+				final_array = final_array.concat(graphicalDecomposition(components[j]));
 			}
 		}
 		else{


### PR DESCRIPTION
This is to avoid returning arrays containing arrays, now all decompositions returns a single array.
