### PR TITLE
Avoid adding methods to String prototype

### DIFF
--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -366,8 +366,8 @@ function getRegularityScale(charpinyin, phoneticpinyin){
 		return null;
 	}
 	var regularity = 0;
-	charpinyin = charpinyin.toLowerCase();
-	phoneticpinyin = phoneticpinyin.toLowerCase();
+	charpinyin = new PinyinSyllable(charpinyin.toLowerCase());
+	phoneticpinyin = new PinyinSyllable(phoneticpinyin.toLowerCase());
 
 	// Regularity Scale: 1 = Exact Match (with tone), 2 = Syllable Match (without tone)
 	// 3 = Similar in Initial, 4 = Similar in Final, 0 = No regularity
@@ -375,7 +375,7 @@ function getRegularityScale(charpinyin, phoneticpinyin){
 	//First test for Scale 1 & 2
 	if(charpinyin.syllable() == phoneticpinyin.syllable()){
 		regularity = 2;
-		if(charpinyin == phoneticpinyin){
+		if(charpinyin.raw_syllable == phoneticpinyin.raw_syllable){
 			regularity = 1;
 		}
 	}
@@ -403,26 +403,30 @@ function getPhoneticSet(regularity_scale){
 	}
 }
 
+function PinyinSyllable(raw_syllable){
+	this.raw_syllable = raw_syllable;
+}
+
 //Methods
-String.prototype.syllable = function(){
+PinyinSyllable.prototype.syllable = function(){
 	// Returns Pinyin sans tone
-	return this.substring(0, this.length-1);
+	return this.raw_syllable.substring(0, this.raw_syllable.length-1);
 };
 
-String.prototype.initial = function(){
+PinyinSyllable.prototype.initial = function(){
 	//Returns the initial of pinyin syllable
 	var initial = "";
-	if(this.substring(1,2) == "h"){
+	if(this.raw_syllable.substring(1,2) == "h"){
 		//Take into zh, ch, sh
-		initial = this.substring(0,2);
+		initial = this.raw_syllable.substring(0,2);
 	}
 	else{
-		initial = this.substring(0,1);
+		initial = this.raw_syllable.substring(0,1);
 	}
 	return initial;
 };
 
-String.prototype.final = function(){
+PinyinSyllable.prototype.final = function(){
 	var syllable = this.syllable();
 	var rhyme = syllable.replace(this.initial(),"");
 	return rhyme;

--- a/test/all.js
+++ b/test/all.js
@@ -22,6 +22,18 @@ describe('hanzidecomposer', function(){
 		assert(hanzi.getRadicalMeaning('氵'), "water");
 	});
 
+	it("determines phonetic regularity", function(){
+		var expected = {
+			di1: {
+				character: '低',
+				component: [ '亻', '氐', '氐', '亻', '氏', '氏', '丶', '丶' ],
+				phoneticpinyin: [ 'ren2', 'di1', 'di3', 'ren2', 'shi4', 'zhi1', 'dian3', 'zhu3' ],
+				regularity: [ 0, 1, 2, 0, 4, 4, 3, 0 ]
+			}
+		};
+		assert.deepEqual(hanzi.determinePhoneticRegularity('低'), expected);
+	});
+
 	it('should once decompose simplified character', function(){
 		assert.deepEqual(hanzi.decompose('爱').components1, ['No glyph available', '友']);
 	});


### PR DESCRIPTION
To avoid polluting the String prototype, I've refactored the code a bit.
Also I've created a test for the determinePhoneticRegularity method, I used `低` there becasue it has all five "phonetic regularities".
