### PR TITLE
:memo: Add MIT license to npm `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "author": "Niel de la Rouviere",
     "description": "HanziJS is a Chinese character and NLP module for Chinese language processing for Node.js",
     "version": "0.5.0",
+    "license": "MIT",
     "main": "index.js",
     "browserify": { "transform": [ "brfs" ] },
     "browser": {


### PR DESCRIPTION
Suppresses the license missing error when installing this package in npm 5