### PR TITLE
Task/change frequency data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,3 +22,4 @@ v0.5.0 - Add Longest Match segment function thanks to nikdvp! Browserify builds 
 v0.5.1 - Add licence information to package.json. Thanks zurawiki!
 v0.6.0 - Fix frequency info for some traditional characters. Traditional characters now default to using the simplified list. Thanks raylillywhite!
 v0.7.0 - Add a new function getCharacterInFrequencyListByPosition which grabs a character in the frequency list.
+v1.0.0 - Changes which frequency data we use. A new list removes the traditional variants of simplified characters. Meaning some characters from a frequency perspective were in there twice which caused odd side-effects.

--- a/lib/data/frequency_with_script_variants_removed.txt
+++ b/lib/data/frequency_with_script_variants_removed.txt
@@ -1,0 +1,8943 @@
+1	的	7922684	4.09432531783	de/di2/di4	(possessive particle)/of, really and truly, aim/clear
+2	一	3050722	5.67089309742	yi1	one/1/single/a(n)
+3	是	2615490	7.02253944928	shi4	is/are/am/yes/to be
+4	不	2237915	8.17906065392	bu4/bu2	(negative prefix)/not/no
+5	了	2128528	9.27905228304	le/liao3/liao4	(modal particle intensifying preceding clause)/(completed action marker), to know/to understand/to know, clear, look afar from a high place
+6	在	2009181	10.3173671567	zai4	(located) at/in/exist
+7	人	1867999	11.2827212715	ren2	man/person/people
+8	有	1782004	12.2036344486	you3	to have/there is/there are/to exist/to be
+9	我	1690048	13.0770261318	wo3	I/me/myself
+10	他	1595761	13.9016916951	ta1	he/him
+11	这	1552042	14.7037639291	zhe4/zhei4	this/these, this/these/(sometimes used before a measure word, especially in Beijing)
+12	个	1199580	15.3236890409	ge4	(a measure word)/individual
+13	们	1169853	15.9282516811	men	(plural marker for pronouns and a few animate nouns)
+14	中	1104541	16.4990620505	zhong1/zhong4	within/among/in/middle/center/while (doing sth)/during/China/Chinese, hit (the mark)
+15	来	1079469	17.056915583	lai2	to come
+16	上	1069575	17.6096560434	shang4	on/on top/upon/first (of two parts)/previous or last (week, etc.)/upper/higher/above/previous/to climb/to go into/above/to go up
+17	大	1054064	18.1543806496	da4/dai4	big/huge/large/major/great/wide/deep/oldest/eldest, doctor
+18	为	1039036	18.6913390088	wei2/wei4	act as/take...to be/to be/to do/to serve as/to become, because of/for/to
+19	和	1010465	19.2135322999	he2/he4/huo2/huo4	and/together with/with/peace/harmony/union, cap (a poem)/respond in singing, soft/warm, mix together/to blend
+20	国	985350	19.7227465323	guo2	country/state/nation
+21	地	969349	20.2236916858	de/di4	(subor. part. adverbial)/-ly, earth/ground/field/place/land
+22	到	965035	20.7224074283	dao4	to (a place)/until (a time)/up to/to go/to arrive
+23	以	910627	21.1930059251	yi3	to use/according to/so as to/in order to/by/with/because/Israel (abbrev.)
+24	说	874977	21.6451810318	shui4/shuo1	persuade (politically), to speak/to say
+25	时	833532	22.0759379787	shi2	o'clock/time/when/hour/season/period
+26	要	811011	22.4950564076	yao1/yao4	demand/ask/request/coerce, important/vital/to want/to be going to/must
+27	就	771108	22.8935535592	jiu4	at once/then/right away/only/(emphasis)/to approach/to move towards/to undertake
+28	出	755256	23.2838586328	chu1	to go out/to come out/to occur/to produce/to go beyond/to rise/to put forth/to occur/to happen/(a measure word for dramas, plays, or operas)
+29	会	734888	23.6636378269	hui4/kuai4	can/be possible/be able to/to assemble/to meet/to gather/to see/union/group/association, to balance an account/accounting
+30	可	723108	24.037329292	ke3	can/may/able to/certain(ly)/to suit/(particle used for emphasis)
+31	也	710259	24.404380585	ye3	also/too
+32	你	705205	24.7688200459	ni3	you
+33	对	703632	25.1324466038	dui4	couple/pair/to be opposite/to oppose/to face/for/to/correct (answer)/to answer/to reply/to direct (towards sth)/right
+34	生	682031	25.4849100859	sheng1	to be born/to give birth/life/to grow
+35	能	665358	25.8287572096	neng2	can/may/capable/energy/able
+36	而	649239	26.1642742736	er2	and/as well as/but (not)/yet (not)/(shows causal relation)/(shows change of state)/(shows contrast)
+37	子	640640	26.4953475023	zi3/zi	11 p.m.-1 a.m./1st earthly branch/child/midnight/son/child/seed/egg/small thing, (noun suff.)
+38	那	638538	26.8253344486	na3/na4/nei4	how/which, that/those, that/those/(sometimes used before a measure word, especially in Beijing)
+39	得	630688	27.1512646316	de2/de/dei3	obtain/get/gain/proper/suitable/proud/contented/allow/permit/ready/finished, a sentence particle used after a verb to show effect/degree or possibility, to have to/must/ought to/to need to
+40	于	630524	27.4771100619	yu2	(surname), in/at/to/from/by/than/out of
+41	着	626326	27.8007860281	zhao1/zhao2/zhe/zhu4/zhuo2	catch/receive/suffer, part. indicates the successful result of a verb/to touch/to come in contact with/to feel/to be affected by/to catch fire/to fall asleep/to burn, -ing part. (indicates an action in progress)/part. coverb-forming after some verbs, to make known/to show/to prove/to write/book/outstanding, to wear (clothes)/to contact/to use/to apply
+42	下	621185	28.121805202	xia4	under/second (of two parts)/next (week, etc.)/lower/below/underneath/down(wards)/to decline/to go down/latter
+43	自	611687	28.4379159507	zi4	from/self/oneself/since
+44	之	609003	28.752639648	zhi1	(literary equivalent of 的)/(subor. part.)/him/her/it
+45	年	601887	29.0636859024	nian2	year
+46	过	589925	29.3685503729	guo4	(experienced action marker)/to cross/to go over/to pass (time)/to celebrate (a holiday)/to live/to get along/(surname)/excessively/too-
+47	发	572904	29.6646186437	fa1/fa4	to send out/to show (one's feeling)/to issue/to develop, hair
+48	后	570764	29.9595809943	hou4	empress/queen/surname, back/behind/rear/afterwards/after/later
+49	作	542791	30.2400873144	zuo4	to regard as/to take (somebody) for/to do/to make
+50	里	537795	30.5180117759	li3	inside/internal/interior, village/within/inside, Chinese mile/neighborhood/li, a Chinese unit of length = one-half kilometer/hometown
+51	用	535480	30.7947398798	yong4	to use
+52	道	534695	31.0710623073	dao4	direction/way/method/road/path/principle/truth/reason/skill/method/Tao (of Taoism)/a measure word/to say/to speak/to talk
+53	行	531848	31.3459134476	hang2/xing2/xing4	a row/profession/professional, all right/capable/competent/OK/okay/to go/to do/to travel/temporary/to walk/to go/will do, behavior/conduct
+54	所	523028	31.6162065431	suo3	actually/place
+55	然	511026	31.8802971833	ran2	correct/right/so/thus/like this/-ly
+56	家	509790	32.1437490771	jia1	furniture/tool, -ist/-er/-ian/home/family/a person engaged in a certain art or profession
+57	种	503344	32.4038697739	zhong3/zhong4	kind/type/race/breed/seed/species (taxonomy), to plant/to cultivate
+58	事	499172	32.6618344431	shi4	matter/thing/item/work/affair
+59	成	499007	32.9197138428	cheng2/cheng4	finish/complete/accomplish/become/turn into/win/succeed/one tenth, finish/complete/accomplish/become/turn into/win/succeed/one tenth
+60	方	492763	33.1743664362	fang1	square/quadrilateral/direction/just
+61	多	481689	33.4232961509	duo1	many/much/a lot of/numerous/multi-
+62	经	481338	33.672044474	jing1	classics/sacred book/pass through/to undergo/scripture
+63	么	477969	33.9190517481	ma/me/yao1	(interrog. part.), (interrog. suff.), one on dice/small
+64	去	476270	34.1651810041	qu4	to go/to leave/to remove
+65	法	466816	34.4064245736	fa3	law/method/way/Buddhist teaching/Legalist/France (abbrev.)
+66	学	464261	34.646347757	xue2	learn/study/science/-ology
+67	如	449036	34.8784028867	ru2	as (if)/such as
+68	都	439568	35.1055650948	dou1/du1	all/both (if two things are involved)/entirely (due to)each/even/already, (surname)/metropolis/capital city
+69	同	437611	35.3317159543	tong2	like/same/similar/together/alike/with
+70	现	433960	35.5559800314	xian4	appear/present/now/existing/current
+71	当	429274	35.7778224533	dang1/dang4	to be/to act as/manage/withstand/when/during/ought/should/match equally/equal/same/obstruct/just at (a time or place)/on the spot/right/just at, at or in the very same.../to pawn/suitable/adequate/fitting/proper/replace/represent
+72	没	428146	35.9990819415	mei2/mo4	(negative prefix for verbs)/have not/not, drowned/to end/to die/to inundate
+73	动	426839	36.2196659916	dong4	to use/to act/to move/to change
+74	面	425180	36.4393926952	mian4	fade/side/surface/aspect/top/face/flour/noodles, flour/noodles
+75	起	424933	36.6589917528	qi3	to rise/to raise/to get up
+76	看	424616	36.8784269896	kan1/kan4	to look after/to take care of/to watch/to guard, it depends/think/to see/to look at
+77	定	422538	37.0967883468	ding4	to set/to fix/to determine/to decide/to order
+78	天	419884	37.3137781563	tian1	day/sky/heaven
+79	分	419382	37.5305085396	fen1/fen4	to divide/minute/(a measure word)/(a unit of length = 0.33 centimeter), part
+80	还	415855	37.7454162218	hai2/huan2/huan4	also/in addition/more/still/else/still/yet/(not) yet, (surname)/pay back/return
+81	进	412166	37.9584174836	jin4	advance/enter/to come in
+82	好	411866	38.1712637099	hao3/hao4	good/well, be fond of
+83	小	410987	38.383655682	xiao3	small/tiny/few/young
+84	部	403066	38.5919541991	bu4	ministry/department/section/part/division/troops/board/(a measure word)/(a measure word for works of literature, films, machines, etc.)
+85	其	403028	38.8002330784	qi2	his/her/its/theirs/that/such/it (refers to sth preceding it)
+86	些	400528	39.0072199948	xie1	some/few/several/(a measure word)
+87	主	399693	39.2137753956	zhu3	to own/to host/master/lord/primary
+88	样	398149	39.4195328802	yang4	manner/pattern/way/appearance/shape
+89	理	398087	39.6252583241	li3	reason/logic/science/inner principle or structure
+90	心	392228	39.8279559239	xin1	heart/mind
+91	她	388612	40.0287848286	ta1	she
+92	本	388118	40.2293584415	ben3	roots or stems of plants/origin/source/this/the current/root/foundation/basis/(a measure word)
+93	前	381431	40.4264763122	qian2	before/in front/ago/former/previous/earlier/front
+94	开	377012	40.6213105094	kai1	open/operate (vehicle)/start
+95	但	374459	40.8148253542	dan4	but/yet/however/only/merely/still
+96	因	371612	41.0068689116	yin1	cause/reason/because
+97	只	370059	41.1981099018	qi2/zhi1/zhi3	earth-spirit/peace, (a measure word, for birds and some animals, etc.)/single/only, M for one of a pair, only/merely/just/but, but/only
+98	从	369958	41.3892986966	cong1/cong2/zong4	lax/yielding/unhurried, from/obey/observe/follow, second cousin
+99	想	368819	41.5798988732	xiang3	to think/to believe/to suppose/to wish/to want/to miss
+100	实	368494	41.7703310946	shi2	real/true/honest/really/solid
+101	日	363763	41.9583184056	ri4	Japan/day/sun/date/day of the month
+102	军	362526	42.1456664533	jun1	army/military/arms
+103	者	360974	42.3322124505	zhe3	-ist, -er (person)/person (who does sth)
+104	意	360232	42.5183749931	yi4	idea/meaning/wish/desire/(abbr.) Italy
+105	无	359265	42.7040378045	wu2	-less/not to have/no/none/not/to lack/un-
+106	力	359136	42.8896339507	li4	power/force/strength
+107	它	346173	43.0685310111	ta1	it
+108	与	345532	43.2470968122	yu2/yu3/yu4	(interrog. part.), and/to give/together with, take part in
+109	长	342148	43.4239138125	chang2/zhang3	length/long/forever/always/constantly, chief/head/elder/to grow/to develop
+110	把	340730	43.5999980114	ba3/ba4	(a measure word)/(marker for direct-object)/to hold/to contain/to grasp/to take hold of, handle
+111	机	339823	43.7756134862	ji1	machine/opportunity/secret
+112	十	338954	43.9507798748	shi2	ten/10
+113	民	335796	44.1243142558	min2	the people/nationality/citizen
+114	第	325780	44.292672517	di4	(prefix before a number, for ordering numbers, e.g. "first", "number two", etc)
+115	公	318626	44.4573336973	gong1	just/honorable (designation)/public/common
+116	此	318534	44.6219473334	ci3	this/these
+117	已	318143	44.7863589065	yi3	already/to stop/then/afterwards
+118	工	317532	44.9504547239	gong1	work/worker/skill/profession/trade/craft/labor
+119	使	316273	45.1138999088	shi3	to make/to cause/to enable/to use/to employ/messenger
+120	情	312900	45.2756019774	qing2	feeling/emotion/passion/situation
+121	明	309873	45.4357397375	ming2	clear/bright/to understand/next/the Ming dynasty
+122	性	309844	45.5958625107	xing4	sex/nature/surname/suffix corresponding to -ness or -ity
+123	知	306384	45.7541972074	zhi1	to know/to be aware
+124	全	305248	45.9119448362	quan2	all/whole/entire/every/complete
+125	三	304272	46.0691880827	san1	three/3
+126	又	302933	46.2257393539	you4	(once) again/also/both... and.../again
+127	关	302473	46.3820529039	guan1	(surname)/mountain pass/to close/to shut/to turn off/to concern/to involve
+128	点	300800	46.5375018724	dian3	(downwards-right convex character stroke)/o'clock/(a measure word)/point/dot/(decimal) point)
+129	正	296810	46.6908888683	zheng1/zheng4	Chinese 1st month of year, just (right)/main/upright/straight/correct/principle
+130	业	296169	46.8439446048	ye4	business/occupation/study
+131	外	295645	46.9967295459	wai4	outside/in addition/foreign/external
+132	将	295586	47.1494839968	jiang1/jiang4	(will, shall, "future tense")/ready/prepared/to get/to use, a general
+133	两	294600	47.3017288974	liang3	both/two/ounce/some/a few/tael
+134	高	293542	47.4534270394	gao1	high/tall
+135	间	292227	47.604445609	jian1/jian4	between/among/space/(measure word), interstice/separate
+136	由	292199	47.7554497085	you2	follow/from/it is for...to/reason/cause/because of/due to/by/to/to leave it (to sb)
+137	问	288237	47.9044063054	wen4	to ask
+138	很	284252	48.0513035135	hen3	very/extremely
+139	最	283689	48.1979097716	zui4	(the) most/-est
+140	重	282843	48.3440788294	chong2/zhong4	to double/to repeat/repetition/iteration/again/a layer, heavy/serious
+141	并	281616	48.4896137919	bing4	and/furthermore/(not) at all/simultaneously/also/together with/to combine/to join/to merge, amalgamate/combine, and/also/together with
+142	物	281146	48.6349058654	wu4	thing/object/matter
+143	手	280442	48.7798341221	shou3	hand/convenient
+144	应	280384	48.9247324053	ying1/ying4	ought, (surname)/to answer/to respond
+145	战	278776	49.068799698	zhan4	to fight/fight/war/battle
+146	向	276986	49.2119419453	xiang4	direction/part/side/towards/to/guide/opposite to, guide/opposite to
+147	头	274911	49.3540118635	tou2/tou	head, suff. for nouns
+148	文	274222	49.4957257167	wen2	language/culture/writing/formal/literary
+149	体	273792	49.6372173523	ti3	body/form/style/system
+150	政	269878	49.7766862908	zheng4	political/politics/government
+151	美	269452	49.9159350789	mei3	America/beautiful
+152	相	269125	50.0550148783	xiang1/xiang4	each other/one another/mutually, appearance/portrait/picture
+153	见	269080	50.1940714223	jian4/xian4	to see/to meet/to appear (to be sth)/to interview, appear
+154	被	268905	50.333037529	bei4	by (marker for passive-voice sentences or clauses)/quilt/blanket/to cover/to wear
+155	利	268813	50.4719560914	li4	advantage/benefit/profit/sharp
+156	什	267869	50.6103868086	shen2/shi2	what, tenth (used in fractions)
+157	二	267506	50.7486299328	er4	two/2
+158	等	266296	50.8862477471	deng3	class/rank/grade/equal to/same as/wait for/await/et cetera/and so on
+159	产	265164	51.0232805605	chan3	to reproduce/to produce/give birth/products/produce/resources/estate/property
+160	或	260786	51.1580508886	huo4	maybe/perhaps/might/possibly/or
+161	新	253921	51.2892734868	xin1	meso- (chem.)/new/newly
+162	己	250894	51.4189317764	ji3	6th heavenly stem/self
+163	制	250754	51.5485177161	zhi4	system/to make/to manufacture/to control/to regulate, manufacture
+164	身	249725	51.6775718838	shen1	body/torso/person/life/status/pregnancy/(a measure word used for clothes) suit
+165	果	246831	51.8051304754	guo3	fruit/result
+166	加	243648	51.9310441399	jia1	to add/plus
+167	西	243619	52.0569428176	xi1	west
+168	斯	240900	52.1814363565	si1	(phonetic)/this
+169	月	240566	52.3057572892	yue4	moon/month
+170	话	240067	52.4298203462	hua4	dialect/language/spoken words/speech/talk/words/conversation/what someone said
+171	合	239277	52.5534751428	ge3/he2	one-tenth of a peck, Chinese musical note/fit/to join
+172	回	239243	52.6771123688	hui2	(a measure word for matters or actions) a time/to circle/to go back/to turn around/to answer/to return/to revolve/Islam
+173	特	239091	52.8006710434	te2/te4	special/unusual/extraordinary, male animal/special (-ly)
+174	代	231734	52.9204277298	dai4	substitute/replace/generation/dynasty/geological era/era/age/period
+175	内	231331	53.0399761518	nei4	inside/inner/internal/within/interior
+176	信	230248	53.1589648955	xin4	letter/true/to believe/sign/evidence
+177	表	226768	53.2761552269	biao3	surface/exterior/to watch/to show/express/an example/a list or table/a meter/a watch/chart/external
+178	化	224729	53.3922918334	hua4	to make into/to change into/-ization/to ... -ize/to transform
+179	老	223050	53.5075607577	lao3	(a prefix used before the surname of a person or a numeral indicating the order of birth of the children in a family to indicate affection or familiarity)/old (of people)
+180	给	217815	53.6201243118	gei3/ji3	to/for/for the benefit of/to give/to allow/to do sth (for sb)/(passive particle), to supply/provide
+181	世	214990	53.7312279479	shi4	life/age/generation/era/world/lifetime
+182	位	214983	53.8423279665	wei4	position/location/(measure word for persons)/place/seat
+183	次	214857	53.9533628702	ci4	nth/number (of times)/order/sequence/next/second(ary)/(measure word)
+184	度	214376	54.0641492003	du4	capacity/degree/standard
+185	门	212769	54.1741050566	men2	opening/door/gate/doorway/gateway/valve/switch/way to do something/knack/family/house/(religious) sect/school (of thought)/class/category/phylum or division (taxonomy)
+186	任	212485	54.2839141459	ren4	to assign/to appoint/office/responsibility
+187	常	212309	54.3936322811	chang2	always/ever/often/frequently/common/general/constant
+188	先	210628	54.5024817004	xian1	early/prior/former/in advance/first
+189	海	209302	54.6106458627	hai3	ocean/sea
+190	通	209046	54.7186777279	tong1	go through/know well/to connect/to communicate/open
+191	教	208875	54.8266212229	jiao1/jiao4	teach, religion/teaching
+192	儿	207827	54.9340231271	er2/er	son, non-syllabic dimi. suff.
+193	原	207579	55.0412968686	yuan2	former/original/primary/raw/level/cause/source
+194	东	206238	55.1478776012	dong1	east
+195	声	206083	55.2543782321	sheng1	sound/voice/(a measure word, used for sounds)/tone/noise
+196	提	205159	55.3604013535	di1/ti2	carry (suspended), to carry/to lift/to put forward/(upwards character stroke)/lifting (brush stroke in painting)/to mention
+197	立	204985	55.4663345544	li4	set up/to stand
+198	及	202671	55.5710719144	ji2	to reach/and
+199	比	200645	55.6747622677	bi3/bi4	(particle used for comparison and "-er than")/to compare/to contrast/to gesture (with hands)/ratio, associate with/be near
+200	员	200217	55.778231437	yuan2	person/employee/member
+201	解	200090	55.8816349746	jie3/jie4/xie4	to separate/to divide/to break up/to loosen/to explain/to untie/to emancipate, transport under guard, (surname)
+202	水	198933	55.9844405918	shui3	water/river
+203	名	198481	56.0870126221	ming2	name/(measure word for persons)/place (e.g. among winners)
+204	真	198416	56.1895510614	zhen1	real/true/genuine
+205	论	197165	56.2914430025	lun2/lun4	the Analects (of Confucius), by the/per/discuss/theory/to talk (about)/to discuss
+206	处	194237	56.3918217967	chu3/chu4	to reside/to live/to dwell/to be in/to stay/get along with/to be in a position of/deal with, a place/location/spot/point/office/department/bureau/respect
+207	走	193619	56.4918812177	zou3	to walk/to go/to move
+208	义	193507	56.5918827587	yi4	justice/righteousness/meaning
+209	各	193435	56.6918470913	ge4	each/every
+210	入	192433	56.7912936051	ru4	to enter
+211	几	192355	56.8906998097	ji1/ji3	small table, almost, a few/how many, how much/how many/several/a few
+212	口	191936	56.9898894813	kou3	mouth/(a measure word)
+213	认	191866	57.0890429779	ren4	to recognize/to know/to admit
+214	条	191280	57.1878936385	tiao2	measure word for long, thin things (i.e. ribbon, river, etc.)/a strip/item/article
+215	平	191267	57.2867375808	ping2	flat/level/equal/to make the same score/to tie/to draw/calm/peaceful
+216	系	190769	57.3853241642	xi4	be/connection/relation/tie up/bind, be/system/to tie/department/faculty, connect/to tie
+217	气	190687	57.4838683711	qi4	air/anger/gas, gas/air/smell/weather/vital breath/to make sb. angry/to get angry/to be enraged
+218	题	189921	57.5820167207	ti2	topic/subject/to inscribe/to superscribe
+219	活	189876	57.6801418149	huo2	to live/alive/living/work/workmanship
+220	尔	189785	57.7782198817	er3	thus/so/like that/you/thou
+221	更	187378	57.8750540467	geng1/geng4	to change, more/even more/further/still/still more
+222	别	186634	57.9715037235	bie2/bie4	leave/depart/separate/distinguish/classify/other/another/do not/must not/to pin, contrary/difficult/awkward
+223	打	186146	58.0677012092	da2/da3	dozen, beat/strike/break/mix up/build/fight/fetch/make/tie up/issue/shoot/calculate/since/from
+224	女	185188	58.1634036147	nu:3/nv3	female/woman
+225	变	185121	58.2590713956	bian4	to change/to become different/to transform/to vary/rebellion
+226	四	184874	58.3546115306	si4	four/4
+227	神	184554	58.4499862943	shen2	God/unusual/mysterious/soul/spirit/divine essence/lively/spiritual being
+228	总	184470	58.5453176481	zong3	always/to assemble/gather/total/overall/head/chief/general/in every case
+229	何	184335	58.6405792359	he2	carry/what/how/why/which
+230	电	183834	58.7355819144	dian4	electric/electricity/electrical
+231	数	183312	58.830314831	shu3/shu4/shuo4	to count, number/figure/to count/to calculate/several, frequently/repeatedly
+232	安	183210	58.9249950355	an1	content/calm/still/quiet/to pacify/peace
+233	少	183018	59.0195760173	shao3/shao4	few/little/lack, young
+234	报	182411	59.1138433105	bao4	to announce/to inform/report/newspaper/recompense/revenge
+235	才	181725	59.2077560891	cai2	ability/talent/endowment/gift/an expert/only (then)/only if/just, just/not until
+236	结	181674	59.3016425116	jie1/jie2	knot/sturdy/to bear (fruit)/bond/to tie/to bind
+237	反	181385	59.3953795833	fan3	wrong side out or up/anti-
+238	受	180928	59.4888804841	shou4	to bear/to stand/to endure/(passive marker)/to receive
+239	目	180827	59.5823291897	mu4	eye/item/section/list/catalogue/table of contents/order (taxonomy)/goal/name/title
+240	太	180490	59.6756037386	tai4	highest/greatest/too (much)/very/extremely
+241	量	180008	59.7686291971	liang2/liang4	to measure, capacity/quantity/amount/to estimate
+242	再	179607	59.8614474248	zai4	again/once more/re-/second/another
+243	感	178383	59.9536331075	gan3	to feel/to move/to touch/to affect
+244	建	178289	60.0457702124	jian4	to establish/to found/to set up/to build/to construct
+245	务	176085	60.1367683228	wu4	affair/business/matter
+246	做	175580	60.2275054568	zuo4	to do/to make/to produce
+247	接	175473	60.3181872947	jie1	to extend/to connect/to receive/to join
+248	必	174963	60.4086055722	bi4	certainly/must/will/necessarily
+249	场	173632	60.4983360087	chang3	a courtyard/open space/place/field/a measure word/(a measure word, used for sport or recreation)
+250	件	172895	60.5876855746	jian4	a measure word for thing, clothes, item
+251	计	171949	60.6765462617	ji4	to calculate/to compute/to count/reckon/ruse/to plan
+252	管	170746	60.7647852563	guan3	to take care (of)/to control/to manage/to be in charge of/to look after/to run/tube/pipe
+253	期	169806	60.8525384729	qi1	a period of time/phase/stage/(used for issue of a periodical, courses of study)/time/term/period/to hope
+254	市	169522	60.9401449225	shi4	market/city
+255	直	169439	61.0277084789	zhi2	straight/vertical/frank/directly/straightly/upright
+256	德	168917	61.1150022735	de2	Germany/virtue/goodness/morality/ethics/kindness/favor/character/kind
+257	资	168890	61.2022821149	zi1	resources/capital/to provide/to supply/to support/money/expense
+258	命	168358	61.2892870266	ming4	life/fate
+259	山	168142	61.3761803127	shan1	mountain/hill
+260	金	167912	61.4629547382	jin1	metal/money/gold
+261	指	166865	61.5491880897	zhi3	finger/to point/to direct/to indicate
+262	克	166044	61.6349971606	ke4	gram/subdue/to restrain/to overcome, subdue
+263	许	166034	61.7208010637	xu3	to allow/to permit/to praise/(surname)
+264	统	165820	61.8064943747	tong3	to gather/to unite/to unify/whole
+265	区	164775	61.8916476453	ou1/qu1	Ou (surname), area/region/district/small/distinguish
+266	保	164424	61.9766195243	bao3	to defend/to protect/to insure or guarantee/to maintain/hold or keep/to guard
+267	至	163582	62.0611562702	zhi4	arrive/most/to/until
+268	队	162938	62.1453602064	dui4	squadron/team/group
+269	形	162049	62.2291047207	xing2	to appear/to look/form/shape
+270	社	159527	62.3115459029	she4	society/group
+271	便	159479	62.3939622794	bian4/pian2	ordinary/plain/convenient/handy/easy/then/so/thus/to relieve oneself, advantageous/cheap
+272	空	158539	62.4758928778	kong1/kong4	air/sky/empty/in vain, emptied/leisure
+273	决	157959	62.5575237409	jue2	breach (a dyke)/to decide/to determine
+274	治	156904	62.6386093957	zhi4	to rule/to govern/to manage/to control/to harness (a river)/cure/treatment/to heal
+275	展	156759	62.7196201166	zhan3	to use/to spread out/to postpone/to unfold
+276	马	155772	62.8001207706	ma3	horse/horse chess piece/Surname
+277	科	155750	62.8806100553	ke1	branch of study/administrative section/division/field/branch/stage directions/family (taxonomy)/rules/laws/to mete out (punishment)/to levy (taxes, etc.)/to fine somebody
+278	司	155229	62.960830095	si1	company/control
+279	五	154316	63.0405783099	wu3	five/5
+280	基	153462	63.1198851902	ji1	base/foundation/basic/radical (chem.)
+281	眼	152079	63.1984773567	yan3	eye
+282	书	151357	63.2766964043	shu1	book/letter
+283	非	149915	63.3541702478	fei1	non-/not-/un-
+284	则	149042	63.4311929378	ze2	(expresses contrast with a previous sentence or clause)/standard/norm/rule/to imitate/to follow/then/principle
+285	听	148988	63.5081877215	ting1/ting4	listen/hear/obey, let/allow
+286	白	148728	63.585048141	bai2	white/snowy/empty/blank/bright/clear/plain/pure/gratuitous
+287	却	148679	63.661883238	que4	but/yet/however/while/to go back/to decline/to retreat/nevertheless
+288	界	148438	63.7385937898	jie4	boundary/scope/extent/circles/group/kingdom (taxonomy)
+289	达	147907	63.8150299287	da2	attain/pass through/achieve/reach/realize/clear/inform/notify/dignity
+290	光	147639	63.8913275692	guang1	light/ray/bright
+291	放	147600	63.9676050551	fang4	to release/to free/to let go/to put/to place/to let out
+292	强	146665	64.0433993469	qiang2	strength/force/power/powerful/better
+293	即	146459	64.1190871809	ji2	namely/right away/to approach/to draw near
+294	像	145291	64.1941714099	xiang4	(look) like/similar (to)/appearance/to appear/to seem/image/portrait/resemble/seem
+295	难	144597	64.26889699	nan2/nan4	difficult (to...)/problem/difficulty/difficult/not good, disaster/distress/to scold
+296	且	144597	64.3436225702	qie3	further/moreover
+297	权	144506	64.4183011228	quan2	authority/power/right
+298	思	144503	64.4929781251	si1	to think/to consider
+299	王	143948	64.5673683117	wang2	king/Wang (proper name)
+300	象	143453	64.6415026896	xiang4	shape/form/appearance/elephant/image under a map (math.)
+301	完	143120	64.7154649781	wan2	to finish/to be over/whole/complete/entire
+302	设	142742	64.7892319218	she4	to set up/to arrange/to establish/to found/to display
+303	式	142292	64.8627663122	shi4	type/form/pattern/style
+304	色	142231	64.9362691787	se4/shai3	color/look/appearance, color/dice
+305	路	141812	65.0095555122	lu4	(surname)/road/path/way
+306	记	139501	65.0816475552	ji4	to remember/to note/mark/sign/to record
+307	南	139078	65.1535209982	nan2	south
+308	品	138528	65.2251102093	pin3	conduct/grade/thing/product/good
+309	住	138503	65.2966865008	zhu4	to live/to dwell/to reside/to stop
+310	告	138285	65.3681501332	gao4	to tell/to inform/to say
+311	类	138280	65.4396111816	lei4	kind/type/class/category/similar/like/to resemble
+312	求	138216	65.5110391558	qiu2	to seek/to look for/to request/to demand/to beseech
+313	据	137990	65.5823503365	ju1/ju4	sickness of hand, act in accordance with/seize, according to/to act in accordance with/to depend on/to seize/to occupy
+314	程	136962	65.6531302621	cheng2	rule/order/regulations/formula/journey/procedure/sequence/a surname
+315	北	136939	65.7238983017	bei3	north
+316	边	136277	65.7943242295	bian1	side/edge/margin/border/boundary
+317	死	136194	65.8647072641	si3	to die/inpassable/uncrossable/inflexible/rigid
+318	张	136087	65.9350350027	zhang1	(a measure word)/(a surname)/open up
+319	该	136053	66.0053451707	gai1	that/the above-mentioned/most likely/to deserve/should/ought to/owe
+320	交	135727	66.0754868666	jiao1	to deliver/to turn over/to make friends/to intersect (lines)/to pay (money)
+321	规	134528	66.1450089372	gui1	compass/rule
+322	万	134220	66.214371838	wan4	Wan (surname)/ten thousand/a great number
+323	取	134102	66.2836737581	qu3	to take/to get/to choose/to fetch
+324	拉	134051	66.3529493222	la1	to pull/to play (string instruments)/to drag/to draw
+325	格	133986	66.4221912953	ge2	frame/rule
+326	望	133145	66.490998652	wang4	hope/expect/to visit/to gaze (into the distance)/look towards/towards
+327	觉	132041	66.559235478	jiao4/jue2	a nap/a sleep, feel/find that/thinking/awake/aware
+328	术	131634	66.6272619724	shu4/zhu2	method/technique, Atractylis lancea var. ovata
+329	领	130993	66.6949572076	ling3	neck/collar/to lead/to receive
+330	共	128824	66.7615315357	gong4	all together/in while/to share/common/general/together
+331	确	128417	66.8278955324	que4	authenticated/solid/firm, authenticated/solid/firm/real/true
+332	传	128186	66.8941401517	chuan2/zhuan4	to pass on/to spread/to transmit/to infect/to transfer/to circulate/to pass on/to conduct (electricity), biography
+333	师	128086	66.9603330924	shi1	a division (milit.)/teacher/master/expert/model
+334	观	127796	67.0263761655	guan1/guan4	to look at/to watch/to observe/to behold, Taoist monastery
+335	清	127716	67.0923778957	qing1	clear/distinct/complete/pure
+336	今	126624	67.1578152966	jin1	today/modern/present/current/this/now
+337	切	126391	67.2231322866	qie1/qie4	to cut/to slice, close to
+338	院	126115	67.2883066438	yuan4	courtyard/institution
+339	让	125660	67.3532458639	rang4	to ask/to let/permit/have (someone do something)/to yield/to allow
+340	识	125220	67.4179576984	shi2/zhi4	to know/knowledge, to record/write a footnote
+341	候	124865	67.4824860743	hou4	wait
+342	带	124619	67.546887321	dai4	band/belt/girdle/ribbon/area/zone/region/wear/carry/lead/bring/consists of/show/and
+343	导	124463	67.6112079492	dao3	to transmit/to lead/to guide/to conduct/to direct
+344	争	124420	67.6755063556	zheng1	struggle/fight
+345	运	123903	67.7395375842	yun4	to move/to transport/to use/to apply/fortune/luck/fate
+346	笑	122902	67.8030515108	xiao4	laugh/smile
+347	飞	122290	67.8662491649	fei1	to fly
+348	风	121803	67.9291951447	feng1	wind/news/style/custom/manner
+349	步	121267	67.9918641276	bu4	a step/a pace/walk/march/stages in a process
+350	改	121023	68.0544070149	gai3	to change/to alter/to transform/to correct
+351	收	120897	68.1168847874	shou1	to receive/to accept/to collect/in care of (used on address line after name)
+352	根	120778	68.1793010624	gen1	radical (chem.)/root/basis
+353	干	120564	68.2416067453	gan1/gan4	dry/to concern/shield, to work/to do/to manage, manage/stem
+354	造	120496	68.3038772869	zao4	to make/to build/to invent/to manufacture
+355	言	120308	68.3660506729	yan2	to speak/to say/talk/word
+356	联	120301	68.4282204414	lian2	to ally/to unite/to join
+357	持	119990	68.4902294897	chi2	to grasp/to hold/support/manage/direct/maintain
+358	组	119734	68.552106241	zu3	to form/compose/make up/group/to organize/cord
+359	每	119594	68.6139106424	mei3	each/every
+360	济	119161	68.6754912758	ji4	aid/ferry/frugal
+361	车	118824	68.7368977527	che1/ju1	car/a vehicle/machine/to shape with a lathe, vehicle on land
+362	亲	118451	68.7981114687	qin1/qing4	dear/intimate/parent/relation/closely related, parents-in-law of one's offspring
+363	极	117736	68.8589556833	ji2	extremely/pole (geography, physics)/utmost/top
+364	林	117675	68.919768374	lin2	woods/forest
+365	服	116961	68.9802120801	fu2	clothes/dress/garment/submit/take (medicine)
+366	快	116923	69.0406361484	kuai4	fast/quick/swift
+367	办	116904	69.1010503978	ban4	to do/to manage/to handle/to go about/to run/to set up/to deal with
+368	议	116810	69.1614160694	yi4	criticize/discuss
+369	往	116539	69.2216416922	wang3/wang4	to go (in a direction)/past/previous/towards, toward/(of a train) bound for
+370	元	116488	69.281840959	yuan2	(dynasty)/dollar/primary/first
+371	英	116193	69.3418877741	ying1	(surname)/English/brave
+372	士	115704	69.4016818814	shi4	scholar/warrior/knight
+373	证	115610	69.4614274108	zheng4	prove, confirm, verify/proof, certificate/proof/to prove/to demonstrate/to confirm/certificate/proof
+374	近	115441	69.5210856035	jin4	near/close (to)/approximately
+375	失	115346	69.5806947016	shi1	to lose/to miss/to fail
+376	转	115087	69.6401699524	zhuan3/zhuan4	to convey/to forward (mail)/to transfer/to turn/to shift, to revolve/to turn/to circle about/to walk about
+377	夫	114784	69.6994886173	fu1	porter, husband/man
+378	令	114570	69.7586966902	ling4	make or cause to be/order/command/decree/honorable
+379	准	113877	69.817546631	zhun3	to allow/to grant/to permit/accurate/standard, accurate/standard
+380	布	113652	69.8762802951	bu4	diffuse/extend/notify, to declare/to announce/to spread/to make known/spread/(cotton) cloth
+381	始	112987	69.9346702971	shi3	begin
+382	怎	112294	69.992702167	zen3	how
+383	呢	112185	70.0506777074	ne/ni2	(question particle), woolen material
+384	存	110970	70.1080253538	cun2	exist/deposit/store/keep/survive
+385	未	110491	70.1651254601	wei4	1-3 p.m./8th earthly branch/not yet/did not/have not/not
+386	远	110455	70.2222069621	yuan3	far/distant/remote
+387	叫	110131	70.2791210258	jiao4	to (be) call(ed)
+388	台	109362	70.3356376817	tai2	surname/(classical) you (in letters)/platform/Taiwan (abbr.), desk/platform, (measure word)/platform/stage/terrace/stand/support/desk/station/broadcasting station, typhoon
+389	单	109359	70.3921527872	chan2/dan1/shan4	chieftain, bill/list/form/single/only/sole, (surname)
+390	影	108862	70.4484110506	ying3	picture/image/reflection/shadow
+391	具	108811	70.5046429579	ju4	tool/device/utensil/equipment/instrument
+392	罗	108376	70.5606500636	luo1/luo2	fussy/talkative, subordinate in a gang of bandits, (surname)/gauze/to collect/to gather/to catch/to shift
+393	字	108218	70.6165755173	zi4	letter/symbol/character/word
+394	爱	108167	70.672474615	ai4	to love/affection/to be fond of/to like
+395	击	107513	70.7280357352	ji1	to hit/to strike/to break
+396	流	107397	70.7835369083	liu2	to flow/to spread/to circulate/to move
+397	备	107114	70.8388918312	bei4	to prepare/get ready/to provide or equip
+398	兵	106982	70.8941785385	bing1	soldiers/a force/an army/weapons/arms/military/warlike
+399	连	106814	70.9493784258	lian2	(surname)/even/as/join/to link/successively
+400	调	106379	71.0043535117	diao4/tiao2	mode (music)/to move (troops)/tune/tone/melody/to transfer, harmonize/reconcile/blend/suit well/provoke/incite
+401	深	105924	71.0590934603	shen1	deep/profound
+402	商	105406	71.1135657142	shang1	commerce/consult
+403	算	105293	71.1679795714	suan4	regard as/to figure/to calculate/to compute
+404	质	104560	71.222014625	zhi4	hostage/substance/nature/quality
+405	团	104151	71.2758383136	tuan2	regiment/round/circular/group/society, dumpling
+406	集	104019	71.3295937865	ji2	to gather/to collect/collected works
+407	百	103938	71.3833073998	bai3	hundred
+408	需	103832	71.436966234	xu1	to require/to need/to want/necessity/need
+409	价	103634	71.4905227446	jia4/jie	price/value/valence (on an atom), great/good/middleman/servant
+410	花	103367	71.5439412736	hua1	flower/blossom/to spend (money, time)/fancy pattern
+411	党	103165	71.597255412	dang3	party, party/association/club/society
+412	华	103158	71.650565933	hua2/hua4	(abbreviation for) China/(surname) Hua/magnificent/splendid/flowery, (surname)/name of a mountain
+413	城	102833	71.7037084987	cheng2	city walls/city/town
+414	石	102149	71.7564975834	dan4/shi2	10 pecks, rock/stone
+415	级	102018	71.8092189693	ji2	level/grade/rank/step
+416	整	100910	71.8613677572	zheng3	exactly/in good order/whole/complete/entire/in order/orderly
+417	府	100771	71.913444712	fu3	prefecture/mansion
+418	离	100744	71.9655077136	li2	to leave/to depart/to go away/from
+419	况	100680	72.017537641	kuang4	moreover/situation
+420	亚	100251	72.0693458675	ya4	Asia/Asian/second/next to/inferior
+421	请	100226	72.1211411744	qing3	to ask/to invite/please (do sth)/to treat (to a meal, etc)/to request
+422	技	99790	72.172711163	ji4	skill
+423	际	99412	72.2240858068	ji4	border/edge/boundary/between/among/interval/while
+424	约	99148	72.2753240194	yao1/yue1	weigh, appointment/agreement/to arrange/to restrict/approximately
+425	示	98963	72.3264666267	shi4	to show/reveal
+426	复	98822	72.3775363672	fu4	again/recover/reply to a letter/to repeat/to duplicate, repeat, double, overlap
+427	病	98692	72.4285389257	bing4	ailment/sickness/illness/disease/fall ill/sick/defect
+428	息	98447	72.4794148719	xi1	news/interest/breath/rest
+429	究	98377	72.5302546431	jiu1	after all/to investigate/to study carefully
+430	线	98261	72.5810344672	xian4	thread/string/wire/line
+431	似	98057	72.6317088672	si4	to seem/to appear/similar/like/to resemble
+432	官	97897	72.6823005815	guan1	official/government
+433	火	97760	72.7328214962	huo3	fire
+434	断	97235	72.7830710988	duan4	absolutely/decidedly (in negative constructions)/break/to judge
+435	精	97135	72.8332690229	jing1	energy/perfect/excellent/refined/very/proficient
+436	满	96954	72.8833734088	man3	Manchurian/to fill/to fulfill/filled/packed
+437	支	96814	72.9334054448	zhi1	(a measure word)/to support/to sustain/to erect/to raise/branch/division/to draw money
+438	视	96326	72.9831852897	shi4	to look at/to regard/to inspect
+439	消	96263	73.0329325771	xiao1	consume/news/subside/to disappear/to vanish
+440	越	95657	73.0823666928	yue4	to exceed/to climb over/to surpass/the more ... the more
+441	器	95444	73.1316907332	qi4	device/tool/utensil
+442	容	95407	73.1809956525	rong2	to hold/to contain/to allow/appearance/look/countenance
+443	照	95020	73.230100576	zhao4	according to/in accordance with/to shine/to illuminate/to reflect/photograph
+444	须	94903	73.2791450356	xu1	beard/necessary/must, beard/mustache
+445	九	94580	73.3280225737	jiu3	nine/9
+446	增	93869	73.3765326775	zeng1	to increase/to expand/to add
+447	研	93761	73.4249869685	yan2	grind fine/study/research
+448	写	93710	73.4734149035	xie3	to write
+449	称	93638	73.5218056299	chen4/cheng1/cheng4	balanced/to fit/well-off/suitable, to call/to praise/to weigh/to estimate/to consider/to call/to address/to name/to say/commend, steelyard
+450	企	93453	73.5701007511	qi3	plan a project/stand on tiptoe
+451	八	92700	73.6180067331	ba1	eight/8
+452	功	92052	73.6655778383	gong1	merit/achievement/result/service/accomplishment
+453	吗	91639	73.7129355112	ma3/ma	morphine, (question tag)
+454	包	91240	73.7600869869	bao1	to cover/to wrap/to hold/to include/to take charge of/package/wrapper/container/bag/to hold or embrace/bundle/packet/to contract (to or for)
+455	片	90559	73.8068865319	pian1/pian4	disc/sheet, a slice/piece/flake/thin/slice
+456	史	90469	73.8536395663	shi3	history
+457	委	90263	73.9002861429	wei1/wei3	crooked, give up/indeed/to commission
+458	乎	90127	73.9468624367	hu1	(interrog. part.)
+459	查	90039	73.9933932535	cha2/zha1	to research/to check/to investigate/to examine/to refer to/to search, (surname)
+460	轻	89852	74.0398274314	qing1	light/easy/gentle/soft/reckless/unimportant/frivolous/small in number/unstressed/neutral/soft
+461	易	89730	74.0861985615	yi4	(surname)/change/easy/simple
+462	早	89623	74.1325143956	zao3	early/morning
+463	曾	89328	74.1786777782	ceng2/zeng1	(refers to something that happened previously)/already/at some time in the past/before/once, (surname)/great-grand (father)
+464	除	89272	74.2248122207	chu2	remove/do away with/wipe out/divide/except
+465	农	88412	74.270502228	nong2	agriculture
+466	找	88247	74.3161069658	zhao3	to try to find/to look for/to call on (sb)/to find/to seek/to return/to look for
+467	装	88143	74.3616579579	zhuang1	adornment/adorn/costume/dress/clothing
+468	广	87900	74.4070833713	guang3	wide/numerous/to spread
+469	显	87825	74.4524700257	xian3	prominent/conspicuous
+470	吧	87536	74.4977073293	ba1/ba	(onomat.)/dumb, (modal particle indicating polite suggestion)/...right?/...OK?
+471	阿	87159	74.5427498048	a1/a4/a/e1	an initial particle/prefix to names of people, (phonetic character), (final part.)/(interj.), flatter
+472	李	86593	74.58749978	li3	(a surname)/plum
+473	标	86324	74.6321107399	biao1	the topmost branches of a tree/surface/sign/to mark/(outward) sign/indication/prize/award/bid
+474	谈	86089	74.6766002554	tan2	to speak/to talk/to converse/to chat/to discuss/(surname)
+475	吃	85976	74.7210313741	chi1/ji2	eat/eradicate/destroy/receive, eat, stammer
+476	图	85957	74.765452674	tu2	diagram/to plan/picture/drawing/chart
+477	念	85953	74.8098719066	nian4	read aloud, to read aloud
+478	六	85830	74.8542275747	liu4	six/6
+479	引	85740	74.8985367322	yin3	to lead/to divert (water)/to guide
+480	历	85487	74.942715143	li4	calendar, to experience/to undergo/to pass through/all/each/every/calendar
+481	首	85036	74.9866604837	shou3	head/chief/first (occasion)/first (thing)/measure word for poems
+482	医	84620	75.0303908418	yi1	medical/medicine/doctor/to cure/to treat
+483	局	84587	75.074104146	ju2	narrow, (a measure word used for games) set or round office/situation/office
+484	突	84474	75.1177590535	tu1	to dash/to move forward quickly
+485	专	84361	75.1613555642	zhuan1	for a particular person, occasion, purpose/focused on one thing/special/expert/particular (to sth)/concentrated/specialized, concentrated/specialized
+486	费	84359	75.2049510414	fei4	to cost/to spend/fee/wasteful/expenses/(surname)
+487	号	84335	75.2485341157	hao2/hao4	roar/cry, day of a month/(suffix used after) name of a ship/(ordinal) number
+488	尽	84270	75.292083599	jin3/jin4	to the utmost, to use up/to exhaust/to end/to finish/to the utmost/exhausted/finished/to the limit (of sth)
+489	另	83702	75.3353395483	ling4	other/another/separate/separately
+490	周	83366	75.3784218579	zhou1	(surname)/complete/encircle/circuit/lap/week/cycle/all/every/attentive/thoughtful, bestow alms, cycle/week
+491	较	82870	75.421247842	jiao4	clear/distinct/compare/comparatively
+492	注	82869	75.4640733093	zhu4	to inject/to pour into/to concentrate/to pay attention/to note/to comment on/to record/to register/to annotate, annotate
+493	语	82805	75.5068657024	yu3/yu4	dialect/language/speech, tell to
+494	仅	82729	75.5496188198	jin3	barely/only/merely
+495	考	82688	75.592350749	kao3	to check/to verify/to test/to examine
+496	落	82641	75.6350583893	la4/luo4	leave behind, alight/to fall/to drop (behind)
+497	青	82619	75.6777546604	qing1	green (blue, black)
+498	随	82599	75.7204405957	sui2	to follow/to comply with/to allow/(surname)
+499	选	82498	75.7630743357	xuan3	to choose/to pick/to select/to elect
+500	列	82418	75.805666733	lie4	to arrange/to line up/row/file/series
+501	武	81863	75.8479723145	wu3	martial/military
+502	红	81852	75.8902722113	hong2	bonus/popular/red/revolutionary
+503	响	81702	75.9324945904	xiang3	to make a sound/to sound/to ring/(a measure word for sound)/loud
+504	虽	81097	75.9744043144	sui1	although/even though
+505	推	80933	76.0162292857	tui1	push/refuse (responsibility)/shove
+506	势	80705	76.05793643	shi4	conditions/influence/tendency
+507	参	80663	76.0996218694	can1/shen1	take part in/participate/join/attend/to join/unequal/varied/irregular/to counsel/uneven/not uniform, ginseng
+508	希	80460	76.1412024013	xi1	rare/infrequent
+509	古	80454	76.1827798325	gu3	ancient/old
+510	众	80390	76.2243241895	zhong4	multitude
+511	构	80364	76.26585511	gou4	Broussonetia papyrifera/to construct/to form/to make up/to compose
+512	房	80320	76.3073632921	fang2	house
+513	半	80183	76.3488006745	ban4	half/semi-/incomplete/(after a number) and a half/half
+514	节	80074	76.3901817274	jie2/jie1	festival/section/segment/point/part/to economize/to save/temperate
+515	土	79809	76.4314258322	tu3	earth/dust
+516	投	79708	76.4726177417	tou2	to throw/to send
+517	某	79482	76.5136928578	mou3	(used before measure word and noun) some/(a) certain/so and so
+518	案	79395	76.5547230136	an4	(legal) case/incident/record/file/table
+519	黑	78896	76.5954952935	hei1	black/dark
+520	维	78877	76.6362577546	wei2	to preserve/to maintain/to hold together/dimension
+521	革	78685	76.6769209929	ge2	leather/remove
+522	划	78648	76.7175651102	hua2/hua4	to row, to delimit/to transfer/to assign/to differentiate/to mark off/to draw (a line)/to delete/stroke of a Chinese character
+523	敌	78620	76.7581947575	di2	enemy/match
+524	致	78238	76.7986269929	zhi4	fine and close, to send/to devote/to deliver/to cause/to convey
+525	陈	77914	76.8388917898	chen2	arrange/exhibit/narrate/tell/old/stale/a surname/to state/to display/to explain/(surname)
+526	律	77818	76.8791069754	lu:4/lv4	law
+527	足	77385	76.9190983931	zu2	foot/to be sufficient
+528	态	77219	76.9590040244	tai4	attitude
+529	护	76993	76.9987928623	hu4	protect
+530	七	76766	77.0384643899	qi1	seven/7
+531	兴	76760	77.0781328169	xing1/xing4	flourish/it is the fashion to/to become popular, interest
+532	派	76750	77.1177960759	pai4	clique/school/group/faction/to dispatch
+533	孩	76620	77.157392153	hai2	child
+534	验	76542	77.1969479207	yan4	to examine/to test/to check
+535	责	76377	77.236418419	ze2	duty/responsibility/to reproach/to blame
+536	营	76372	77.2758863333	ying2	army/to deal in/to trade/to operate/to run/camp/nourishment/to manage
+537	星	76320	77.3153273748	xing1	star/satellite/small amount
+538	够	76181	77.3546965831	gou4	to reach/to be enough
+539	章	76098	77.3940228983	zhang1	(surname)/chapter/seal/section
+540	音	76043	77.4333207903	yin1	sound/noise/news
+541	跟	75958	77.4725747555	gen1	to follow/to go with/heel/with/and
+542	志	75904	77.5118008144	zhi4	the will, sign/mark/to record/write a footnote
+543	底	75728	77.5509359191	de/di3	(possessive part.)/(subor. part.), background/bottom/base
+544	站	75402	77.5899025518	zhan4	station/to stand/to halt/to stop
+545	严	75278	77.6288051032	yan2	(air or water) tight/stern/serious/strict/severe
+546	巴	74917	77.6675210951	ba1	(suff. for certain nouns)/to hope/to wish/Palestinian, Palestine (abbrev.)/Pakistan (abbrev.)/Pascal (unit of pressure)
+547	例	74579	77.7060624136	li4	example/precedent/rule/case/instance
+548	防	74459	77.744541718	fang2	to protect/to defend/to guard (against)
+549	族	74174	77.7828737386	zu2	race/nationality/ethnicity/clan
+550	供	74168	77.8212026584	gong1/gong4	offer (information etc.)/supply, offer/sacrificial offering/trial statement/confession
+551	效	74009	77.8594494095	xiao4	imitate, effect/efficacy/imitate
+552	续	73927	77.8976537841	xu4	continue/replenish
+553	施	73861	77.935824051	shi1	(surname)/distribute (alms)/to do/to execute/to carry out
+554	留	73287	77.9736976831	liu2	leave (message)/to retain/to stay/to remain/to keep/to preserve
+555	讲	73220	78.0115366907	jiang3	to talk/speech/to speak/to tell/to explain
+556	型	73216	78.0493736311	xing2	model
+557	料	72778	78.0869842196	liao4	material/stuff/grain/feed/to expect/to anticipate/to guess
+558	终	72533	78.1244681958	zhong1	end/finish
+559	答	72421	78.161894292	da1/da2	to answer/agree, reply/answer/return/respond/echo
+560	紧	72300	78.1992578573	jin3	tight/nervous/strict
+561	黄	72199	78.2365692272	huang2	(surname)/sulfur/yellow
+562	绝	72074	78.273815999	jue2	cut short/extinct/to disappear/to vanish/absolutely/by no means
+563	奇	71919	78.3109826691	ji1/qi2	odd (Num), strange/odd/weird/wonderful
+564	察	71894	78.3481364196	cha2	examine/inquire/observe/inspect/look into/to examine
+565	母	71462	78.3850669189	mu3	female/mother
+566	京	71245	78.4218852758	jing1	capital/Beijing (abbrev.)
+567	段	71172	78.4586659074	duan4	(surname)/paragraph/section/segment
+568	依	70632	78.495167475	yi1	according to/depend on/near to
+569	批	70580	78.5316421698	pi1	to ascertain/(measure word for batches, lots)/to act on/to criticize/to pass on
+570	群	70459	78.5680543336	qun2	crowd/flock/group
+571	项	70453	78.6044633967	xiang4	(surname)/back of neck/item/thing
+572	故	70067	78.6406729808	gu4	happening/instance/reason/cause/deceased/old
+573	按	69984	78.6768396716	an4	to press (with the hand)/to push/to control/to restrain/to check/pressing down (brush movement in painting)/according to/in the light of
+574	河	69687	78.7128528773	he2	river
+575	米	69668	78.7488562641	mi3	(measure word) meter/rice
+576	围	69641	78.7848456976	wei2	to circle/to surround
+577	江	69602	78.8208149766	jiang1	river
+578	织	69482	78.8567222413	zhi1	weave
+579	害	69462	78.8926191703	hai4	to do harm to/to cause trouble to/harm/evil/calamity
+580	斗	69456	78.9285129986	dou3/dou4	Chinese peck, to fight/to battle/to struggle/to incite, fight/incite
+581	双	69440	78.9643985584	shuang1	two/double/pair/both
+582	境	69360	79.0002427753	jing4	border/place/condition/boundary/circumstances/territory
+583	客	69108	79.0359567624	ke4	customer/visitor/guest
+584	纪	69045	79.071638192	ji4	discipline/age/era/period/order/record
+585	采	68946	79.1072684599	cai3/cai4	to pick/to pluck/to collect/to select/to choose/to gather, affairs/gather, allotment to a feudal noble
+586	举	68924	79.1428873585	ju3	to lift/to hold up/to cite/to enumerate/to act/to raise/to choose/to elect
+587	杀	68776	79.178429773	sha1	to kill/to murder/to slaughter
+588	攻	68747	79.2139572006	gong1	to attack/to accuse/to study
+589	父	68576	79.249396258	fu4	father
+590	苏	68487	79.2847893215	su1	loquacious/nag, revive, (plant)/place name/revive
+591	密	68475	79.3201761836	mi4	secret/confidential/close/thick/dense
+592	低	68424	79.3555366897	di1	to lower (one's head)/to let droop/to hang down/low/to incline/beneath/low
+593	朝	68380	79.3908744572	chao2/zhao1	to face/towards/facing/direct/a dynasty/the imperial court/(abbr.) Korea, esp. N. Korea, morning
+594	友	68196	79.4261171362	you3	friend
+595	诉	68147	79.4613344928	su4	complain/sue/tell
+596	止	68082	79.4965182583	zhi3	to stop/toe
+597	细	67915	79.5316157208	xi4	fine/minutely/thin/slender
+598	愿	67915	79.5667131832	yuan4	sincere/willing, hope/wish/desire/ready/willing
+599	千	67843	79.6017734371	qian1	thousand, a swing
+600	值	67732	79.6367763278	zhi2	value/(to be) worth/to happen
+601	仍	67490	79.6716541566	reng2	still/yet/to remain
+602	男	67405	79.7064880586	nan2	male
+603	钱	67304	79.7412697653	qian2	(surname)/coin/money
+604	破	67268	79.7760328677	po4	to break/to split/broken/damaged/worn out
+605	网	67118	79.8107184524	wang3	net/network, a net
+606	热	67051	79.8453694124	re4	heat/to heat up/fervent/hot (of weather)/warm up
+607	助	66867	79.879925284	zhu4	to help/to assist
+608	倒	66634	79.9143607447	dao3/dao4	to fall/to collapse/to topple/to change/to fail/bankrupt, upset/turn over/to tip/to pour/to go home/to the contrary/inverted
+609	育	66551	79.9487533122	yu4	nourish/to rear
+610	属	66374	79.9830544087	shu3/zhu3	belong to/category/be subordinate to/genus (taxonomy)/be born in the year of (one of the 12 animals)/family members/dependants, join together/fix one's attention on/concentrate on
+611	坐	66293	80.0173136457	zuo4	to sit/to take a seat/to take (a bus, airplane etc.)
+612	帝	66035	80.051439552	di4	emperor
+613	限	66018	80.085556673	xian4	limit/bound
+614	船	65883	80.1196040281	chuan2	a boat/vessel/ship
+615	脸	65727	80.1535707646	lian3	face
+616	职	65272	80.1873023639	zhi2	office/duty
+617	速	65094	80.2209419755	su4	fast/rapid/quick
+618	刻	65015	80.254540761	ke4	quarter (hour)/(a measure word)/to carve/to engrave/to cut/oppressive
+619	乐	64965	80.2881137073	le4/yue4	(surname)/happy/laugh/cheerful, (surname)/music
+620	否	64772	80.321586914	fou3/pi3	to negate/to deny/not, clogged/evil
+621	刚	64622	80.354982603	gang1	hard/firm/strong/just/barely/exactly
+622	威	64559	80.3883457345	wei1	power/might/prestige
+623	毛	64522	80.421689745	mao2	hair/pore/fur
+624	状	64495	80.4550198022	zhuang4	accusation/suit/state/condition/strong/great
+625	率	64453	80.4883281545	lu:4/shuai4/lv4	rate/frequency, to lead/command
+626	独	64201	80.5548068774	du2	alone/independent/single/sole/only
+627	球	63913	80.5878361658	qiu2	ball/sphere
+628	般	63739	80.6207755335	ban1	sort/kind/class/way/manner
+629	普	63570	80.6536275645	pu3	general/popular/everywhere/universal
+630	怕	63520	80.6864537562	pa4	to be afraid/to fear
+631	弹	63417	80.7192267191	dan4/tan2	crossball/bullet/shot/shell/ball, impeach/to pluck a string/to play (a stringed musical instrument with fingers)
+632	校	63200	80.7518875396	jiao4/xiao4	proofread/to check/to compare, school
+633	苦	63194	80.7845452594	ku3	bitter/intensely/miserable/painful
+634	创	63156	80.8171833414	chuang1/chuang4	a wound/cut/injury/trauma, begin/initiate/inaugurate/start/create
+635	假	62691	80.8495811183	jia3/jia4	fake/false/artificial/to borrow/if/suppose, vacation
+636	久	62588	80.8819256663	jiu3	(long) time/(long) duration of time
+637	错	62401	80.9141735755	cuo4	mistake/error/blunder/fault/cross/uneven/wrong
+638	承	62285	80.9463615376	cheng2	to bear/to carry/to hold/to continue/to undertake/to take charge/owing to/due to/to receive
+639	印	62179	80.9784947205	yin4	stamp/seal/mark/print/India (abbrev.)
+640	晚	62142	81.0106087823	wan3	evening/night/late
+641	兰	61951	81.0426241382	lan2	orchid
+642	试	61912	81.0746193394	shi4	to test/to try/experiment/examination/test
+643	股	61861	81.1065881846	gu3	share/portion/section/part/thigh/(a measure word, e.g. use with electric current)/whiff
+644	拿	61798	81.1385244724	na2	to hold/to seize/to catch/to apprehend/to take
+645	脑	61647	81.1703827256	nao3	brain
+646	预	61534	81.2021825821	yu4	to advance/in advance/beforehand/to prepare
+647	谁	61528	81.2339793378	shei2/shui2	who, who
+648	益	60896	81.2654494854	yi4	benefit/increase
+649	阳	60867	81.2969046462	yang2	positive (electric.)/sun
+650	若	60736	81.3282921081	ruo4	to seem/like/as/if
+651	哪	60708	81.3596651001	na3/na/nei3	how/which, (final part. preceded by N), which (followed by M or Num)
+652	微	60484	81.3909223322	wei1	micro/tiny/miniature
+653	尼	60474	81.4221743964	ni2	Buddhist nun/(often used in phonetic spellings)
+654	继	60428	81.4534026885	ji4	to continue/to follow after/then/afterwards/to go on with/to succeed/to inherit
+655	送	60182	81.4845038515	song4	to deliver/to carry/to give (as a present)/to present (with)/to see off/to send
+656	急	60141	81.5155838263	ji2	hurried/worried
+657	血	59944	81.5465619944	xie3/xue4	blood, blood
+658	惊	59724	81.5774264698	jing1	to start/to be frightened/to be scared/alarm
+659	伤	59632	81.6082434009	shang1	injure/injury/wound
+660	素	59100	81.6387854024	su4	plain/element
+661	药	59090	81.669322236	yao4	medicine/drug/cure
+662	适	58927	81.6997748336	shi4	to fit/to suit
+663	波	58859	81.7301922899	bo1	wave/ripple/storm/surge
+664	夜	58839	81.7605994104	ye4	night
+665	省	58642	81.7909047243	sheng3/xing3	frugal/save/to omit/to leave out/to save (money)/province, comprehend/introspect/visit
+666	初	58587	81.8211816149	chu1	at first/(at the) beginning/first/junior/basic
+667	喜	58449	81.8513871893	xi3	to be fond of/to like/to enjoy/to be happy/to feel pleased/happiness/delight/glad
+668	卫	58408	81.8815715754	wei4	to guard/to protect/to defend/(surname)
+669	源	58145	81.9116200471	yuan2	root/source/origin
+670	食	58110	81.9416504313	shi2/si4	animal feed/eat/food, to feed
+671	险	58047	81.971648258	xian3	danger (ous)/rugged
+672	待	57757	82.001496217	dai1/dai4	stay/delay, wait/treat/deal with/need/about/intending to do something
+673	述	57744	82.0313374578	shu4	to state/to tell/to narrate/to relate
+674	陆	57430	82.0610164281	liu4/lu4	six (fraud-proof), (surname)/shore/land/continent
+675	习	57329	82.0906432031	xi2	to practice/to study/habit
+676	置	57255	82.120231736	zhi4	to install/to place/to put
+677	居	56307	82.1493303565	ju1	reside
+678	劳	56119	82.1783318215	lao2	toil
+679	财	56037	82.2072909101	cai2	money/wealth/riches/property/valuables
+680	环	55971	82.2362158909	huan2	bracelet/ring (not for finger)/to surround/to loop/loop
+681	排	55938	82.2651238177	pai2/pai3	a platoon/line up, row of logs or boards
+682	福	55871	82.29399712	fu2	good fortune
+683	纳	55597	82.3227288231	na4	to accept/to pay (tax etc.)
+684	欢	55294	82.3513039404	huan1	joyous/happy/pleased
+685	雷	55226	82.3798439162	lei2	(surname)/thunder
+686	警	55189	82.408364771	jing3	to alert/to warn
+687	获	55064	82.4368210277	huo4	to catch/to obtain/to capture, reap/harvest
+688	模	54891	82.4651878805	mo2	imitate/model/norm/pattern
+689	充	54812	82.4935139073	chong1	fill/satisfy/fulfill/to act in place of/substitute/sufficient/full
+690	负	54616	82.5217386442	fu4	lose/negative (math. etc.)/to bear/to carry (on one's back)
+691	云	54510	82.5499086019	yun2	(classical) to say, cloud/(abbr.) for Yunnan/surname
+692	停	54453	82.5780491028	ting2	to stop/to halt
+693	木	54433	82.6061792681	mu4	tree/wood
+694	游	54262	82.634221063	you2	to walk/to tour/to roam/to swim/to travel, to roam/travel
+695	龙	54169	82.662214797	long2	dragon/imperial/Long (a surname)
+696	树	54037	82.6901403153	shu4	tree
+697	疑	53982	82.7180374105	yi2	to doubt/to misbelieve/to suspect
+698	层	53705	82.7457913561	ceng2	a measure word for layers/laminated/repeated/floor/story (of a building)/layer/(math.) sheaf
+699	冷	53460	82.7734186894	leng3	cold
+700	洲	53429	82.8010300024	zhou1	continent/island
+701	冲	53378	82.8286149593	chong1/chong4	to rinse/to collide/to water/to rush/to dash (against)/to wash out/to charge/highway/public road, dash against, strong/powerful/forceful/dynamic/to punch, of great force/towards
+702	射	53184	82.8560996599	she4	radio- (chem.)/shoot
+703	略	53068	82.8835244134	lue4	plan/strategy/outline/summary/slightly/rather/to rob/to plunder/to summarize
+704	范	53033	82.9109310795	fan4	pattern/model/example/(surname)
+705	竟	53033	82.9383377455	jing4	unexpectedly/actually/to go so far as to/indeed
+706	句	52891	82.9656710281	ju4	(a measure word, for sentences or lines of verse)/sentence
+707	室	52846	82.9929810553	shi4	room
+708	异	52735	83.0202337194	yi4	(interj.)/raise/to stop, different/unusual/strange
+709	激	52723	83.047480182	ji1	to arouse/to incite/to excite/to stimulate/sharp/fierce/violent
+710	汉	52656	83.0746920201	han4	Chinese/name of a dynasty
+711	村	52603	83.1018764685	cun1	village
+712	哈	52475	83.1289947685	ha1/ha3	laughter/yawn, a Pekinese/a pug
+713	策	52394	83.1560712088	ce4	method/plan/policy/scheme
+714	演	52394	83.1831476492	yan3	to develop/to evolve/to practice/to perform/to play/to act
+715	简	52280	83.210165176	jian3	simple
+716	卡	52244	83.2371640986	ka3/qia3	to check/to stop/to block/card, customs station/to be choked/to fasten/to clip/to wedge/checkpost
+717	罪	52068	83.264072067	zui4	guilt/crime/fault/blame/sin
+718	判	52045	83.2909681493	pan4	to judge/to sentence/to discriminate/to discern
+719	担	51792	83.317733485	dan1/dan4	to undertake/to carry/to shoulder/to take responsibility, a picul (133.33 lbs.)/burden/a load/responsibility
+720	州	51533	83.3443649733	zhou1	(United States) state/province/sub-prefecture
+721	静	51401	83.370928246	jing4	still/calm/quiet/not moving
+722	退	51272	83.3974248535	tui4	retreat/to decline/to move back/to withdraw
+723	既	51208	83.4238883866	ji4	already/since/both... (and...)
+724	衣	51134	83.4503136777	yi1/yi4	clothes, gown/to dress/to wear
+725	您	51094	83.4767182974	nin2	you (formal)
+726	宗	50799	83.5029704655	zong1	school/sect/purpose/model/ancestor/family
+727	积	50720	83.5291818075	ji1	to amass/to accumulate/to store/old/long-standing
+728	余	50601	83.5553316521	yu2	extra/surplus/remaining/after/I/me
+729	痛	50459	83.5814081132	tong4	ache/pain/sorrow
+730	检	50413	83.6074608022	jian3	to check/to examine/to inspect
+731	差	50349	83.6334804169	cha1/cha4/chai1/ci1	difference/discrepancy/to differ/error/to err/to make a mistake, differ from/short of/to lack/poor, send/a messenger/a mission/to commission, uneven
+732	富	50273	83.659460756	fu4	rich
+733	灵	50134	83.6853692619	ling2	alert/departed soul/efficacious/quick/effective/intelligence
+734	协	50123	83.7112720832	xie2	cooperate/harmonize/to help/to assist/to join
+735	角	50081	83.7371531996	jiao3/jue2	angle/horn/horn-shaped, Chinese musical note/angle/horn
+736	占	49980	83.7629821206	zhan1/zhan4	to observe/to divine, to divine, to occupy/to constitute/to make up/to account
+737	配	49900	83.7887696988	pei4	to join/to fit/to mate/to mix/to match/to deserve/to make up (a prescription)
+738	征	49855	83.8145340217	zheng1	attack/levy (troops or taxes)/journey/trip/expedition
+739	修	49829	83.8402849082	xiu1	to decorate/to embellish/to repair/to build/to study/to write/to cultivate
+740	皮	49803	83.8660223583	pi2	leather/skin/fur
+741	挥	49702	83.891707613	hui1	scatter/wield/wipe away
+742	胜	49565	83.9173220682	sheng1/sheng4	(also sheng4) able to do/competent enough to, peptide, victorious
+743	降	49306	83.9428026761	jiang4/xiang2	to drop/to fall/to come down/to descend, surrender
+744	阶	49058	83.9681551212	jie1	rank or step/stairs
+745	审	48862	83.9934062765	shen3	to examine/to investigate/carefully/to try (in court)
+746	沉	48772	84.018610921	chen2	submerge/immerse/sink/deep/profound/to lower/to drop
+747	坚	48749	84.0438036796	jian1	strong/solid/firm/unyielding/resolute
+748	善	48739	84.0689912702	shan4	good
+749	妈	48622	84.0941183971	ma1	ma/mamma
+750	刘	48600	84.1192341546	liu2	(surname)/to kill
+751	读	48304	84.1441969438	dou4/du2	comma/phrase marked by pause, to read/to study
+752	啊	48244	84.1691287258	a1/a2/a3/a4/a	(interj.)/ah, an interjection/to express doubt or to question/to show realization/to stress, (interj. for surprise), oh (interjection), (a modal particle showing affirmation, approval, or consent)
+753	超	48218	84.1940470714	chao1	to exceed/overtake/surpass/transcend/ultra-/super-/to pass/to cross
+754	免	48044	84.2188754964	mian3	to exempt/to remove/to avoid/to excuse
+755	压	48038	84.2437008207	ya1/ya4	to press/to push down/to keep under (control), in the first place/to crush
+756	银	47955	84.2684832519	yin2	silver
+757	买	47788	84.2931793799	mai3	buy
+758	皇	47750	84.3178558701	huang2	(surname)/emperor
+759	养	47702	84.3425075545	yang3	give birth/keep (pets)/to support/to bring sb. up/to raise (pig, etc.)
+760	伊	47619	84.3671163459	yi1	he/she/(surname)/Iraq (abbrev.)
+761	怀	47561	84.3916951637	huai2	to think of/to cherish/mind/heart/bosom
+762	执	47543	84.4162646793	zhi2	execute (a plan)/grasp
+763	副	47520	84.4408223089	fu4	secondary/auxiliary/deputy/assistant/vice-/(measure word for a pair)
+764	乱	47474	84.4653561664	luan4	in confusion/disorderly
+765	抗	47342	84.4898218082	kang4	to resist/to fight/to defy
+766	犯	47098	84.5141613545	fan4	to violate/to offend
+767	追	47079	84.5384910819	zhui1	pursue (a problem)/to chase
+768	帮	47065	84.5628135742	bang1	to assist/to support/to help/group/gang/party
+769	宣	47041	84.5871236638	xuan1	to declare (publicly)/to announce
+770	佛	47038	84.6114322029	fo2/fu2	Buddha/Buddhism, seemingly
+771	岁	46835	84.6356358347	sui4	year/years old/(a measure word)
+772	航	46789	84.6598156944	hang2	boat/ship/vessel/craft/to navigate/to sail
+773	优	46613	84.6839045999	you1	excellent/superior
+774	怪	46600	84.7079867871	guai4	queer/to blame
+775	香	46525	84.7320302155	xiang1	fragrant/incense/(of food) savory/appetizing/sweet/scented/popular
+776	田	45886	84.779639046	tian2	(surname)/field/farm
+777	铁	45798	84.8033067716	tie3	iron
+778	控	45664	84.826905248	kong4	to accuse/to charge/to control/to sue
+779	税	45615	84.850478402	shui4	taxes/duties
+780	左	45568	84.874027267	zuo3	left
+781	右	45561	84.8975725145	you4	right (-hand)
+782	份	45408	84.9210386939	fen4	(a measure word for gifts, copies of a newspaper)/copy (of newspaper, magazine, etc.)/share/portion/part/(a measure word)
+783	穿	45314	84.9444562955	chuan1	to bore through/pierce/perforate/penetrate/pass through/to dress/to wear/to put on/to thread
+784	艺	45218	84.9678242857	yi4	skill/art
+785	背	45181	84.9911731549	bei1/bei4	carry on one's back, to be burdened/to carry on the back or shoulder, learn by heart/the back of the body
+786	阵	44899	85.0143762906	zhen4	disposition of troops/short period/wave/spate/burst/spell
+787	草	44612	85.0374311091	cao3	grass/straw/draft (of a document)/careless/rough/manuscript/hasty
+788	脚	44529	85.0604430343	jiao3/jue2	a kick/foot/role, role
+789	概	44501	85.0834404896	gai4	general/approximate
+790	恶	44493	85.1064338106	e3/e4/wu4	nauseated, evil, to hate/to loathe
+791	块	44475	85.1294178295	kuai1/kuai4	piece/chunk/lump/(measure word for chunks, lumps), yuan (unit of currency)/fast (of a watch)/swift/rapid/happy/joyful/soon/quick/(a measure word, for cloth, cake, soap)
+792	顿	44425	85.1523760091	dun4	a time/jerk/stop/meal/bout/spell/(measure for beating)
+793	敢	44338	85.1752892284	gan3	dare
+794	守	44264	85.1981642056	shou3	to guard
+795	酒	44069	85.2209384097	jiu3	wine/liquor/spirits
+796	岛	44056	85.2437058956	dao3	island
+797	托	44052	85.2664713143	tuo1	to hold in one's hand/to entrust/to support in one's palm, entrust
+798	央	44052	85.2892367331	yang1	beg/center
+799	户	43810	85.3118770898	hu4	a household/door/family
+800	烈	43751	85.3344869562	lie4	ardent/intense/split/crack/rend
+801	洋	43692	85.3570663323	yang2	foreign/ocean
+802	哥	43620	85.3796084999	ge1	elder brother
+803	索	43365	85.4020188873	suo3	to search/to demand/to ask/to exact/large rope/isolated
+804	胡	43199	85.4243434883	hu2	(surname)/beard/what why how, beard/mustache
+805	款	43087	85.4466102094	kuan3	section/paragraph/funds
+806	靠	42988	85.4688257688	kao4	depend upon/lean on/near/by/against/to support
+807	评	42966	85.4910299589	ping2	to discuss/to comment/to criticize/to judge/to choose (by public appraisal)
+808	版	42853	85.5131757522	ban3	a register/a block of printing/an edition/version/page
+809	宝	42836	85.5353127603	bao3	a jewel or gem/a treasure/precious
+810	座	42814	85.557438399	zuo4	seat/base/stand/measure word for large, solid things
+811	释	42749	85.5795304468	shi4	explain/to release
+812	景	42738	85.6016168098	jing3	bright/circumstance/scenery
+813	顾	42735	85.6237016226	gu4	look after/take into consideration/to attend to
+814	弟	42706	85.6457714485	di4	younger brother
+815	登	42687	85.6678314556	deng1	scale/climb/ascend/mount/go up/register/note/to publish/to issue/to record
+816	货	42602	85.6898475359	huo4	goods/money/commodity
+817	互	42579	85.7118517301	hu4	mutual
+818	付	42527	85.7338290515	fu4	pay
+819	伯	42513	85.755799138	bo2	father's elder brother/senior/paternal elder uncle/eldest of brothers/respectful form of address
+820	慢	42506	85.7777656069	man4	slow
+821	欧	42504	85.7997310423	ou1	Europe
+822	换	42292	85.8215869192	huan4	change/exchange
+823	闻	42253	85.8434226415	wen2	(surname)/hear/sniff at
+824	危	42080	85.86516896	wei1	danger/to endanger
+825	忙	42026	85.886887372	mang2	busy
+826	核	41944	85.9085634077	he2	nuclear/atomic/stone (of fruit)
+827	暗	41881	85.9302068859	an4	dark/gloomy/hidden/secret, to shut the door/unilluminated
+828	姐	41762	85.9517888667	jie3	older sister
+829	介	41749	85.9733641293	jie4	introduce/lie between/between
+830	坏	41723	85.9949259555	huai4	bad/spoiled, bad
+831	讨	41717	86.016484681	tao3	ask for/send punitive expedition/to demand/to marry
+832	丽	41363	86.0378604645	li2/li4	Korea, beautiful
+833	良	41167	86.0591349581	liang2	good/very/very much
+834	序	41129	86.0803898139	xu4	order/sequence/preface
+835	升	41105	86.1016322669	sheng1	to raise/to hoist/to promote/pint, ascend/peaceful, promoted
+836	监	41082	86.1228628338	jian1/jian4	hard/strong/solid/firm/to supervise/to inspect/jail/prison, supervisor
+837	临	41068	86.1440861657	lin2	to face/to overlook/to arrive/to be (just) about to/just before
+838	亮	41016	86.1652826248	liang4	light/bright
+839	露	40954	86.1864470432	lu4/lou4	to show/to reveal/to expos/dew
+840	永	40936	86.2076021595	yong3	forever/always/perpetual (ly)
+841	呼	40709	86.2286399655	hu1	to call/to cry/to shout/to breath out/to exhale
+842	味	40704	86.2496751876	wei4	taste
+843	野	40681	86.2706985237	ye3	field/plain/open space/limit/boundary/rude/wild
+844	架	40619	86.2916898191	jia4	to support/frame/rack/framework/measure word for planes, large vehicles, radios, etc.
+845	域	40597	86.3126697452	yu4	field/region/area/domain (taxonomy)
+846	沙	40573	86.3336372685	sha1	granule/hoarse/raspy/sand/powder
+847	掉	40541	86.3545882546	diao4	to drop/to fall
+848	括	40519	86.3755278715	kuo4	enclose/include
+849	舰	40500	86.3964576694	jian4	warship
+850	鱼	40452	86.4173626617	yu2	fish
+851	杂	40265	86.4381710151	za2	mixed/miscellaneous/various/to mix
+852	误	40196	86.4589437104	wu4	mistake/error/to miss/to harm/to delay/to neglect
+853	湾	40101	86.4796673111	wan1	bay/gulf
+854	吉	40081	86.5003805761	ji2	lucky
+855	减	40011	86.5210576661	jian3	to lower/to decrease/to reduce/to subtract/to diminish
+856	编	39879	86.5416665405	bian1	weave/plait/organize/group/arrange/edit/compile/write/compose/fabricate
+857	楚	39846	86.562258361	chu3	(surname)/ancient place name/distinct/clear/orderly/pain/suffering/(a surname)
+858	肯	39813	86.5828331275	ken3	to agree/to consent/to be ready (to do sth)/willing
+859	测	39752	86.6033763702	ce4	side/to lean/to survey/to measure/conjecture
+860	败	39627	86.6238550147	bai4	be defeated/to defeat/loss
+861	屋	39588	86.6443135046	wu1	house/room
+862	跑	39497	86.6647249671	pao3	to run/to escape
+863	梦	39486	86.6851307449	meng4	to dream
+864	散	39336	86.705459005	san3/san4	leisurely/loosen/powdered medicine/to scatter/to come loose, adjourn/scatter
+865	温	39312	86.7257748622	wen1	(luke)warm/to review
+866	困	39172	86.7460183695	kun3/kun4	a bunch/tie together, distress/sleepy/doze off, sleepy/doze off
+867	剑	39020	86.7661833255	jian4	(double-edged) sword
+868	渐	39010	86.7863431136	jian1/jian4	imbue, gradual/gradually
+869	封	38954	86.8064739617	feng1	to confer/to grant/to seal/(a measure word)
+870	救	38824	86.8265376278	jiu4	to save/to assist/to rescue
+871	贵	38668	86.8465206753	gui4	expensive/noble/your (name)/precious
+872	枪	38569	86.8664525612	qiang1	gun/firearm/rifle/spear, rifle/spear
+873	缺	38506	86.8863518896	que1	lack/scarce/vacant post/to run short of
+874	楼	38463	86.9062289962	lou2	house with more than 1 story/storied building/floor
+875	县	38407	86.9260771629	xian4	a district/county
+876	尚	38376	86.9459093092	shang4	still/yet/to value/to esteem
+877	毫	38374	86.965740422	hao2	hair/drawing brush/(in the) least/one thousandth
+878	移	38349	86.9855586151	yi2	to move/to shift/to change/to alter/to remove
+879	娘	38274	87.0053380494	niang2	mother/young lady, mother/troubled
+880	朋	38271	87.0251159333	peng2	friend
+881	画	38263	87.0448896829	hua4	draw/picture/painting
+882	班	38130	87.0645947	ban1	team/class/rank/squad/a work shift/a measure word/(a surname)
+883	智	38064	87.0842656094	zhi4	wisdom/knowledge
+884	亦	37960	87.1038827731	yi4	also
+885	耳	37939	87.1234890843	er3	ear
+886	恩	37898	87.1430742074	en1	kind act (from above)
+887	短	37834	87.1626262562	duan3	lack/short
+888	掌	37729	87.1821240425	zhang3	in charge of/palm of hand
+889	恐	37676	87.2015944392	kong3	afraid/frightened/to fear
+890	遗	37619	87.2210353792	yi2	to lose/to leave behind
+891	固	37582	87.2404571982	gu4	hard/strong/solid/sure
+892	席	37579	87.2598774667	xi2	banquet/woven mat/seat/place, woven mat
+893	松	37563	87.2792894667	song1	loose/pine, loose
+894	秘	37560	87.2986999164	mi4	secret
+895	谢	37550	87.3181051982	xie4	(surname)/to thank
+896	鲁	37474	87.3374712043	lu3	crass/place name
+897	遇	37343	87.3567695116	yu4	meet with
+898	康	37302	87.3760466307	kang1	peaceful/spongy (of radishes)
+899	虑	37208	87.395275172	lu:4/lv4	anxiety
+900	幸	37198	87.4144985455	xing4	lucky, fortunate/lucky
+901	均	36842	87.4335379434	jun1	equal/even/all/uniform
+902	销	36821	87.4525664888	xiao1	to melt/to do away with/to sell
+903	钟	36770	87.4715686782	zhong1	clock/time as measured in hours and minutes/bell
+904	诗	36762	87.4905667333	shi1	poem/poetry/verse
+905	藏	36704	87.5095348149	cang2/zang4	to hide away/to conceal/to harbor/store/accumulate, storehouse/depository/Buddhist or Taoist scripture/Zang/Tibet
+906	赶	36599	87.5284486341	gan3	to catch up/to overtake/to hurry/to rush/to drive away
+907	剧	36585	87.5473552182	ju4	drama/play/show/severe
+908	票	36459	87.5661966875	piao4	bank note/ticket
+909	损	36444	87.5850304049	sun3	to damage/injure/to lose/to harm
+910	忽	36378	87.6038300145	hu1	suddenly
+911	巨	36351	87.622615671	ju4	very large/huge/tremendous/gigantic
+912	炮	36315	87.6413827231	pao4	cannon/gun/firecracker, gun/cannon
+913	旧	36291	87.6601373724	jiu4	old (opposite of new)/former
+914	端	36233	87.6788620482	duan1	end/extremity/item/port/to hold sth. level with both hands/to carry/regular
+915	探	36230	87.6975851737	tan4	to explore/to search out/to scout/to visit
+916	湖	36112	87.7162473184	hu2	lake
+917	录	36080	87.7348929261	lu4	to record/to hit/to copy
+918	叶	36032	87.7535137281	ye4	(surname)/leaf/page
+919	春	36027	87.7721319461	chun1	spring (time)/gay/joyful/youthful/love/lust/life
+920	乡	36025	87.7907491306	xiang1	country/village
+921	附	35955	87.8093301401	fu4	to add/to attach/to be close to/to be attached
+922	吸	35891	87.8278780754	xi1	to breathe/to suck in/to absorb/to inhale
+923	予	35757	87.8463567614	yu2/yu3	I, to give
+924	礼	35612	87.8647605137	li3	gift/propriety/rite
+925	港	35577	87.8831461784	gang3	harbor/Hong Kong (abbr.)
+926	雨	35370	87.9014248686	yu3	rain
+927	呀	35343	87.9196896056	ya/ya1	(final part.)
+928	板	35332	87.937948658	ban3	board/plank/plate/slab, boss
+929	庭	35205	87.9561420787	ting2	court/courtyard
+930	妇	35188	87.974326714	fu4	woman
+931	归	35153	87.9924932618	gui1	to go back/to return
+932	睛	35082	88.0106231179	jing1	eye
+933	饭	35076	88.0287498733	fan4	food/cuisine/cooked rice/meal
+934	额	34823	88.046745882	e2	volume/amount/quantity/forehead/quota
+935	含	34759	88.0647088165	han2	to keep/to contain
+936	顺	34708	88.082645395	shun4	to obey/to follow/to arrange/to make reasonable/along/favorable
+937	输	34688	88.1005716377	shu1	to transport/to lose
+938	摇	34635	88.1184704909	yao2	shake/to rock
+939	招	34625	88.1363641762	zhao1	provoke/to recruit
+940	婚	34610	88.1542501097	hun1	to marry/marriage/wedding/to take a wife
+941	脱	34548	88.1721040025	tuo1	to shed/to take off/to escape/to get away from
+942	补	34542	88.1899547946	bu3	to repair/to patch/to mend/to make up for/to fill (a vacancy)/to supplement
+943	谓	34527	88.207797835	wei4	speak of
+944	督	34523	88.2256388082	du1	supervise
+945	毒	34517	88.2434766807	du2	poison/narcotics
+946	油	34469	88.2612897475	you2	oil/sly
+947	疗	34467	88.2791017807	liao2	to treat/to cure
+948	旅	34384	88.2968709208	lu:3/lv3	trip/travel
+949	泽	34311	88.3146023355	ze2	beneficence/marsh
+950	材	34237	88.3322955082	cai2	material
+951	灭	34135	88.3499359688	mie4	extinguish
+952	逐	34128	88.3675728118	zhu2	to pursue/to chase/individually/one by one
+953	莫	34097	88.3851936346	mo4	do not/there is none who
+954	笔	34057	88.4027937859	bi3	pen/pencil/writing brush/to write or compose/the strokes of Chinese characters
+955	亡	33917	88.4203215873	wang2	to die/to perish
+956	鲜	33720	88.4377475821	xian1/xian3	fresh, few/rare
+957	词	33669	88.4551472208	ci2	works/phrases/classical Chinese poem/word/diction
+958	圣	33620	88.472521537	sheng4	holy/sacred/saint/sage
+959	择	33615	88.4898932693	ze2/zhai2	to select/to choose/to pick, pick over
+960	寻	33469	88.507189551	xun2	to search/to look for/to seek
+961	厂	33468	88.5244853159	chang3	cliff/slope/factory/yard/depot/workhouse/works/(industrial) plant
+962	睡	33420	88.5417562751	shui4	to sleep
+963	博	33366	88.5589993279	bo2	extensive/ample/rich/obtain/aim/to win/to get/rich/plentiful/to gamble
+964	勒	33228	88.5761710643	le4/lei1	rein in, strangle
+965	烟	33137	88.5932957733	yan1	cigarette/tobacco/smoke
+966	授	33017	88.6103584681	shou4	to teach/to instruct/to award/to give
+967	诺	32991	88.6274077265	nuo4	to promise/to yes
+968	伦	32822	88.6443696482	lun2	human relationship
+969	岸	32807	88.6613238181	an4	bank/shore/beach/coast
+970	奥	32761	88.6782542159	ao4	obscure/mysterious
+971	唐	32757	88.6951825465	tang2	Tang dynasty (618-907)
+972	卖	32694	88.7120783197	mai4	to sell
+973	俄	32638	88.728945153	e2	suddenly/very soon/Russian
+974	炸	32540	88.7457613412	zha2/zha4	fry, explode
+975	载	32456	88.7625341196	zai3/zai4	year, to carry/to convey/to load/to hold/and/also/as well as/simultaneously
+976	洛	32431	88.7792939783	luo4	(surname)/name of a river
+977	健	32399	88.7960372999	jian4	healthy
+978	堂	32367	88.8127640843	tang2	(main) hall/large room
+979	旁	32268	88.829439707	pang2	beside/one side/other/side/self
+980	宫	32179	88.8460693359	gong1	palace
+981	喝	32112	88.8626643401	he1/he4	my goodness/to drink, shout applause
+982	借	32027	88.8792154176	jie4	to lend/to borrow/excuse/pretext/by means of
+983	君	31960	88.8957318705	jun1	monarch/lord/gentleman/ruler
+984	禁	31951	88.9122436724	jin1/jin4	endure, to prohibit/to forbid
+985	阴	31936	88.9287477224	yin1	(of weather) overcast/Yin/feminine/moon/cloudy/negative (electric.)/shady
+986	园	31925	88.9452460879	yuan2	garden
+987	谋	31910	88.9617367015	mou2	to plan/seek/scheme
+988	宋	31748	88.978143596	song4	(surname)/name of a dynasty
+989	避	31731	88.9945417051	bi4	avoid/shun/flee/escape/leave/to keep away/to leave/to hide
+990	抓	31675	89.0109108742	zhua1	to grab/to catch/to arrest/to snatch
+991	荣	31662	89.0272733251	rong2	glory/honored
+992	姑	31647	89.0436280243	gu1	paternal aunt
+993	孙	31506	89.0599098568	sun1	grandson
+994	逃	31468	89.0761720514	tao2	to escape/to run away/to flee
+995	牙	31466	89.0924332124	ya2	tooth/ivory
+996	束	31370	89.1086447621	shu4	bunch/(a measure word)/to bind/to control
+997	跳	31324	89.1248325397	tiao4	jump/hop/skip (a grade)/to leap/to bounce/to beat
+998	顶	31318	89.1410172165	ding3	go against/most/peak/top/to replace/to substitute/a measure word (use with "hat")
+999	玉	31279	89.1571817387	yu4	jade
+1000	镇	31170	89.1732899314	zhen4	composed/small town/to suppress/to press down/to post
+1001	雪	30997	89.1893087202	xue3	snow
+1002	午	30985	89.2053213076	wu3	11 a.m.-1 p.m./7th earthly branch/noon
+1003	练	30963	89.2213225257	lian4	to practice/to train/to perfect (one's skill)/to drill
+1004	迫	30930	89.2373066899	po4	to force/to compel/pressing/urgent
+1005	爷	30930	89.2532908541	ye2	grandpa/etc./old gentleman
+1006	篇	30894	89.2692564141	pian1	sheet/piece of writing/(a measure word)/chapter/article
+1007	肉	30820	89.2851837319	rou4	meat/flesh
+1008	嘴	30765	89.3010826266	zui3	mouth
+1009	馆	30564	89.3168776475	guan3	house/establishment
+1010	遍	30545	89.3326628494	bian4	a time/everywhere/turn/all over/one time
+1011	凡	30533	89.3484418499	fan2	ordinary/every/all/whatever/worldly
+1012	础	30477	89.3641919105	chu3	foundation/base
+1013	洞	30399	89.3799016618	dong4	cave/hole
+1014	卷	30343	89.3955824731	juan3/juan4	to roll (up)/to sweep up/to carry on, coil/to roll, chapter/examination paper
+1015	坦	30341	89.4112622509	tan3	flat/open-hearted/level/smooth
+1016	牛	30047	89.4267900938	niu2	ox/cow/bull
+1017	宁	30001	89.4422941647	ning2	peaceful/rather
+1018	纸	30001	89.4577982355	zhi3	paper
+1019	诸	29957	89.4732795678	zhu1	(surname)/all/many/various
+1020	训	29911	89.4887371279	xun4	example/pattern/to teach/to train/instruction
+1021	私	29700	89.5040856464	si1	personal/private/selfish
+1022	庄	29679	89.5194233124	zhuang1	farm/village
+1023	祖	29644	89.534742891	zu3	ancestor/forefather/grandparents
+1024	丝	29585	89.5500319792	si1	silk/thread/trace
+1025	翻	29568	89.565312282	fan1	flit about/translate/turn over
+1026	暴	29566	89.5805915513	bao4	sudden/violent/cruel/to show or expose/to injure
+1027	森	29533	89.5958537667	sen1	forest
+1028	塔	29454	89.6110751561	ta3	pagoda/tower
+1029	默	29432	89.6262851762	mo4	silent/write from memory
+1030	握	29418	89.6414879612	wo4	shake hands/to hold/to grasp
+1031	戏	29402	89.6566824778	xi4	trick/drama/play/show
+1032	隐	29294	89.6718211815	yin3	secret/hidden/concealed
+1033	熟	29271	89.6869479992	shu2	familiar/skilled/ripe/done/ripe/cooked
+1034	骨	29180	89.7020277894	gu3	bone
+1035	访	29134	89.7170838075	fang3	inquire/seek/visit
+1036	弱	29129	89.7321372417	ruo4	weak/feeble/young/inferior
+1037	蒙	29019	89.7471338295	meng1/meng2/meng3	deceive/cheat/hoodwink, drizzle/mist, dim sighted/ignorant, Mongolia/cover
+1038	歌	28957	89.7620983767	ge1/ge1ge	song
+1039	店	28926	89.7770469035	dian4	inn/shop/store
+1040	鬼	28916	89.7919902624	gui3	ghost/sly/crafty
+1041	软	28885	89.8069176011	ruan3	soft/flexible
+1042	典	28860	89.82183202	dian3	canon/dictionary
+1043	欲	28856	89.8367443719	yu4	desire/wish, desire/longing/appetite/wish
+1044	萨	28804	89.8516298509	sa4	(surname)/Bodhisattva
+1045	伙	28724	89.8664739871	huo3	assistant/furniture/partner
+1046	遭	28642	89.8812757469	zao1	a time/incident/meet by chance/turn
+1047	盘	28582	89.8960464997	pan2	big/wooden tray, dish/tray/to build/to check/to examine/to transfer/(a measure word used for dishes of food or coils of wire)/to coil
+1048	爸	28526	89.9107883124	ba4	father/dad/pa/papa
+1049	扩	28331	89.9254293521	kuo4	enlarge
+1050	盖	28310	89.9400595392	gai4/ge3	lid/top/cover/canopy/to build, (surname)
+1051	弄	28205	89.954635464	long4/nong4	lane/alley, to do/to manage/to handle/to play with/to fool with/to mess with/to fix/to toy with
+1052	雄	28184	89.9692005362	xiong2	heroic/male
+1053	稳	28031	89.9836865403	wen3	settled/steady/stable
+1054	忘	27961	89.9981363694	wang4	to forget/to overlook/to neglect
+1055	亿	27897	90.0125531243	yi4	a hundred million/calculate
+1056	刺	27891	90.0269667785	ci4	thorn/sting/prick/pierce/stab/thrust/assassinate/murder
+1057	拥	27833	90.0413504592	yong1	(v) gather round/rush in/crowd/throng/to hold/crowded/to support
+1058	徒	27812	90.0557232874	tu2	apprentice/disciple
+1059	姆	27808	90.0700940484	mu3	governess
+1060	杨	27561	90.0843371635	yang2	(surname)/poplar
+1061	齐	27480	90.098538419	qi2	(surname)/even/to make even
+1062	赛	27472	90.1127355402	sai4	to compete/competition/match
+1063	趣	27434	90.1269130236	qu4	interesting/to interest
+1064	曲	27401	90.1410734531	qu1/qu3	bent/crooked/wrong, tune/song
+1065	刀	27292	90.155177553	dao1	knife
+1066	床	27283	90.1692770018	chuang2	bed/couch/(a measure word)
+1067	迎	27228	90.1833480274	ying2	to welcome
+1068	冰	27201	90.1974050999	bing1	ice
+1069	虚	27076	90.2113975742	xu1	devoid of content/void/false/empty/vain
+1070	玩	27043	90.2253729946	wan2/wan4	curios/antiques/to play/to amuse oneself, curios/antiques
+1071	析	27019	90.2393360121	xi1	to separate/to divide/to analyze
+1072	窗	26978	90.2532778415	chuang1	shutter/window
+1073	醒	26899	90.2671788448	xing3	to wake up/to be awake
+1074	妻	26847	90.2810529753	qi1/qi4	wife, to marry off (a daughter)
+1075	透	26836	90.2949214212	tou4	to penetrate/thorough/penetrating/to pass through/to pierce
+1076	购	26803	90.3087728132	gou4	to buy/to purchase
+1077	替	26687	90.3225642581	ti4	to substitute for/to take the place of/to replace/for/on behalf of/to stand in for
+1078	塞	26590	90.3363055748	sai1/sai4/se4	stop up/to squeeze in/to stuff/Serb (abbr.)/Serbian, strategic pass, piston/unenlightened
+1079	努	26564	90.3500334551	nu3	to exert/to strive
+1080	休	26539	90.3637484158	xiu1	to rest
+1081	虎	26514	90.3774504569	hu3	tiger
+1082	扬	26509	90.391149914	yang2	hurl/to raise/to scatter
+1083	途	26485	90.4048369683	tu2	way/route/road
+1084	侵	26466	90.4185142037	qin1	to invade/to infringe/to approach
+1085	刑	26453	90.4321847208	xing2	punishment
+1086	绿	26414	90.4458350834	lu:4/lv4	green/chlorine
+1087	兄	26386	90.4594709759	xiong1	elder brother
+1088	迅	26321	90.4730732775	xun4	rapid
+1089	套	26301	90.4866652433	tao4	to cover/covering/case/cover/(a measure word, a set of something)/sheath
+1090	贸	26198	90.5002039803	mao4	commerce/trade
+1091	毕	26148	90.513716878	bi4	the whole of/to finish/to complete/complete/full/finished
+1092	唯	26041	90.5271744797	wei2/wei3	-ism/only/alone, yes
+1093	谷	26005	90.5406134771	gu3/yu4	grain/corn, valley, (surname)
+1094	轮	25958	90.5540281856	lun2	wheel/gear/(by) turn/rotate
+1095	库	25924	90.5674253234	ku4	warehouse/storehouse
+1096	迹	25920	90.5808203941	ji1/ji4	footprint/mark/trace/vestige/sign/indication, footprint/trace
+1097	尤	25908	90.5942092634	you2	outstanding/particularly/especially
+1098	竞	25897	90.607592448	jing4	to compete/to contend/to struggle
+1099	街	25866	90.6209596123	jie1	street
+1100	促	25792	90.6342885345	cu4	to hurry/to rush/to hasten/near/to promote
+1101	延	25768	90.6476050539	yan2	to prolong/to extend/to delay
+1102	震	25746	90.6609102039	zhen4	shake/shock/sign in trigram
+1103	弃	25730	90.6742070855	qi4	abandon/relinquish/to discard/to throw away
+1104	甲	25620	90.6874471206	jia3	"A" (in a sequence of examples involving "A", "B", "C", etc.)/1st heavenly stem/1st in order/armor
+1105	伟	25591	90.700672169	wei3	big/large/great
+1106	麻	25584	90.7138935999	ma2	(to have) pins and needles/tingling/hemp/numb/to bother
+1107	川	25575	90.7271103797	chuan1	river/creek/plain/an area of level country
+1108	申	25531	90.740304421	shen1	(surname)/3-5 p.m./9th earthly branch/extend/to state/to explain
+1109	缓	25455	90.7534591866	huan3	slow/sluggish/gradual/to postpone
+1110	潜	25452	90.7666124018	qian2	hidden/latent/secret/to hide/to conceal/secret/hidden/to submerge
+1111	闪	25427	90.7797526974	shan3	flash/lightning
+1112	售	25405	90.7928816238	shou4	to sell
+1113	灯	25401	90.806008483	deng1	lamp/light
+1114	针	25384	90.8191265568	zhen1	injection/needle/pin, needle
+1115	哲	25353	90.8322286104	zhe2	philosophy/wise
+1116	络	25256	90.8452805357	lao4/luo4	small net, net-like
+1117	抵	25228	90.8583179911	di3	hold up/on the whole/push against/to support/to resist/to reach/to arrive/mortgage
+1118	朱	25195	90.8713383926	zhu1	(surname)/vermilion, vermilion
+1119	埃	25101	90.8843102162	ai1	dirt/dust/angstrom
+1120	抱	25069	90.8972655028	bao4	to hold/to carry (in one's arms)/to hug or embrace/surround/cherish
+1121	鼓	25016	90.9101933997	gu3	convex/drum/to rouse/to beat
+1122	植	24999	90.9231125113	zhi2	to plant
+1123	纯	24890	90.9359752933	chun2	pure/simple/unmixed/genuine
+1124	夏	24888	90.9488370417	xia4	summer/Xia (proper name)
+1125	忍	24862	90.9616853537	ren3	to beat/to endure/to tolerate
+1126	页	24861	90.974533149	ye4	page/leaf
+1127	杰	24796	90.9873473532	jie2	hero/heroic
+1128	筑	24780	91.0001532888	zhu2/zhu4	build/five-string lute
+1129	折	24737	91.0129370027	she2/zhe2	broken (as of rope, stick), tenth (in price)/to break/to fold/to turn
+1130	郑	24716	91.0257098641	zheng4	(surname)
+1131	贝	24675	91.0384615373	bei4	cowries/shell/valuables/shellfish
+1132	尊	24662	91.0512064923	zun1	to honor
+1133	吴	24632	91.0639359437	wu2	(surname)/province of Jiangsu
+1134	秀	24620	91.0766591937	xiu4	handsome/elegant
+1135	混	24605	91.089374692	hun2/hun4	confused/dirty/mix, to mix/to get along/thoughtless
+1136	臣	24553	91.1020633174	chen2	statesman/vassal/courtier/minister/official
+1137	雅	24527	91.1147385064	ya3	elegant
+1138	振	24469	91.1273837218	zhen4	rouse
+1139	染	24444	91.1400160177	ran3	to catch (a disease)/dye
+1140	盛	24387	91.1526188567	cheng2/sheng4	to hold/contain/to ladle/pick up with a utensil, (surname)/flourishing
+1141	怒	24374	91.1652149776	nu4	indignant
+1142	舞	24360	91.1778038635	wu3	to dance/to wield/to brandish
+1143	圆	24267	91.1903446883	yuan2	circle/round/circular/spherical/(of the moon) full/unit of Chinese currency (Yuan)/tactful/to justify
+1144	搞	24265	91.2028844796	gao3	to do/to make/to go in for/to set up/to get hold of/to take care of
+1145	狂	24259	91.2154211702	kuang2	conceited/mad
+1146	措	24172	91.2279129005	cuo4	put in order/arrange/administer/execute/take action on
+1147	姓	24142	91.2403891272	xing4	surname/family name/name
+1148	残	24030	91.252807474	can2	destroy/spoil/ruin/injure/cruel/oppressive/savage/incomplete/disabled
+1149	秋	24030	91.2652258208	qiu1	autumn/fall/harvest time/a swing, a swing
+1150	培	24009	91.2776333151	pei2	to cultivate/to earth up
+1151	迷	23959	91.2900149701	mi2	bewilder/crazy about/fan/enthusiast/lost/confused
+1152	诚	23947	91.3023904237	cheng2	honest/sincere/true
+1153	宽	23918	91.3147508906	kuan1	lenient/wide/broad
+1154	宇	23891	91.3270974043	yu3	room/universe
+1155	猛	23862	91.3394289311	meng3	ferocious/suddenly/fierce/violent/abrupt
+1156	摆	23853	91.351755807	bai3	pendulum/to place/to display/to swing/to oscillate/to show/to move/to exhibit
+1157	梅	23824	91.364067696	mei2	plum flower
+1158	毁	23773	91.376353229	hui3	to destroy/to damage/to ruin, blaze/destroy by fire, defame/to slander
+1159	伸	23732	91.3886175738	shen1	to stretch/to extend
+1160	摩	23645	91.4008369583	mo2	rub
+1161	盟	23581	91.4130232686	meng2	oath/pledge/union/to ally
+1162	末	23526	91.4251811557	mo4	end/final stage/latter part
+1163	乃	23520	91.437335942	nai3	to be/thus/so/therefore/then/only/thereupon
+1164	悲	23500	91.4494803927	bei1	sad/sadness/sorrow/grief
+1165	拍	23483	91.461616058	pai1	to clap/to pat/to beat/to hit/to slap/to take (a picture)
+1166	丁	23479	91.4737496562	ding1	(surname)/4th heavenly stem/a Chinese surname
+1167	赵	23428	91.4858568983	zhao4	(surname)
+1168	硬	23364	91.4979310662	ying4	hard/stiff/strong/firm
+1169	麦	23271	91.5099571731	mai4	(surname)/wheat/barley/oats
+1170	蒋	23237	91.5219657093	jiang3	(surname)
+1171	操	23193	91.5339515069	cao1	to hold/to drill/to exercise/to act/to do/to take in hand/to keep/to manage
+1172	耶	23175	91.5459280024	ye1	(final part.)/(phonetic)
+1173	阻	23151	91.557892095	zu3	to hinder/to block/to obstruct
+1174	订	22991	91.5697735021	ding4	to agree/to conclude/to draw up/to subscribe to (a newspaper, etc.)/to order
+1175	彩	22982	91.581650258	cai3	(bright) color/variety/applause/applaud/(lottery) prize, colored/variegated
+1176	抽	22937	91.5935037587	chou1	to draw out/to smoke (cigarettes)/to pump
+1177	赞	22909	91.6053427893	zan4	to praise, to patronize/to support/to praise
+1178	魔	22835	91.6171435779	mo2	devil
+1179	纷	22820	91.6289366146	fen1	numerous/confused/disorderly
+1180	沿	22781	91.6407094968	yan2/yan4	along, riverside (with -r)
+1181	喊	22779	91.6524813454	han3	call/cry/to shout
+1182	违	22751	91.664238724	wei2	to disobey/to violate/to separate/to go against
+1183	妹	22723	91.6759816326	mei4	younger sister
+1184	浪	22639	91.6876811313	lang4	wave/breaker/unrestrained/dissipated
+1185	汇	22608	91.6993646096	hui4	remit/to converge (of rivers)/to exchange, class/collection
+1186	币	22592	91.7110398193	bi4	money/coins/currency
+1187	丰	22439	91.722635961	feng1	buxom/good-looking/appearance and carriage of a person, (surname)/abundant/plentiful/great
+1188	蓝	22437	91.734231069	la/lan2	kohlrabi, blue
+1189	殊	22407	91.7458106736	shu1	unique
+1190	献	22396	91.7573845934	xian4	to offer
+1191	桌	22336	91.7689275062	zhuo1	table
+1192	啦	22263	91.7804326937	la1/la	(onomat.)/(phonetic), (an auxiliary word performing the grammatical functions of mood)/fusion of le + a
+1193	瓦	22229	91.7919203104	wa3	tile
+1194	莱	22187	91.8033862222	lai2	Chenopodium album
+1195	援	22180	91.8148485165	yuan2	to help/to assist/to aid
+1196	译	22170	91.8263056429	yi4	to translate/to interpret
+1197	夺	22148	91.8377514001	duo2	rob/snatch
+1198	汽	22098	91.849171318	qi4	steam/vapor
+1199	烧	22078	91.8605809002	shao1	to burn/to cook/to stew/to bake/to roast/fever
+1200	距	21970	91.8719346696	ju4	at a distance of/distance/to be apart
+1201	裁	21918	91.8832615662	cai2	cut out (as a dress)/cut/trim/reduce/diminish/decision/judgment
+1202	偏	21877	91.8945672746	pian1	one-sided/to lean/to slant/prejudiced/inclined to one side
+1203	符	21862	91.9058652312	fu2	mark/sign/talisman/to seal/to correspond (to)/tally/symbol/written charm/to coincide
+1204	勇	21819	91.917140966	yong3	brave
+1205	触	21719	91.9283650224	chu4	knock against/touch/to feel
+1206	课	21705	91.9395818437	ke4	subject/class/lesson
+1207	敬	21646	91.9507681747	jing4	to respect/to venerate/to salute/to offer
+1208	哭	21444	91.9618501152	ku1	to cry/to weep
+1209	懂	21117	91.9727630669	dong3	to understand/to know
+1210	墙	21101	91.98366775	qiang2	wall
+1211	袭	21098	91.9945708828	xi2	inherit/raid/suit of clothes
+1212	召	21098	92.0054740155	shao4/zhao4	(surname)/name of an ancient state, to call together/to summon/to convene
+1213	罚	21011	92.016332188	fa2	to punish/to penalize
+1214	侠	20999	92.027184159	xia2	heroic
+1215	厅	20989	92.0380309622	ting1	(reception) hall/office
+1216	拜	20978	92.0488720808	bai4	to pay respect/worship/visit/salute
+1217	巧	20964	92.0597059643	qiao3	opportunely/coincidentally/as it happens/skillful/timely
+1218	侧	20960	92.0705377808	ce4/zhai1	the side/to incline towards/to lean/inclined/lateral/side, lean on one side
+1219	韩	20947	92.081362879	han2	South Korea/Korean/Japan-annexed Korea
+1220	冒	20917	92.0921724736	mao4	brave/bold/to cover
+1221	债	20902	92.1029743165	zhai4	debt
+1222	曼	20897	92.1137735755	man4	handsome/large/long
+1223	融	20883	92.1245655995	rong2	harmonious/melt/mild
+1224	惯	20880	92.1353560731	guan4	accustomed to/used to
+1225	享	20830	92.1461207074	xiang3	enjoy
+1226	戴	20826	92.1568832746	dai4	to put on/to respect/to bear/to support/wear (glasses, hat, gloves)
+1227	童	20813	92.1676391236	tong2	(surname)/boy/child/children
+1228	犹	20747	92.1783608648	you2	Jew/as if/still/to scheme
+1229	乘	20731	92.1890743375	cheng2	ride/mount/make use of/take advantage of/multiply/to avail of/to ride
+1230	挂	20706	92.1997748905	gua4	hang/suspend, to hang/to put up/to suspend
+1231	奖	20690	92.2104671749	jiang3	prize/award/encouragement
+1232	绍	20681	92.2211548083	shao4	connect/to introduce
+1233	厚	20624	92.2318129849	hou4	generous/thick (for flat things)
+1234	纵	20599	92.2424582419	zong1/zong4	vertical, even if/release
+1235	障	20503	92.2530538875	zhang4	to block/to hinder/to obstruct
+1236	讯	20488	92.2636417813	xun4	to question/to ask/to interrogate/rapid/speedy/fast/news/information
+1237	涉	20482	92.2742265745	she4	involve/concern/wade/to experience
+1238	彻	20461	92.2848005151	che4	pervade/penetrate/pass through/thorough/penetrating
+1239	刊	20458	92.2953729054	kan1	to print/publish
+1240	丈	20372	92.3059008521	zhang4	ten feet
+1241	爆	20340	92.3164122618	bao4	to crack/to explode or burst
+1242	乌	20291	92.326898349	wu1	a crow/black
+1243	役	20254	92.3373653151	yi4	service
+1244	描	20247	92.3478286637	miao2	depict/to trace (a drawing)/to copy/to touch up
+1245	洗	20229	92.3582827102	xi3	to wash/to bathe
+1246	玛	20207	92.3687253874	ma3	agate/cornelian
+1247	患	20203	92.3791659975	huan4	misfortune/suffer (from illness)/trouble/danger/worry/to contract (a disease)
+1248	妙	20165	92.3895869697	miao4	clever/wonderful
+1249	镜	20100	92.3999743509	jing4	mirror
+1250	唱	20085	92.4103539803	chang4	sing/to call loudly/to chant
+1251	烦	20076	92.4207289587	fan2	feel vexed/to bother
+1252	签	20057	92.4310941182	qian1	sign one's name, a note/a stick/sign one's name
+1253	仙	20051	92.4414561769	xian1	immortal
+1254	彼	20021	92.4518027321	bi3	that/those/(one) another)
+1255	弗	19905	92.4620893402	fu2	not
+1256	症	19878	92.4723619951	zheng1/zheng4	obstruction of bowels, disease/illness
+1257	仿	19870	92.4826305157	fang3	to imitate/to copy, imitate, seemingly
+1258	倾	19849	92.4928881839	qing1	to overturn/to collapse/to lean/to tend/to incline/to pour out
+1259	牌	19752	92.5030957238	pai2	cards/game pieces/signboard/plate/tablet
+1260	陷	19703	92.5132779413	xian4	to fall/trap
+1261	鸟	19698	92.5234575749	niao3	bird
+1262	轰	19670	92.5336227385	hong1	explosion/bang/boom/rumble/strike (by thunder or a bomb)
+1263	咱	19554	92.543727955	za2/zan2	we (incl.), we (incl.)
+1264	菜	19516	92.5538135337	cai4	dish (type of food)/vegetables
+1265	闭	19515	92.5638985956	bi4	to close/stop up/shut/obstruct
+1266	奋	19499	92.573975389	fen4	exert oneself
+1267	庆	19487	92.5840459809	qing4	celebrate
+1268	撤	19485	92.5941155392	che4	remove/take away/withdraw
+1269	泪	19411	92.6041468555	lei4	tears
+1270	茶	19404	92.6141745542	cha2	tea/tea plant
+1271	疾	19402	92.6242012194	ji2	sickness/disease/hate/envy
+1272	缘	19330	92.6341906761	yuan2	along/predestined affinity/reason/edge
+1273	播	19327	92.6441785824	bo1	sow/scatter/spread/broadcast
+1274	朗	19288	92.6541463341	lang3	clear/bright
+1275	杜	19246	92.6640923808	du4	(surname)/fabricate/restrict/to prevent
+1276	奶	19219	92.6740244743	nai3	breast/lady/milk
+1277	季	19211	92.6839524335	ji4	season/period
+1278	丹	19171	92.6938597213	dan1	red/pellet/powder/cinnabar
+1279	狗	19093	92.7037266999	gou3	dog
+1280	尾	19076	92.7135848931	wei3	tail
+1281	仪	19064	92.7234368849	yi2	apparatus/rites/appearance/present/ceremony
+1282	偷	19006	92.7332589032	tou1	to steal/to pilfer
+1283	奔	18989	92.7430721361	ben1/ben4	to hurry or rush/to run quickly/to elope, go to/towards
+1284	珠	18916	92.7528476437	zhu1	bead/pearl
+1285	虫	18909	92.7626195338	chong2	insect/worm, an animal/an invertebrate/a worm/an insect
+1286	驻	18901	92.7723872897	zhu4	resident in/stationed in/located at/to station (troops)
+1287	孔	18890	92.7821493608	kong3	(surname)/hole
+1288	宜	18833	92.7918819753	yi2	proper/should/suitable/appropriate
+1289	艾	18825	92.8016104554	ai4	(surname)/Artemisia vulgaris/Chinese mugwort
+1290	桥	18815	92.8113337678	qiao2	bridge
+1291	淡	18779	92.8210384758	dan4	insipid/diluted/weak/light in color/tasteless/fresh/indifferent/nitrogen
+1292	翼	18710	92.8307075257	yi4	wing
+1293	恨	18702	92.8403724413	hen4	to hate
+1294	繁	18699	92.8500358065	fan2	complicated/many/in great numbers
+1295	寒	18684	92.8596914199	han2	cold/poor/to tremble
+1296	伴	18678	92.8693439327	ban4	a partner/companion or associate/to accompany/comrade
+1297	叹	18587	92.878949418	tan4	to sigh
+1298	旦	18569	92.8885456012	dan4	dawn/morning/day-break/day
+1299	愈	18540	92.8981267976	yu4	heal/the more...the more/to recover/better, heal
+1300	潮	18532	92.9077038597	chao2	tide/current/damp/moist/humid
+1301	粮	18528	92.9172788546	liang2	provisions
+1302	缩	18495	92.9268367957	suo1	to withdraw/to pull back/to contract/to shrink/to reduce
+1303	罢	18492	92.9363931864	ba4/ba	to stop/cease/dismiss/suspend/to quit/to finish, (final part.)
+1304	聚	18458	92.9459320064	ju4	form gathering/gather
+1305	径	18428	92.9554553229	jing4	path
+1306	恰	18420	92.9649745051	qia4	exactly/just
+1307	挑	18417	92.9744921369	tiao1/tiao3	carry on a pole/choose, incite
+1308	袋	18381	92.9839911645	dai4	a pouch/bag/sack/pocket
+1309	灰	18298	92.9934472989	hui1	gray/ash
+1310	捕	18236	93.0028713926	bu3	to catch/to seize/to capture/to catch
+1311	徐	18175	93.0122639624	xu2	slow/gentle/Xu (a surname)
+1312	珍	18144	93.0216405119	zhen1	precious thing/treasure
+1313	幕	18138	93.0310139607	mu4	stage curtain/tent
+1314	映	18102	93.0403688052	ying4	reflect/shine
+1315	裂	18093	93.0497189986	lie4	crack/split
+1316	泰	18069	93.0590567892	tai4	safe/peaceful/most/Thai(land)/grand
+1317	隔	18056	93.0683878616	ge2	to separate/to stand or lie between/to divide/to cut off
+1318	启	18041	93.0777111822	qi3	to open/to start
+1319	尖	18036	93.0870319189	jian1	point (of needle)/sharp/shrewd/pointed
+1320	忠	18021	93.0963449038	zhong1	loyal
+1321	累	18017	93.1056558216	lei2/lei3/lei4	cumbersome, accumulate, implicate/tired
+1322	炎	17971	93.1149429672	yan2	flame/inflammation/-itis
+1323	暂	17968	93.1242285625	zan4	temporarily
+1324	估	17943	93.1335012382	gu1/gu4	estimate, old/second-hand (clothes)
+1325	泛	17928	93.1427661621	fan4	broad/vast/float/pan-, float/general/vague
+1326	荒	17924	93.1520290188	huang1	out of practice/uncultivated
+1327	偿	17919	93.1612892917	chang2	to compensate/pay back/to recompense
+1328	横	17912	93.170545947	heng2/heng4	horizontal/across/(horizontal character stroke), unruly
+1329	拒	17892	93.1797922666	ju4	to resist/to repel/to refuse
+1330	瑞	17869	93.1890267002	rui4	lucky/auspicious/propitious/rayl (acoustical unit)
+1331	忆	17829	93.1982404624	yi4	remember
+1332	孤	17817	93.2074480231	gu1	lone/lonely
+1333	鼻	17773	93.2166328453	bi2	nose
+1334	闹	17764	93.2258130165	nao4	make noise or disturbance
+1335	羊	17763	93.2349926708	yang2	(surname)/sheep
+1336	呆	17746	93.2441635398	dai1	foolish/stupid/no expression/stay, stay/stupid
+1337	厉	17726	93.2533240731	li4	severe
+1338	衡	17719	93.2624809889	heng2	to weigh/weight/measure
+1339	胞	17702	93.2716291193	bao1	the placenta/womb
+1340	零	17675	93.2807632966	ling2	remnant/zero
+1341	穷	17672	93.2898959235	qiong2	exhausted/poor
+1342	舍	17647	93.2990156308	she3/she4	give up/abandon, residence
+1343	码	17626	93.3081244856	ma3	a weight/number/yard/pile/stack
+1344	赫	17613	93.3172266221	he4	(surname)/awe-inspiring
+1345	婆	17603	93.3263235909	po2	grandmother/matron/mother-in-law
+1346	魂	17535	93.3353854182	hun2	soul
+1347	灾	17531	93.3444451784	zai1	disaster/calamity
+1348	洪	17526	93.3535023547	hong2	flood
+1349	腿	17509	93.3625507456	tui3	leg
+1350	胆	17486	93.3715872505	dan3	the gall/the nerve/courage/guts/gall bladder
+1351	津	17470	93.3806154868	jin1	Tianjin/ferry
+1352	俗	17463	93.3896401056	su2	vulgar
+1353	辩	17459	93.3986626572	bian4	dispute/debate/argue/discuss
+1354	胸	17392	93.4076505843	xiong1	chest/bosom/heart/mind/thorax
+1355	晓	17316	93.4165992357	xiao3	dawn/to know/to tell (sb sth)/dawn
+1356	劲	17307	93.425543236	jin4/jing4	strength, stalwart/sturdy
+1357	贫	17263	93.4344644978	pin2	poor
+1358	仁	17263	93.4433857596	ren2	humane
+1359	偶	17246	93.452298236	ou3	accidental/image/pair/mate
+1360	辑	17169	93.46117092	ji2	gather up/collect/edit/compile
+1361	邦	17153	93.4700353354	bang1	a state/country or nation
+1362	恢	17123	93.4788842473	hui1	to restore/to recover/great
+1363	赖	17123	93.4877331591	lai4	disclaim/rely/to blame
+1364	圈	17115	93.4965779367	juan1/juan4/quan1	to confine/enclose, pen (pig)/a fold, circle/ring/loop
+1365	摸	17067	93.5053979086	mo1/mo2	feel with the hand/to touch/to stroke/to grope/to feel (one's pulse), imitate/copy
+1366	仰	16940	93.5141522488	yang3	look up
+1367	润	16922	93.5228972868	run4	smooth/moist
+1368	堆	16920	93.5316412913	dui1	a pile/a mass/heap/stack
+1369	碰	16919	93.540384779	peng4	to touch/to meet with/to bump
+1370	艇	16868	93.5491019106	ting3	small boat
+1371	稍	16855	93.5578123241	shao1	somewhat/a little
+1372	迟	16808	93.5664984486	chi2	late/delayed/slow
+1373	辆	16767	93.575163385	liang4	(a measure word for vehicles)
+1374	废	16754	93.5838216031	fei4	abolish/crippled
+1375	净	16751	93.5924782709	jing4	clean, clean/completely/only
+1376	凶	16707	93.6011122002	xiong1	fierce, fierce/terrible/ominous
+1377	署	16641	93.6097120216	shu3	office/bureau
+1378	壁	16588	93.6182844534	bi4	wall/rampart
+1379	御	16586	93.6268558516	yu4	defend/imperial/to drive, defend/resist
+1380	奉	16453	93.6353585175	feng4	to receive (from superior)/to offer/to revere
+1381	旋	16441	93.6438549819	xuan2/xuan4	revolve, lathe/specially for an occasion
+1382	冬	16368	93.6523137209	dong1	winter
+1383	矿	16360	93.6607683258	kuang4	ore/mine
+1384	抬	16315	93.6691996752	tai2	to lift/to raise/(of two or more persons) to carry
+1385	蛋	16305	93.6776258568	dan4	egg/oval shaped
+1386	晨	16235	93.6860158635	chen2	morning/dawn/daybreak
+1387	伏	16181	93.6943779638	fu2	conceal (ambush)/prostrate/submit
+1388	吹	16180	93.7027395472	chui1	to blow/blast/puff/boast/brag/end in failure
+1389	鸡	16164	93.7110928622	ji1	fowl/chicken
+1390	倍	16102	93.7194141364	bei4	(two, three, etc) -fold/times (multiplier)/double/to increase or multiply
+1391	糊	16098	93.7277333435	hu2/hu4	muddled/paste/scorched, paste/cream
+1392	秦	16088	93.7360473827	qin2	(surname)/name of a dynasty
+1393	盾	16080	93.7443572877	dun4	shield
+1394	杯	16068	93.7526609913	bei1	cup/a measure word
+1395	租	16052	93.7609564262	zu1	rent/taxes
+1396	骑	16037	93.7692441094	qi2	to ride (an animal or bike)/to sit astride
+1397	乏	16010	93.7775178394	fa2	short of/tired
+1398	隆	15979	93.7857755491	long1/long2	sound of drums, grand/intense/prosperous/start (a fire)
+1399	诊	15931	93.7940084531	zhen3	examine or treat medically
+1400	奴	15917	93.8022341221	nu2	slave
+1401	摄	15801	93.810399844	she4	assist/collect/absorb
+1402	丧	15731	93.818529391	sang1/sang4	mourning/funeral, lose (by death)
+1403	污	15696	93.8266408504	wu1	see 污, dirt/filth
+1404	渡	15692	93.8347502428	du4	to cross/to pass through/to ferry
+1405	旗	15665	93.8428456819	qi2	banner/flag
+1406	甘	15654	93.8509354364	gan1	(surname)/sweet
+1407	耐	15629	93.8590122713	nai4	to be unbearable/unable to endure
+1408	凭	15619	93.8670839383	ping2	lean against/proof/to rely on/to depend on/to be based on
+1409	扎	15600	93.8751457864	za1/zha1/zha2	to tie/to bind, tie with string or ribbon/bind with rope or cord/to stop, to prick/to run or stick (a needle, etc.) into, penetrating (as of cold)/struggle
+1410	抢	15596	93.8832055673	qiang1/qiang3	against wind, fight over/to rush/to scramble/to grab/to rob/to snatch
+1411	绪	15571	93.8912524287	xu4	beginnings/clues/mental state/thread
+1412	粗	15557	93.899292055	cu1	coarse/rough/thick/unfinished/vulgar/rude/crude
+1413	肩	15528	93.9073166946	jian1	shoulder
+1414	梁	15387	93.9152684674	liang2	(surname)/beam of roof/bridge, beam of roof
+1415	幻	15371	93.9232119718	huan4	fantasy
+1416	菲	15365	93.9311523753	fei1	rich/luxurious/phenanthrene (chemical)/Philippines
+1417	皆	15357	93.9390886447	jie1	all/each and every/in all cases
+1418	碎	15334	93.9470130279	sui4	to break down/to break into pieces/fragmentary
+1419	宙	15331	93.9549358608	zhou4	universe
+1420	叔	15310	93.9628478412	shu1	uncle in direct address
+1421	岩	15279	93.9707438013	yan2	cliff/rock, cliff
+1422	荡	15268	93.9786340767	dang4	a pond/pool/wash/squander/sweep away/move/shake/dissolute
+1423	综	15258	93.9865191843	zong1	to sum up
+1424	爬	15255	93.9944027415	pa2	crawl/climb
+1425	荷	15249	94.0022831981	he2/he4	lotus, peppermint/to carry burden
+1426	悉	15234	94.0101559028	xi1	in all cases/know
+1427	蒂	15183	94.0180022515	di4	stem (of fruit)
+1428	返	15179	94.0258465331	fan3	to return (to)
+1429	井	15158	94.0336799621	jing3	warn/well
+1430	壮	15151	94.0415097737	zhuang4	to strengthen/strong/robust
+1431	薄	15150	94.0493390685	bo2/bo4/bao2	mean/slight/thin, thin/slight/meagre/small/ungenerous/unkind/mean/frivolous/despise/belittle/to approach/to go near/peppermint
+1432	悄	15141	94.0571637122	qiao3/qiao1	quiet/sad
+1433	扫	15140	94.0649878392	sao3/sao4	to sweep, broom
+1434	敏	15135	94.0728093822	min3	keen
+1435	碍	15121	94.0806236902	ai4	to hinder/to obstruct/to block
+1436	殖	15118	94.0884364479	zhi2	grow/reproduce
+1437	详	15099	94.0962393866	xiang2	detailed/comprehensive
+1438	迪	15073	94.104028889	di2	direct/follow
+1439	矛	15059	94.1118111563	mao2	spear/lance/pike
+1440	霍	15034	94.119580504	huo4	(surname)/cholera
+1441	允	15027	94.1273462342	yun3	just/fair/to permit/to allow
+1442	幅	15021	94.1351088637	fu2	(measure word for textile or picture)/width/roll
+1443	撒	15003	94.1428621911	sa1/sa3	let go, to scatter
+1444	剩	14996	94.150611901	sheng4	have as remainder
+1445	凯	14990	94.1583585102	kai3	triumphant/victorious
+1446	颗	14987	94.166103569	ke1	(measure word for small spheres)
+1447	骂	14976	94.1738429431	ma4	scold/abuse
+1448	赏	14946	94.1815668138	shang3	enjoy the beauty of/give
+1449	液	14940	94.1892875837	ye4	liquid/fluid
+1450	番	14927	94.1970016354	fan1/pan1	(measure word for acts)/deeds/foreign, (surname)/place name
+1451	箱	14913	94.2047084521	xiang1	box/trunk/chest
+1452	贴	14888	94.2124023492	tie1	to stick/to paste/to keep close to/to fit snugly/subsidize/allowance
+1453	漫	14869	94.2200864274	man4	free/unrestrained/inundate
+1454	酸	14855	94.2277632705	suan1	sour/sore/ache/acid
+1455	郎	14845	94.2354349459	lang2	(surname)/a youth
+1456	腰	14841	94.243104554	yao1	waist
+1457	舒	14833	94.2507700279	shu1	(surname)/relax
+1458	眉	14763	94.2583993269	mei2	eyebrow/upper margin
+1459	忧	14753	94.266023458	you1	worried
+1460	浮	14717	94.2736289848	fu2	to float
+1461	辛	14713	94.2812324445	xin1	8th heavenly stem/tired
+1462	恋	14674	94.2888157496	lian4	feel attached to/long for/love
+1463	餐	14641	94.2963820007	can1	eat/meal
+1464	吓	14620	94.3039373994	xia4	to frighten/to scare/to intimidate/to threaten
+1465	挺	14615	94.3114902141	ting3	be straight and stiff/rather (good)
+1466	励	14512	94.3189898	li4	exhort
+1467	辞	14439	94.3264516606	ci2	bid farewell/diction/resign/say goodbye/take leave/decline
+1468	艘	14438	94.3339130043	sao1/sou1	measure word for warships (Taiwan pronunciation), measure word for boats and ships (mainland pronunciation)
+1469	键	14434	94.341372281	jian4	(door lock) key
+1470	伍	14425	94.3488269065	wu3	associate with/five/company
+1471	峰	14424	94.3562810153	feng1	peak/summit
+1472	尺	14422	94.3637340905	chi3	a Chinese foot (M)/one-third of a meter/a ruler/a note musical note on traditional Chinese scale
+1473	昨	14406	94.3711788972	zuo2	yesterday
+1474	黎	14389	94.3786149185	li2	(surname)/black/abbreviation for Lebanon
+1475	辈	14384	94.3860483559	bei4	contemporaries/generation/lifetime
+1476	贯	14361	94.3934699072	guan4	pierce/to string
+1477	侦	14329	94.4008749214	zhen1	to scout/to spy
+1478	滑	14303	94.4082664991	gu3/hua2	comical, comical/cunning/slippery/smooth
+1479	券	14293	94.4156529091	quan4	deed/bond/contract/ticket
+1480	崇	14262	94.4230232987	chong2	high/dignified/lofty/to honor
+1481	扰	14252	94.4303885204	rao3	disturb
+1482	宪	14251	94.4377532254	xian4	statute/constitution
+1483	绕	14172	94.4450771043	rao4	go around/to wind (around)
+1484	趋	14160	94.4523947818	qu1	to hasten/to hurry/walk fast
+1485	慈	14141	94.4597026404	ci2	compassionate/gentle/merciful/kind/humane
+1486	乔	14107	94.4669929283	qiao2	tall
+1487	阅	14067	94.4742625448	yue4	peruse/review/to read
+1488	汗	14011	94.4815032213	han4	perspiration/sweat
+1489	枝	13982	94.488728911	zhi1	branch/(a measure word)
+1490	拖	13973	94.4959499497	tuo1	dragging (brush stroke in painting)/to drag along
+1491	墨	13959	94.5031637534	mo4	China ink/ink stick
+1492	胁	13948	94.5103718725	xie2	side of body/threaten
+1493	插	13938	94.5175748237	cha1	insert/stick in/pierce/to take part in/to interfere/to interpose
+1494	箭	13922	94.5247695063	jian4	arrow
+1495	腊	13892	94.5319486854	la4	preserved (meat), December/preserved (meat)
+1496	粉	13874	94.5391185624	fen3	dust/powder
+1497	泥	13874	94.5462884393	ni2/ni4	mud/paste/pulp, restrained
+1498	氏	13868	94.5534552156	shi4	clan name/maiden name
+1499	彭	13866	94.5606209583	peng2	(surname)
+1500	拔	13865	94.5677861842	ba2	pull up/pull out/select/promote
+1501	骗	13854	94.5749457254	pian4	to cheat/to swindle/to deceive/to fool
+1502	凤	13817	94.5820861456	feng4	phoenix
+1503	慧	13810	94.5892229483	hui4	intelligent
+1504	媒	13802	94.5963556168	mei2	medium/intermediary/matchmaker/go-between
+1505	佩	13784	94.6034789831	pei4	to respect/wear (belt, etc.), girdle ornaments
+1506	愤	13749	94.6105842619	fen4	indignant/anger/resentment
+1507	扑	13748	94.6176890239	pu1	to rush at/to throw oneself on, rush on
+1508	龄	13733	94.6247860342	ling2	age
+1509	驱	13692	94.6318618562	qu1	to expel/to urge on/to drive/to run quickly
+1510	惜	13687	94.6389350944	xi1	pity, regret, rue, begrudge
+1511	豪	13680	94.646004715	hao2	grand/heroic
+1512	掩	13680	94.6530743356	yan3	cover up/to surprise
+1513	兼	13656	94.6601315534	jian1	double/twice/simultaneous/holding two or more (official) posts at the same time
+1514	跃	13645	94.6671830866	yue4	to jump/to leap
+1515	尸	13609	94.6742160155	shi1	corpse
+1516	肃	13581	94.6812344744	su4	Gansu/respectful
+1517	帕	13566	94.6882451816	pa4	handkerchief
+1518	驶	13537	94.6952409019	shi3	hasten/proceed to/sail a vessel
+1519	堡	13533	94.7022345552	bao3/pu4	an earthwork/castle/position of defense/stronghold, character used in place names
+1520	届	13521	94.709222007	jie4	arrive at (place or time)/period/to become due/measure words for events (e.g., meetings, elections)
+1521	欣	13500	94.7161986063	xin1	happy
+1522	惠	13492	94.7231710713	hui4	favor/kind act (from above)
+1523	册	13462	94.7301280328	ce4	book/a measure word for books/booklet
+1524	储	13408	94.7370570879	chu3	savings/to save/to deposit/to store/(a surname)
+1525	飘	13357	94.7439597869	piao1	to float
+1526	桑	13328	94.7508474992	sang1	mulberry tree
+1527	闲	13316	94.7577290101	xian2	to stay idle/to be unoccupied/not busy/leisure/enclosure
+1528	惨	13314	94.7646094873	can3	miserable/wretched/cruel/inhuman/seriously/badly/tragic
+1529	洁	13261	94.771462575	jie2	clean
+1530	踪	13193	94.7782805213	zong1	footprint/trace/tracks
+1531	勃	13183	94.7850932997	bo2	flourishing/prosperous/suddenly/abruptly
+1532	宾	13149	94.7918885075	bin1	visitor/guest
+1533	频	13127	94.7986723459	pin2	frequency/frequently/repetitious
+1534	仇	13118	94.8054515333	chou2/qiu2	hatred/animosity/enmity/a rival/an enemy/feud, (surname)/match/mate
+1535	磨	13082	94.8122121164	mo2/mo4	to sharpen/to delay/hardship/to grind/to rub, grindstone
+1536	递	13012	94.8189365246	di4	to hand over/to pass/to give
+1537	邪	12952	94.8256299257	xie2	demonical/iniquitous/nefarious
+1538	撞	12894	94.8322933532	zhuang4	to hit/to strike/to meet by accident/to run into/to bump against/to bump into
+1539	拟	12885	94.8389521297	ni3	plan to
+1540	滚	12863	94.8455995369	gun3	to boil/to roll
+1541	奏	12859	94.8522448769	zou4	present a memorial
+1542	巡	12852	94.8588865995	xun2	to patrol/to make one's rounds
+1543	颜	12837	94.8655205702	yan2	(surname)/color/countenance
+1544	剂	12821	94.8721462724	ji4	dose
+1545	绩	12789	94.8787554375	ji1/ji4	merit/accomplishment
+1546	贡	12785	94.8853625355	gong4	tribute/gifts
+1547	疯	12771	94.8919623984	feng1	insane/mad/wild
+1548	坡	12758	94.8985555432	po1	slope
+1549	瞧	12745	94.9051419697	qiao2	look at
+1550	截	12718	94.9117144431	jie2	a section/cut off (a length)
+1551	燃	12708	94.9182817485	ran2	burn/combustion
+1552	焦	12684	94.9248366512	jiao1	burnt/scorched/worried/anxious
+1553	殿	12667	94.9313827685	dian4	palace hall
+1554	伪	12654	94.9379221676	wei3	false/fake/forged/bogus
+1555	柳	12642	94.9444553653	liu3	willow/Liu (a surname)
+1556	锁	12638	94.9509864958	suo3	to lock up/to lock
+1557	逼	12623	94.9575098745	bi1	close to/compel, force/compel/drive/press for/extort/press on towards/press up to/close in on/close
+1558	颇	12605	94.9640239512	po1	quite/rather/uneven/sloping
+1559	昏	12600	94.9705354439	hun1	muddle-headed/twilight/to faint/to lose consciousness
+1560	劝	12587	94.9770402184	quan4	to advise/to urge/to try to persuade/exhort
+1561	呈	12567	94.9835346571	cheng2	to assume (a form)/to submit/to petition/to show/to present/to offer
+1562	搜	12537	94.9900135924	sou1	to search
+1563	勤	12536	94.9964920108	qin2	diligent/frequent
+1564	戒	12510	95.0029569929	jie4	swear off/warn against
+1565	驾	12492	95.0094126728	jia4	to drive/to draw/to harness/to mount
+1566	漂	12488	95.0158662855	piao1/piao3/piao4	to float/to drift, to bleach, elegant/polished
+1567	饮	12453	95.0223018108	yin3	drink
+1568	曹	12443	95.0287321682	cao2	a company/a class/a generation/(a surname)
+1569	朵	12435	95.0351583914	duo3	M for flowers
+1570	仔	12428	95.041580997	zi1/zi3/zai3	duty/responsibility, minutely/young
+1571	柔	12389	95.0479834481	rou2	soft
+1572	俩	12340	95.0543605766	lia3/liang3	(a numeral-measure word) two/both, craft/cunning
+1573	孟	12274	95.0607035974	meng4	first month/eldest brother/(surname)
+1574	腐	12264	95.0670414503	fu3	decay/rotten
+1575	幼	12257	95.0733756857	you4	young
+1576	践	12242	95.0797021693	jian4	fulfill (a promise)/tread/walk
+1577	籍	12205	95.0860095319	ji2	(surname)/record/register/native place
+1578	牧	12193	95.092310693	mu4	shepherd
+1579	凉	12156	95.0985927331	liang2	cool/cold
+1580	牲	12107	95.1048494507	sheng1	domestic animal
+1581	佳	12061	95.1110823962	jia1	excellent
+1582	娜	12060	95.117314825	nuo2/na4	elegant/graceful
+1583	浓	12016	95.1235245151	nong2	concentrated/dense
+1584	芳	12015	95.1297336885	fang1	fragrant
+1585	稿	12012	95.1359413116	gao3	manuscript/draft/stalk of grain
+1586	竹	12000	95.1421427332	zhu2	bamboo
+1587	腹	11974	95.1483307184	fu4	abdomen/stomach/belly
+1588	跌	11967	95.1545150861	die1	to drop/to fall/to tumble
+1589	逻	11959	95.1606953195	luo2	logic/patrol
+1590	垂	11949	95.1668703851	chui2	to hang (down)/droop/dangle/bend down/hand down/bequeath/nearly/almost/to approach
+1591	遵	11935	95.1730382157	zun1	to observe/to obey/to follow
+1592	脉	11932	95.1792044959	mai4	mountain range/pulse
+1593	貌	11921	95.1853650915	mao4	appearance
+1594	柏	11902	95.1915158682	bai3/bo4	(surname)/cedar/cypress, cypress/cedar
+1595	狱	11886	95.1976583763	yu4	prison
+1596	猜	11875	95.2037951997	cai1	to guess
+1597	怜	11848	95.20991807	lian2	to pity
+1598	惑	11829	95.2160311214	huo4	confuse
+1599	陶	11821	95.2221400385	tao2	pottery, (surname)/pleased/pottery
+1600	兽	11820	95.2282484387	shou4	beast/quadruped
+1601	帐	11798	95.2343454698	zhang4	account/mosquito net/tent/curtain/debt/credit
+1602	饰	11794	95.2404404336	shi4	adorn/ornaments
+1603	贷	11793	95.2465348807	dai4	lend on interest/borrow/loan/make excuses/pardon/forgive
+1604	昌	11787	95.2526262271	chang1	prosperous/flourish
+1605	叙	11786	95.2587170567	xu4	narrate/abbreviation for Syria
+1606	躺	11745	95.2647866981	tang3	to recline/to lie down
+1607	钢	11738	95.270852722	gang1	steel
+1608	沟	11735	95.2769171956	gou1	ditch/gutter
+1609	寄	11729	95.2829785684	ji4	lodge at/to mail/to send/to entrust/to depend
+1610	扶	11659	95.2890037663	fu2	to support with hand/to help sb. up/to help
+1611	铺	11654	95.2950263803	pu1/pu4	to spread, a store, a bed/a store
+1612	邓	11651	95.3010474439	deng4	Deng (Xiaoping)
+1613	寿	11646	95.3070659236	shou4	(long) life
+1614	惧	11644	95.3130833697	ju4	to fear
+1615	询	11643	95.319100299	xun2	inquire
+1616	汤	11620	95.3251053423	tang1	(surname)/soup
+1617	盗	11595	95.3310974659	dao4	steal/rob/plunder/a thief/bandit/robber
+1618	肥	11594	95.3370890727	fei2	loose-fitting/fat/fertile
+1619	尝	11557	95.3430615585	chang2	indicator of past tense/to taste/flavor/already/ever/once/test/already/formerly, to taste
+1620	匆	11540	95.349025259	cong1	hurried/hasty
+1621	辉	11518	95.3549775902	hui1	bright/glorious
+1622	奈	11509	95.3609252703	nai4	how can one help
+1623	扣	11505	95.3668708833	kou4	10 percent/button/detain, button
+1624	廷	11499	95.3728133955	ting2	palace courtyard
+1625	澳	11475	95.378743505	ao4	Australia/deep bay/cove/bay/harbor/(abbrev) Macao
+1626	嘛	11474	95.3846730976	ma	(a modal particle)
+1627	董	11450	95.3905902874	dong3	(surname)/supervise/to direct/director
+1628	迁	11433	95.3964986918	qian1	to move/to shift
+1629	凝	11409	95.4023946934	ning2	congeal/concentrate attention
+1630	慰	11379	95.4082751915	wei4	reassure
+1631	厌	11376	95.4141541392	yan4	loathe
+1632	脏	11350	95.4200196504	zang1/zang4	dirty/filthy, viscera
+1633	腾	11343	95.4258815442	teng2	to soar/to gallop/to rise/to prance/to hover/to move out
+1634	幽	11319	95.4317310352	you1	quiet/secluded
+1635	怨	11305	95.4375732911	yuan4	blame/complain
+1636	鞋	11288	95.4434067617	xie2	shoe
+1637	丢	11285	95.449238682	diu1	to lose/to put aside/to throw
+1638	埋	11246	95.4550504476	mai2/man2	bury, to blame
+1639	泉	11237	95.4608575621	quan2	fountain/spring
+1640	涌	11228	95.4666600256	yong3	bubble up/rush forth
+1641	辖	11213	95.4724547373	xia2	have jurisdiction over
+1642	躲	11201	95.4782432476	duo3	avoid/get out of way/to hide/to go into hiding
+1643	晋	11192	95.4840271069	jin4	name of a dynasty
+1644	紫	11172	95.4898006304	zi3	purple
+1645	艰	11164	95.4955700196	jian1	difficult/hard/hardship
+1646	魏	11161	95.5013378585	wei4	(surname)/name of a dynasty
+1647	吾	11154	95.5071020799	wu2	I/my
+1648	慌	11149	95.5128637174	huang1	nervous
+1649	祝	11144	95.5186227709	zhu4	invoke/pray to/wish/to express good wishes
+1650	邮	11137	95.524378207	you2	post (office)/mail
+1651	吐	11132	95.5301310591	tu3/tu4	to spit, vomit
+1652	狠	11116	95.5358756426	hen3	fierce/very
+1653	鉴	11090	95.5416067898	jian4	example/mirror/to view/reflection/to reflect/to inspect/to warn/(ancient bronze mirror)
+1654	曰	11075	95.5473301852	yue1	to speak/to say
+1655	械	11060	95.5530458287	xie4	tools
+1656	咬	11029	95.558745452	yao3	bite/nip
+1657	邻	10996	95.5644280213	lin2	neighbor/adjacent/close to
+1658	赤	10981	95.5701028389	chi4	red/scarlet/bare/naked
+1659	挤	10920	95.5757461326	ji3	crowded/to squeeze
+1660	弯	10917	95.5813878759	wan1	bend/bent
+1661	椅	10917	95.5870296192	yi3	chair
+1662	陪	10908	95.5926667114	pei2	to accompany/to keep sb. company
+1663	割	10894	95.5982965687	ge1	cut off
+1664	揭	10892	95.6039253924	jie1	lift off (a cover)/divulge
+1665	韦	10882	95.6095490482	wei2	(surname)/soft leather
+1666	悟	10876	95.6151696034	wu4	comprehend
+1667	聪	10863	95.6207834403	cong1	quick at hearing/wise/clever/sharp-witted/intelligent/acute
+1668	雾	10856	95.6263936597	wu4	fog/mist
+1669	锋	10783	95.6319661538	feng1	point or edge of a tool
+1670	梯	10738	95.6375153926	ti1	ladder
+1671	猫	10724	95.6430573964	mao1	cat/pussy
+1672	祥	10724	95.6485994001	xiang2	auspicious/propitious
+1673	阔	10722	95.6541403704	kuo4	rich/wide/broad
+1674	誉	10683	95.659661186	yu4	reputation
+1675	筹	10671	95.6651758001	chou2	a tally/counter/ticket/plan/devise/manage
+1676	丛	10665	95.6706873136	cong2	cluster/collection/collection of books/thicket
+1677	牵	10641	95.6761864242	qian1	lead along
+1678	鸣	10636	95.6816829509	ming2	to cry (of birds)
+1679	沈	10628	95.6871753433	chen2/shen3	sink, (surname)/place name
+1680	阁	10595	95.6926506818	ge2	council-chamber/shelf
+1681	穆	10592	95.69812447	mu4	(surname)/solemn
+1682	屈	10591	95.7035977413	qu1	bent/feel wronged
+1683	旨	10590	95.7090704959	zhi3	imperial decree/purport/aim/purpose
+1684	袖	10564	95.7145298141	xiu4	sleeve
+1685	猎	10561	95.7199875819	lie4	hunting
+1686	臂	10542	95.7254355307	bi4	arm
+1687	蛇	10538	95.7308814125	she2	snake/serpent
+1688	贺	10507	95.7363112739	he4	congratulate
+1689	柱	10504	95.741739585	zhu4	pillar
+1690	抛	10477	95.7471539428	pao1	to throw/to toss/to fling/to cast/to abandon
+1691	鼠	10476	95.7525677839	shu3	rat/mouse
+1692	瑟	10473	95.7579800746	se4	(mus. instr.)
+1693	戈	10456	95.76338358	ge1	(surname)/spear
+1694	牢	10454	95.7687860518	lao2	firm/fast
+1695	逊	10444	95.7741833557	xun4	to yield
+1696	迈	10432	95.7795744582	mai4	take a step
+1697	欺	10418	95.7849583258	qi1	take unfair advantage of/to deceive/to cheat
+1698	吨	10403	95.7903344415	dun1/dun4	ton, ton
+1699	琴	10383	95.7957002216	qin2	(mus. instr.)
+1700	衰	10367	95.8010577331	cui1/shuai1	mourning garments, weak/feeble/decline/wane
+1701	瓶	10361	95.8064121439	ping2	bottle/(a measure word)/vase/pitcher
+1702	恼	10356	95.8117639707	nao3	get mad
+1703	燕	10325	95.8170997772	yan1/yan4	(surname)/place name, swallow (a type of bird)
+1704	仲	10316	95.8224309327	zhong4	2nd in seniority
+1705	诱	10307	95.8277574371	you4	entice/tempt
+1706	狼	10295	95.83307774	lang2	wolf
+1707	池	10289	95.8383949423	chi2	pond/reservoir
+1708	疼	10279	95.8437069767	teng2	(it) hurts/love fondly/ache/pain/sore
+1709	卢	10266	95.8490122929	lu2	(surname)
+1710	仗	10263	95.8543160587	zhang4	battle
+1711	冠	10217	95.8595960524	guan1/guan4	hat/crown/crest/cap, to head
+1712	粒	10200	95.8648672608	li4	a grain/a granule
+1713	遥	10179	95.8701276167	yao2	distant/remote/far/far away
+1714	吕	10156	95.8753760865	lu:3/lv3	(surname)
+1715	玄	10151	95.8806219724	xuan2	black/mysterious
+1716	尘	10137	95.8858606233	chen2	dust/dirt/earth
+1717	冯	10128	95.8910946232	feng2	
+1718	抚	10100	95.896314153	fu3	to comfort/touch gently with hand
+1719	浅	10088	95.9015274815	jian1/qian3	sound of moving water, shallow
+1720	敦	10084	95.9067387428	dun1	kind-hearted, kind-hearted/place name
+1721	纠	10064	95.9119396684	jiu1	gather together/to investigate/to entangle/correct
+1722	钻	10064	95.9171405939	zuan1/zuan4	enter (a hole)/probe, an auger/diamond
+1723	晶	10038	95.9223280831	jing1	crystal
+1724	岂	10036	95.9275145387	qi3	how can it be that
+1725	峡	10028	95.9326968601	xia2	gorge
+1726	苍	10027	95.9378786646	cang1	dark blue/fly/musca/deep green
+1727	喷	10027	95.9430604692	pen1/pen4	to puff/to spout/to spray/to spurt, fragrant/sneeze
+1728	耗	9999	95.9482278037	hao4	mouse/new/to waste/to spend/to consume/to squander
+1729	凌	9999	95.9533951383	ling2	encroach/soar/thick ice
+1730	敲	9978	95.9585516204	qiao1	extort/knock/to strike/to knock (at a door)/to hit
+1731	菌	9971	95.9637044849	jun1/jun4	germ/bacteria, bacteria/mold/mushroom
+1732	赔	9960	95.9688516649	pei2	lose in trade/pay damage
+1733	涂	9949	95.9739931602	tu2	to smear/daub, (surname)/to smear/daub/to apply (paint)/to spread
+1734	粹	9943	95.9791315548	cui4	pure/unmixed/essence
+1735	扁	9917	95.984256513	bian3/pian1	flat/tablet/inscription, (surname)/small boat, Polygonum aviculare
+1736	亏	9884	95.9893644172	kui1	deficiency/deficit
+1737	寂	9875	95.9944676704	ji4	lonesome
+1738	煤	9832	95.9995487019	mei2	coal
+1739	熊	9788	96.0046069948	xiong2	bear/to scold/to rebuke
+1740	恭	9787	96.0096647709	gong1	respectful
+1741	湿	9783	96.0147204799	shi1	moist/wet
+1742	循	9768	96.0197684371	xun2	to follow/to adhere to/to abide by
+1743	暖	9762	96.0248132935	nuan3	warm
+1744	糖	9757	96.0298555661	tang2	sugar/sweets/candy
+1745	赋	9723	96.034880268	fu4	poetic essay/taxation/bestow on/endow with
+1746	抑	9719	96.0399029027	yi4	to restrain/to restrict/to keep down/or
+1747	秩	9713	96.0449224367	zhi4	order/orderliness
+1748	帽	9697	96.0499337022	mao4	hat/cap
+1749	哀	9693	96.0549429005	ai1	sorrow/grief/pity/to grieve for/to pity/to lament
+1750	宿	9693	96.0599520988	su4/xiu3/xiu4	lodge for the night/old/former, (a) night, constellation
+1751	踏	9656	96.064942176	ta4	step on
+1752	烂	9635	96.0699214008	lan4	overcooked/rotten/soft
+1753	袁	9609	96.0748871892	yuan2	(surname)
+1754	侯	9585	96.0798405747	hou2	marquis
+1755	抖	9584	96.0847934434	dou3	shake out/tremble
+1756	夹	9574	96.0897411443	jia1/jia2	clip/folder/hold between/to press from both sides/to place in between, hold between/lined/narrow lane
+1757	昆	9557	96.0946800598	kun1	Kunlun mountains, descendant/elder brother
+1758	肝	9551	96.0996158746	gan1	liver
+1759	擦	9542	96.1045470384	ca1	to wipe/to erase/rubbing (brush stroke in painting)/to clean/to polish
+1760	猪	9535	96.1094745847	zhu1	hog/pig/swine
+1761	炼	9528	96.1143985134	lian4	refine/smelt, refine
+1762	恒	9483	96.1192991869	heng2	permanent
+1763	慎	9479	96.1241977931	shen4	cautious
+1764	搬	9478	96.1290958826	ban1	remove/transport/move/shift
+1765	纽	9466	96.1339877707	niu3	to turn/to wrench/button
+1766	纹	9463	96.1388781085	wen2	line/trace/mark
+1767	玻	9447	96.1437601776	bo1	glass
+1768	渔	9441	96.1486391461	yu2	fisherman/to fish
+1769	磁	9433	96.1535139803	ci2	magnetic/magnetism/porcelain
+1770	铜	9416	96.1583800291	tong2	copper
+1771	齿	9415	96.1632455611	chi3	tooth
+1772	跨	9404	96.1681054085	kua4	step across/step astride
+1773	押	9401	96.1729637056	ya1	detain in custody
+1774	怖	9400	96.1778214859	bu4	terror/terrified/afraid/frightened
+1775	漠	9366	96.1826616954	mo4	desert/unconcerned
+1776	疲	9364	96.1875008714	pi2	weary
+1777	叛	9361	96.1923384971	pan4	to betray/to rebel/to revolt
+1778	遣	9335	96.1971626863	qian3	dispatch
+1779	兹	9319	96.201978607	zi1	herewith
+1780	祭	9316	96.2067929773	ji4/zhai4	offer sacrifice, (surname)
+1781	醉	9292	96.2115949448	zui4	intoxicated
+1782	拳	9290	96.2163958787	quan2	fist
+1783	弥	9276	96.2211895776	mi2	full/to fill, overflowing
+1784	斜	9264	96.2259770751	xie2	slanting
+1785	档	9248	96.230756304	dang4	cross-piece/official records/grade (of goods)/file/records/shelves
+1786	稀	9234	96.2355282979	xi1	diluted/sparse
+1787	捷	9225	96.2402956408	jie2	victory/triumph/quick/prompt/rapid
+1788	肤	9214	96.245057299	fu1	skin
+1789	疫	9202	96.2498127558	yi4	epidemic/plague
+1790	肿	9202	96.2545682126	zhong3	swollen
+1791	豆	9179	96.2593117834	dou4	bean/peas, bean/sacrificial vessel
+1792	削	9169	96.2640501863	xiao1/xue1	to scrape, to reduce/to pare (away)/to cut (down)
+1793	岗	9163	96.2687854885	gang3	mound/policeman's beat
+1794	晃	9157	96.27351769	huang3/huang4	dazzle, sway/to shade
+1795	吞	9142	96.2782421397	tun1	to swallow/to take
+1796	宏	9134	96.2829624551	hong2	spacious
+1797	癌	9114	96.2876724348	ai2/yan2	cancer, cancer (old pronuniation)/carcinoma
+1798	肚	9102	96.2923762131	du3/du4	tripe, belly
+1799	隶	9100	96.2970789578	li4	attached to/scribe
+1800	履	9091	96.3017770515	lu:3/lv3	shoe/to tread on
+1801	涨	9089	96.3064741116	zhang3/zhang4	to rise (of prices, rivers), to swell/distend
+1802	耀	9060	96.3111561849	yao4	brilliant/glorious
+1803	扭	9054	96.3158351575	niu3	to turn/to twist/to grab/to wring
+1804	坛	9049	96.3205115462	tan2	altar
+1805	拨	9047	96.3251869013	bo1	to push aside/to appropriate (money)/to move/to set aside/group/batch/to poke/to stir
+1806	沃	9047	96.3298622564	wo4	fertile/rich
+1807	绘	9039	96.3345334772	hui4	to draw/to paint
+1808	伐	9028	96.3391990134	fa2	(v) cut down; fell/(v) dispatch an expedition against; descend upon
+1809	堪	9026	96.3438635161	kan1	endure
+1810	仆	8976	96.3485021794	pu1/pu2	fall prostrate, servant
+1811	郭	8931	96.3531175875	guo1	(surname)/outer city wall
+1812	牺	8926	96.3577304116	xi1	sacrifice
+1813	歼	8910	96.3623349671	jian1	annihilate
+1814	墓	8890	96.366929187	mu4	tomb
+1815	雇	8857	96.3715063529	gu4	hire
+1816	廉	8854	96.3760819685	lian2	incorrupt/inexpensive
+1817	契	8845	96.380652933	qi4	contract
+1818	拼	8842	96.3852223472	pin1	piece together/stake (all)/spell/join together
+1819	惩	8839	96.389790211	cheng2	punish/discipline
+1820	捉	8838	96.394357558	zhuo1	to clutch/to grab/to capture
+1821	刷	8773	96.4034364392	shua1/shua4	brush, to select
+1822	劫	8752	96.4079593427	jie2	plunder
+1823	嫌	8748	96.4124801791	xian2	to dislike/to suspect
+1824	瓜	8740	96.4169968812	gua1	melon/claw/gourd/squash
+1825	歇	8733	96.4215099658	xie1	to rest
+1826	雕	8713	96.4260127146	diao1	engrave, engrave/shrewd, golden eagle
+1827	闷	8708	96.4305128796	men1/men4	smother/stuffy, melancholy
+1828	乳	8701	96.435009427	ru3	breast/milk
+1829	串	8695	96.4395028738	chuan4	to string together/to mix up/to conspire/to connect/(a measure word)/string
+1830	娃	8662	96.4439792666	wa2	baby/doll
+1831	缴	8659	96.4484541091	jiao3	hand in/hand over
+1832	唤	8657	96.452927918	huan4	to call
+1833	赢	8657	96.4574017269	ying2	to beat/to win/to profit
+1834	莲	8650	96.4618719183	lian2	lotus
+1835	霸	8639	96.4663364251	ba4	feudal chief/rule by force/tyrant/lord/master/hegemon/usurp
+1836	桃	8639	96.4708009319	tao2	peach
+1837	妥	8634	96.4752628547	tuo3	secure/sound
+1838	瘦	8632	96.479723744	shou4	tight/thin/lean
+1839	搭	8626	96.4841815326	da1	build (scaffolding)/take (boat, train)/hang/join/match/take passage
+1840	赴	8594	96.488622784	fu4	go towards/go to/attend (a banquet, etc.)/to go
+1841	岳	8577	96.4930552501	yue4	(surname)/mountain/wife's father, mountain
+1842	嘉	8576	96.4974871995	jia1	excellent
+1843	舱	8575	96.501918632	cang1	cabin/the hold of a ship or airplane
+1844	俊	8543	96.5063335274	jun4	smart/eminent/handsome/talented
+1845	址	8541	96.5107473892	zhi3	location/site
+1846	庞	8531	96.5151560832	pang2	(surname)/huge/enormous/tremendous
+1847	耕	8525	96.5195616765	geng1	to plow/to till
+1848	锐	8522	96.5239657194	rui4	acute
+1849	缝	8512	96.5283645945	feng2/feng4	to sew/to stitch, crack/seam
+1850	悔	8485	96.5327495163	hui3	regret
+1851	邀	8484	96.5371339214	yao1	invite to come
+1852	玲	8475	96.5415136754	ling2	(used in compounds)/tinkling of gem-pendants
+1853	惟	8469	96.5458903287	wei2	-ism/only
+1854	斥	8464	96.5502643981	chi4	blame/reprove/reprimand
+1855	宅	8464	96.5546384675	zhai2	residence
+1856	添	8460	96.5590104697	tian1	to add/to increase/to replenish
+1857	挖	8449	96.5633767873	wa1	to dig/to excavate/to scoop out
+1858	呵	8433	96.5677348364	a1/he1	(phonetic particle), expel breath/my goodness
+1859	讼	8410	96.5720809994	song4	litigation
+1860	氧	8401	96.5764225113	yang3	oxygen
+1861	浩	8387	96.5807567882	hao4	grand/vast (water)
+1862	羽	8366	96.5850802126	yu3	feather
+1863	斤	8365	96.5894031203	jin1	catty/weight equal to 0.5 kg
+1864	酷	8345	96.5937156922	ku4	ruthless/strong (as of wine)/(slang loan from English) cool, great
+1865	掠	8343	96.5980272306	lue4/lue3	plunder
+1866	妖	8337	96.6023356683	yao1	goblin/witch/devil/bewitching/enchanting/monster/phantom
+1867	祸	8336	96.6066435892	huo4	disaster
+1868	侍	8320	96.6109432415	shi4	attend on
+1869	乙	8313	96.6152392763	yi3	"B" (in a sequence of examples involving "A", "B", "C", etc.)/2nd heavenly stem/2nd in order
+1870	妨	8311	96.6195342776	fang2	hinder/harm
+1871	贪	8304	96.6238256613	tan1	greedy
+1872	挣	8297	96.6281134276	zheng1/zheng4	struggle, to earn/to make (money)
+1873	汪	8294	96.6323996435	wang1	(surname)/expanse of water/ooze
+1874	尿	8292	96.6366848258	sui1/niao4	urinate/urine
+1875	莉	8289	96.6409684578	li4	jasmine
+1876	悬	8282	96.6452484723	xuan2	hang/suspend
+1877	唇	8279	96.6495269364	chun2	lip
+1878	翰	8279	96.6538054006	han4	pen
+1879	仓	8275	96.6580817976	cang1	barn/granary/storehouse/cabin/hold (in ship)
+1880	轨	8273	96.662357161	gui3	course/path/track/rail
+1881	枚	8270	96.666630974	mei2	M for small objects
+1882	盐	8266	96.67090272	yan2	salt
+1883	览	8259	96.6751708484	lan3	look over/to view
+1884	傅	8256	96.6794374265	fu4	(surname)/tutor
+1885	帅	8249	96.683700387	shuai4	handsome/graceful/smart/commander in chief
+1886	庙	8220	96.6879483608	miao4	temple/monastery
+1887	芬	8218	96.6921953011	fen1	fragrant
+1888	屏	8208	96.6964370735	bing3/ping2	get rid of/put aside/reject/keep control/hold back, (standing) screen
+1889	寺	8200	96.7006747116	si4	Buddhist temple
+1890	胖	8184	96.7049040811	pang4	fat/plump
+1891	璃	8176	96.7091293164	li2	colored glaze/glass
+1892	愚	8144	96.7133380145	yu2	stupid
+1893	滴	8104	96.7175260412	di1	a drop/to drip
+1894	疏	8101	96.7217125176	shu1	negligent/sparse/thin
+1895	萧	8097	96.7258969269	xiao1	mournful
+1896	姿	8092	96.7300787522	zi1	beauty/disposition/looks/appearance
+1897	颤	8080	96.7342543761	zhan4/chan4	to tremble/to shiver/to shake/to vibrate
+1898	丑	8067	96.7384232817	chou3	2nd Earthly Branch/clown/Chou (surname), shameful/ugly/disgraceful
+1899	劣	8067	96.7425921874	lie4	inferior
+1900	柯	8061	96.7467579924	ke1	(surname)/handle of axe/stem
+1901	寸	8056	96.7509212134	cun4	a unit of length/inch/thumb
+1902	扔	8045	96.7550787498	reng1	throw
+1903	盯	8041	96.7592342191	ding1	stare/gaze
+1904	辱	8029	96.763383487	ru3	disgrace/insult
+1905	匹	8025	96.7675306877	pi1/pi3	mate/one of a pair, (measure word for horses, mules, a bolt of cloth)/ordinary person
+1906	俱	8024	96.7716773716	ju1/ju4	entirely/without exception, a social club
+1907	辨	8023	96.7758235387	bian4	distinguish/recognize
+1908	饿	7992	96.7799536855	e4	to be hungry/hungry
+1909	蜂	7989	96.784082282	feng1	bee/wasp
+1910	哦	7980	96.7882062273	e2/o2/o4	to chant, oh is that so
+1911	腔	7975	96.7923275888	qiang1	cavity of body/tune
+1912	郁	7968	96.7964453327	yu4	(surname)/elegant, dense (growth)/melancholy
+1913	溃	7962	96.800559976	kui4	be dispersed/break down
+1914	谨	7960	96.8046735856	jin3	cautious
+1915	糟	7960	96.8087871953	zao1	dregs/to waste/spoil, to waste/spoil
+1916	葛	7952	96.8128966707	ge2/ge3	coarse grass linen, (surname)
+1917	苗	7946	96.8170030454	miao2	(surname)/Miao tribe/sprout
+1918	肠	7939	96.8211058026	chang2	intestines
+1919	忌	7938	96.825208043	ji4	avoid as taboo/jealous
+1920	溜	7935	96.829308733	liu1	slip away/to skate
+1921	鸿	7931	96.8334073559	hong2	eastern bean goose/great/large
+1922	爵	7902	96.837490992	jue2	nobility/(ancient wine holder with 3 legs and loop handle)
+1923	鹏	7895	96.8415710107	peng2	large fabulous bird
+1924	鹰	7890	96.8456484454	ying1	eagle/falcon/hawk
+1925	笼	7888	96.8497248465	long2	basket/cage
+1926	丘	7886	96.8538002141	qiu1	Confucius/given name/mound, earthenware, earthenware vessel
+1927	桂	7877	96.8578709306	gui4	Cinnamonum cassia
+1928	滋	7874	96.8619400968	zi1	excite/nourish/this
+1929	聊	7865	96.8660046119	liao2	to chat/to have a chat/to kill time
+1930	挡	7851	96.8700618919	dang3/dang4	hinder/resist/obstruct/hinder/cover/keep off/a cover/to block/to get in the way of, arrange/put in order
+1931	纲	7832	96.8741093531	gang1	head rope of a fishing net/guiding principle/key link/class (taxonomy)/outline/program
+1932	肌	7830	96.8781557807	ji1	flesh/muscle
+1933	茨	7823	96.8821985908	ci2	Tribulus terrestris/thatched hut
+1934	壳	7813	96.8862362331	ke2/qiao4	shell, shell
+1935	痕	7805	96.8902697411	hen2	scar/traces
+1936	碗	7773	96.8942867119	wan3	bowl/cup
+1937	穴	7772	96.898303166	xue2	hole/cave
+1938	膀	7731	96.9022984319	bang3/bang4/pang1/pang2	upper arm/wing, to flirt, puffed (swollen), bladder
+1939	卓	7714	96.9062849124	zhuo2	(surname)/outstanding
+1940	贤	7713	96.9102708761	xian2	worthy (person)
+1941	卧	7696	96.9142480545	wo4	to lie/to crouch
+1942	膜	7694	96.9182241994	mo2	(n) membrane; film
+1943	毅	7686	96.9221962099	yi4	perseverance
+1944	锦	7682	96.9261661533	jin3	brocade/embroidered work/bright
+1945	欠	7682	96.9301360967	qian4	deficient/owe/to lack/yawn
+1946	哩	7677	96.9341034562	li1/li3/li	(onomat.), mile, (part. for continued state)
+1947	函	7672	96.9380682317	han2	envelope/case/letter
+1948	茫	7659	96.9420262891	mang2	vague/vast
+1949	昂	7637	96.9459729772	ang2	high/raise (head), high/soaring/raise/lift/expensive/to raise one's head
+1950	薛	7630	96.9499160477	xue1	(surname)/wormwood
+1951	皱	7609	96.9538482658	zhou4	to wrinkle/wrinkled/to crease
+1952	夸	7594	96.9577727321	kua1	to boast
+1953	豫	7590	96.9616951313	yu4	beforehand/prepare
+1954	胃	7533	96.9655880737	wei4	stomach
+1955	舌	7511	96.9694696469	she2	tongue
+1956	剥	7504	96.9733476025	bo1/bao1	peel/to skin
+1957	傲	7503	96.9772250414	ao4	proud/overbearing/insolent/arrogant
+1958	拾	7497	96.9810993795	shi2	pick up/ten (fraud-proof)
+1959	窝	7456	96.9849525295	wo1	nest
+1960	睁	7454	96.9888046459	zheng1	to open (eye)
+1961	携	7449	96.9926541784	xie2	to carry/to take along/to bring along/to hold (hands)
+1962	陵	7436	96.9964969926	ling2	mound/tomb/hill/mountain
+1963	哼	7419	97.0003310216	heng1/hng	hum, (interj. of contempt)
+1964	棉	7416	97.0041635001	mian2	cotton
+1965	晴	7405	97.007990294	qing2	clear/fine (weather)
+1966	铃	7404	97.0118165712	ling2	(small) bell
+1967	填	7401	97.0156412979	tian2	to fill in
+1968	饲	7399	97.0194649912	si4	to raise/to rear/to feed
+1969	渴	7395	97.0232866172	ke3	thirsty
+1970	吻	7395	97.0271082433	wen3	kiss/mouth
+1971	扮	7372	97.0309179833	ban4	to disguise oneself/to dress up/adorn
+1972	逆	7339	97.0347106694	ni4	contrary/opposite/backwards/to go against/to oppose/to betray/to rebel
+1973	脆	7336	97.0385018052	cui4	crisp/brittle/clear and loud voice
+1974	喘	7320	97.0422846724	chuan3	to gasp/to pant/asthma
+1975	罩	7309	97.0460618549	zhao4	cover/fish trap (basket)/shade
+1976	卜	7301	97.0498349032	bo/bu3	turnip, to divine/foretell
+1977	炉	7295	97.0536048507	lu2	stove
+1978	柴	7276	97.0573649794	chai2	(surname)/firewood
+1979	愉	7259	97.0611163227	yu2	pleased
+1980	绳	7256	97.0648661156	sheng2	rope
+1981	胎	7256	97.0686159085	tai1	fetus/litter
+1982	蓄	7213	97.0723434797	xu4	to store
+1983	眠	7195	97.0760617488	mian2	sleep
+1984	竭	7194	97.079779501	jie2	exhaust
+1985	喂	7184	97.0834920854	wei4	(interjection) hello/to feed (someone or some animal)/hey/telephone greeting, to feed
+1986	傻	7167	97.0871958845	sha3	foolish
+1987	慕	7165	97.09089865	mu4	admire
+1988	浑	7136	97.0945864287	hun2	muddy
+1989	奸	7132	97.0982721403	jian1	traitor, adultery
+1990	扇	7125	97.1019542344	shan1/shan4	to fan, (a measure word for doors, windows, etc.)
+1991	柜	7101	97.1056239256	gui4/ju3	cupboard/cabinet/wardrobe, Salix multinervis
+1992	悦	7094	97.1092899993	yue4	pleased
+1993	拦	7091	97.1129545227	lan2	cut off/hinder
+1994	诞	7085	97.1166159454	dan4	birth/birthday/brag/boast/to increase
+1995	饱	7059	97.1202639317	bao3	to eat till full/satisfied
+1996	乾	7057	97.1239108844	gan1/qian2	dry, (surname)/male/strong/one of the Eight Trigrams
+1997	泡	7046	97.1275521524	pao1/pao4	puffed/swollen, to steep/soak/bubble(s)/foam
+1998	贼	7045	97.1311929037	zei2	thief
+1999	亭	7041	97.1348315878	ting2	pavilion
+2000	夕	7025	97.1384620034	xi1/xi4	evening, dusk
+2001	爹	7016	97.1420877679	die1	dad
+2002	酬	7011	97.1457109485	chou2	entertain/repay/return/reward/compensate
+2003	儒	7004	97.1493305116	ru2	scholar/Confucian
+2004	姻	6998	97.1529469739	yin1	marriage connections
+2005	卵	6971	97.1565494831	luan3	ovum
+2006	氛	6968	97.1601504419	fen1	miasma/vapor
+2007	泄	6955	97.1637446826	xie4	divulge/leak out
+2008	杆	6944	97.1673332385	gan1/gan3	pole, measure for guns, stick/pole
+2009	挨	6930	97.1709145595	ai1/ai2	lean to/in order/in sequence, next to/suffer (hunger)/endure/drag out/delay/stall/play for time
+2010	僧	6920	97.1744907126	seng1	monk
+2011	蜜	6919	97.178066349	mi4	honey
+2012	吟	6916	97.181640435	yin2	moan/to hum
+2013	猩	6909	97.1852109035	xing1	ape
+2014	遂	6904	97.188778788	sui4/sui2	forthwith
+2015	狭	6901	97.1923451223	xia2	narrow/narrow-minded
+2016	肖	6899	97.1959104229	xiao4/xiao1	similar/resembling/to resemble/to be like
+2017	甜	6894	97.1994731396	tian2	sweet
+2018	霞	6885	97.2030312053	xia2	red clouds
+2019	驳	6879	97.2065861702	bo2	argue/parti-colored/tranship/dispute/contradict/refute, argue/parti-colored/tranship
+2020	裕	6871	97.2101370009	yu4	abundant
+2021	顽	6868	97.2136862812	wan2	mischievous/obstinate/to play/stupid/stubborn/naughty
+2022	摘	6845	97.2207677879	zhai1	to borrow/to pick (flowers, fruit)/to pluck/to take/to select
+2023	矮	6834	97.2242994975	ai3	short (not tall)
+2024	秒	6829	97.2278286232	miao3	(a measure word)/second
+2025	卿	6825	97.2313556817	qing1	(old) minister/(old) term of endearment between spouses/thou (poet.)
+2026	畜	6821	97.2348806731	chu4/xu4	livestock/domesticated animal/domestic animal, to raise (animals)
+2027	咽	6818	97.2384041142	yan1/yan4/ye4	narrow pass/throat, to swallow, to choke (in crying)
+2028	披	6790	97.2419130852	pi1	scatter/separate/to open/to unroll/to spread out
+2029	辅	6782	97.245417922	fu3	to assist/to complement/auxiliary
+2030	勾	6780	97.2489217252	gou1/gou4	to cancel/to delineate/hook, affair/to reach for (with hand)
+2031	盆	6780	97.2524255284	pen2	basin
+2032	疆	6779	97.2559288149	jiang1	border/boundary
+2033	赌	6759	97.2594217656	du3	bet/gamble
+2034	塑	6744	97.2629069645	su4	to model (a figure) in clay
+2035	畏	6722	97.2663807942	wei4	to fear
+2036	吵	6709	97.2698479057	chao3	to quarrel/to make a noise/noisy/to disturb by making a noise
+2037	囊	6709	97.2733150172	nang2	sack
+2038	嗯	6707	97.2767810951	en1/ng/en4	(a groaning sound)
+2039	泊	6695	97.2802409715	bo2	to anchor/touch at/to moor
+2040	肺	6692	97.2836992977	fei4	lung
+2041	骤	6688	97.2871555566	zhou4	sudden/suddenly
+2042	缠	6675	97.2906050974	chan2	to bother/wind around/wrap round/coil/involve/annoy/tangle
+2043	冈	6651	97.2940422353	gang1	ridge/mound
+2044	羞	6651	97.2974793733	xiu1	shy/ashamed/shame/bashful
+2045	瞪	6644	97.3009128937	deng4	stare at
+2046	吊	6637	97.3043427966	diao4	to hang a person, condole with/hang
+2047	贾	6627	97.3077675317	gu3/jia3	merchant/to buy, (surname)
+2048	漏	6627	97.3111922668	lou4	funnel/to leak/to let out/to divulge
+2049	斑	6622	97.314614418	ban1	variegated
+2050	涛	6611	97.3180308845	tao1	big wave
+2051	悠	6604	97.3214437335	you1	at ease/long (in time)/sad
+2052	鹿	6599	97.3248539986	lu4	deer
+2053	俘	6594	97.3282616798	fu2	prisoner of war
+2054	锡	6586	97.3316652267	xi2/xi1	tin
+2055	卑	6572	97.3350615386	bei1	low/base/vulgar/inferior/humble
+2056	葬	6558	97.3384506155	zang4	bury (the dead)
+2057	铭	6555	97.3418381421	ming2	inscribed motto
+2058	滩	6550	97.3452230847	tan1	beach/shoal
+2059	嫁	6539	97.3486023427	jia4	marry (a husband)
+2060	催	6538	97.3519810839	cui1	urge/press/expedite/prompt/hurry
+2061	璇	6536	97.3553587916	xuan2	(jade)
+2062	翅	6524	97.3587302978	chi4	wing
+2063	盒	6506	97.3620925019	he2	small box/case
+2064	蛮	6503	97.3654531556	man2	barbarian/bullying/very/quite/rough/reckless
+2065	矣	6490	97.3688070911	yi3	final part.
+2066	潘	6477	97.3721543084	pan1	(surname)
+2067	歧	6451	97.3754880893	qi2	divergent/side road
+2068	赐	6431	97.3788115345	ci4	confer/bestow/grant
+2069	鲍	6416	97.382127228	bao4	abalone
+2070	锅	6416	97.3854429214	guo1	pot/pan/boiler
+2071	廊	6413	97.3887570645	lang2	porch
+2072	拆	6412	97.3920706907	chai1	to tear open/to tear down/to tear apart/to open
+2073	灌	6403	97.395379666	guan4	irrigate/pour
+2074	勉	6398	97.3986860573	mian3	exhort
+2075	盲	6395	97.4019908982	mang2	blind
+2076	宰	6390	97.4052931552	zai3	slaughter/butcher/govern/rule/official
+2077	佐	6378	97.4085892108	zuo3	assist
+2078	啥	6331	97.4118609775	sha2	(dialect) what
+2079	胀	6327	97.415130677	zhang4	dropsical/swollen/to swell/to be bloated
+2080	扯	6325	97.418399343	che3	pull/tear/to talk casually
+2081	禧	6308	97.4216592236	xi3	joy
+2082	辽	6300	97.42491497	liao2	Liaoning/name of a dynasty
+2083	抹	6299	97.4281701995	mo3/mo4	play/to smear, girdle/brassiere/to plaster
+2084	筒	6296	97.4314238788	tong3	tube/cylinder
+2085	棋	6294	97.4346765244	qi2	chess
+2086	裤	6282	97.4379229686	ku4	drawers/trousers/pants
+2087	唉	6269	97.4411626946	ai1/ai4	an interjection/to express realization or agreement (yes, oh, right, etc), alas/oh dear
+2088	朴	6261	97.4443982863	po4/pu3	Celtis sinensis var. japonica, Pak or Park (Korean surname)/plain and simple
+2089	咐	6257	97.4476318109	fu4	to order
+2090	孕	6256	97.4508648187	yun4	pregnant
+2091	誓	6249	97.454094209	shi4	oath/vow/to swear/to pledge
+2092	喉	6233	97.4573153308	hou2	throat/larynx
+2093	妄	6228	97.4605338686	wang4	absurd/fantastic
+2094	拘	6224	97.4637503393	ju1	adhere/capture/restrain
+2095	链	6223	97.4669662932	lian4	chain/lead or tin ore
+2096	驰	6199	97.4701698442	chi2	run fast/speed/spread/gallop
+2097	栏	6182	97.4733646099	lan2	fence/railing/hurdle
+2098	逝	6182	97.4765593756	shi4	depart/die
+2099	窃	6174	97.4797500071	qie4	I beg to presume/steal
+2100	艳	6172	97.4829396049	yan4	glamorous
+2101	臭	6166	97.486126102	chou4/xiu4	stench/stink/smelly/to smell (bad), sense of smell/smell bad
+2102	纤	6166	97.4893125992	qian4/xian1	boatman's tow-rope, fine/delicate/minute
+2103	玑	6165	97.4924985795	ji1	irregular pearl
+2104	棵	6159	97.4956814592	ke1	M for plants
+2105	趁	6154	97.4988617549	chen4	avail oneself of/take advantage of
+2106	匠	6142	97.5020358492	jiang4	craftsman
+2107	盈	6142	97.5052099435	ying2	full/filled/surplus
+2108	翁	6137	97.5083814539	weng1	(surname)/elderly person
+2109	愁	6135	97.5115519307	chou2	worry about
+2110	瞬	6119	97.5147141389	shun4	to wink
+2111	婴	6114	97.5178737632	ying1	infant/baby
+2112	孝	6112	97.521032354	xiao4	filial
+2113	颈	6104	97.5241868104	jing3	neck
+2114	倘	6072	97.5273247298	tang3	if
+2115	浙	6045	97.5304486959	zhe4	Zhejiang
+2116	谅	6024	97.5335618096	liang4	forgive
+2117	蔽	6016	97.5366707889	bi4	to cover/to shield/to screen/to conceal
+2118	畅	6012	97.5397777012	chang4	smooth/fluent/joyful/happy
+2119	赠	6004	97.5428804791	zeng4	give present
+2120	妮	6000	97.5459811899	ni1	girl/phonetic "ni" (in girl's name)
+2121	莎	5990	97.5490767329	sha1/suo1	(insect)/(phonetic), (grass)/Cyperus rotundus
+2122	尉	5988	97.5521712423	wei4	(surname)/milit. official/to quiet
+2123	冻	5984	97.5552636845	dong4	to freeze
+2124	跪	5955	97.55834114	gui4	kneel
+2125	闯	5954	97.5614180787	chuang3	to rush/break through
+2126	葡	5943	97.5644893327	pu2	grapes
+2127	厨	5932	97.5706235723	chu2	kitchen
+2128	鸭	5932	97.5736891417	ya1	duck
+2129	颠	5921	97.5767490265	dian1	inverted/jolt/top
+2130	遮	5914	97.5798052938	zhe1	cover up (a shortcoming)/screen off/to hide/to conceal
+2131	谊	5902	97.5828553596	yi4	friendship
+2132	圳	5901	97.5859049087	zhen4	furrow in field, small drainage
+2133	吁	5891	97.5889492899	xu1/yu4	sh/hush, implore
+2134	仑	5882	97.5919890201	lun2	arrange, Koulkun mountains
+2135	辟	5876	97.5950256495	bi4/pi4	king/emperor/monarch/royal/ward off, law, dispel/open up/refute
+2136	瘤	5875	97.5980617622	liu2	tumor
+2137	嫂	5863	97.6010916735	sao3	older brother's wife; sister-in-law
+2138	陀	5863	97.6041215847	tuo2	(phonetic)/declivity/steep bank
+2139	框	5853	97.6071463281	kuang4	frame/door frame
+2140	谭	5849	97.6101690043	tan2	(surname)
+2141	亨	5845	97.6131896135	heng1	prosperous
+2142	钦	5840	97.6162076386	qin1	royal
+2143	庸	5835	97.6192230799	yong1	ordinary/to use
+2144	歉	5833	97.6222374876	qian4	apologize/deficient/to regret
+2145	芝	5832	97.6252513785	zhi1	Zoysia pungens
+2146	吼	5814	97.6282559673	hou3	roar (of a lion)
+2147	甫	5805	97.631255905	fu3	just/just now
+2148	衫	5802	97.6342542923	shan1	Chinese gown (unlined)
+2149	摊	5798	97.6372506125	tan1	spread out/vendor's stand
+2150	宴	5798	97.6402469328	yan4	feast/repose
+2151	嘱	5788	97.6432380851	zhu3	enjoin
+2152	衷	5781	97.64622562	zhong1	inner feelings
+2153	娇	5772	97.6492085038	jiao1	lovable/pampered/tender/delicate/frail
+2154	陕	5769	97.6521898372	shan3/Shan3	Shaanxi
+2155	矩	5766	97.6551696203	ju3	carpenter's square/rule
+2156	浦	5766	97.6581494034	pu3	beach
+2157	讶	5760	97.6611260858	ya4	astounded
+2158	耸	5758	97.6641017346	song3	excite/raise up/to shrug/high/lofty/towering
+2159	裸	5752	97.6670742827	luo3	naked
+2160	碧	5751	97.670046314	bi4	green jade/bluish green/blue/jade
+2161	摧	5743	97.673014211	cui1	break/destroy/devastate/ravage/repress
+2162	薪	5741	97.6759810745	xin1	fuel/salary
+2163	淋	5737	97.6789458708	lin4/lin2	diseases of the bladder/to drain/to drip
+2164	耻	5735	97.6819096335	chi3	shame/disgrace
+2165	胶	5721	97.6848661613	jiao1	glue/gum
+2166	屠	5718	97.6878211387	tu2	slaughter/slaughter man
+2167	鹅	5703	97.6907683643	e2	goose
+2168	饥	5689	97.6937083549	ji1	hungry
+2169	盼	5689	97.6966483456	pan4	to hope for/to long for/to expect
+2170	脖	5682	97.6995847187	bo2	neck
+2171	虹	5670	97.7025148904	hong2/jiang4	rainbow, rainbow
+2172	翠	5661	97.7054404111	cui4	bluish-green/green jade
+2173	崩	5658	97.7083643814	beng1	collapse/fall into ruins
+2174	账	5652	97.7112852509	zhang4	account
+2175	萍	5646	97.7142030198	ping2	duckweed
+2176	逢	5632	97.7171135537	feng2	every time/meet by chance
+2177	赚	5630	97.720023054	zhuan4/zuan4	earn/make a profit, cheat/swindle
+2178	撑	5628	97.7229315207	cheng1	support/prop-up/to pole a boat/to open/to overfill
+2179	翔	5625	97.7258384371	xiang2	soar
+2180	倡	5622	97.7287438031	chang4	initiate/instigate/introduce/lead/initiate
+2181	绵	5622	97.7316491692	mian2	cotton/incessant/soft/downy
+2182	猴	5582	97.7345338638	hou2	monkey
+2183	枯	5582	97.7374185584	ku1	dried up
+2184	巫	5576	97.7403001523	wu1	witch
+2185	昭	5569	97.7431781287	zhao1	illustrious/manifest
+2186	怔	5561	97.7460519709	zheng1	be startled
+2187	渊	5551	97.7489206452	yuan1	abyss
+2188	凑	5544	97.7517857019	cou4	assemble/put together/press near/come together
+2189	溪	5543	97.7546502419	qi1/xi1	creek, creek
+2190	蠢	5542	97.7575142652	chun3	blunt/stupid/to wiggle (of worms)/sluggish
+2191	禅	5540	97.7603772548	chan2/shan4	meditation/abstraction/(Zen) Buddhism, abdicate
+2192	阐	5532	97.7632361102	chan3	to express/disclose/enlighten/open
+2193	旺	5529	97.7660934152	wang4	prosperous/flourishing/to prosper/to flourish
+2194	寓	5519	97.7689455523	yu4	reside/residence
+2195	藤	5514	97.7717951056	teng2	rattan/cane
+2196	匪	5511	97.7746431084	fei3	bandit
+2197	伞	5511	97.7774911113	san3	umbrella/parasol
+2198	碑	5509	97.7803380806	bei1	a monument/an upright stone tablet/stele
+2199	挪	5500	97.7831803989	nuo2	to shift/to move
+2200	琼	5495	97.7860201332	qiong2	(red stone)/beautiful
+2201	脂	5492	97.7888583171	zhi1	fat
+2202	谎	5481	97.7916908165	huang3	lies/to lie
+2203	慨	5479	97.7945222822	kai3	generous/sad
+2204	菩	5477	97.7973527144	pu2	Bodhisattva
+2205	萄	5463	97.8001759116	tao2	grapes
+2206	狮	5456	97.8029954913	shi1	lion
+2207	掘	5436	97.8058047353	jue2	dig
+2208	抄	5433	97.8086124289	chao1	to copy/to plagiarize/to search and seize/to go/to transcribe/to take a shortcut/to search and confiscate
+2209	岭	5429	97.8114180554	ling3	mountain range
+2210	晕	5420	97.8142190308	yun1/yun4	confused/dizzy/giddy/faint/swoon/lose consciousness/pass out, dizzy/ring around moon or sun
+2211	逮	5418	97.8170189727	dai3/dai4	arrest/catch/seize/until, catch/seize/until
+2212	砍	5418	97.8198189146	kan3	to chop
+2213	掏	5416	97.8226178229	tao1	fish out (from pocket)
+2214	狄	5414	97.8254156976	di2	(surname)/barbarians/name of a tribe
+2215	晰	5412	97.8282125387	xi1	understanding
+2216	罕	5409	97.8310078295	han3	rare
+2217	挽	5389	97.8337927846	wan3	draw/pull/send funeral ode
+2218	脾	5386	97.8365761893	pi2	spleen
+2219	舟	5363	97.839347708	zhou1	boat
+2220	痴	5359	97.8421171596	chi1	imbecile/sentimental/stupid/foolish/silly, imbecile/sentimental
+2221	蔡	5325	97.8448690404	cai4	(surname)
+2222	剪	5324	97.8476204045	jian3	cut with scissors/scissors
+2223	脊	5316	97.8503676342	ji3	spine/back/ridge
+2224	弓	5315	97.8531143472	gong1	a bow (weapon)
+2225	懒	5307	97.8558569259	lan3	lazy
+2226	叉	5299	97.8585953704	cha1/cha2/cha3	fork/pitchfork/prong/pick/cross/intersect, to cross/be stuck, to diverge/to open (as legs)
+2227	拐	5282	97.8613250294	guai3	kidnap/to turn
+2228	喃	5282	97.8640546885	nan2	mumble in repetition
+2229	僚	5278	97.8667822805	liao2	bureaucrat
+2230	捐	5273	97.8695072885	juan1	to contribute/to donate/tax/to abandon
+2231	姊	5272	97.8722317797	zi3	older sister
+2232	骚	5268	97.8749542038	sao1	have sex appeal
+2233	拓	5256	97.8776704265	ta4/tuo4	make rubbing, expand/support on palm/to develop/to open up
+2234	歪	5251	97.8803840652	wai1	askew
+2235	粘	5231	97.8830873682	nian2/zhan1	sticky, to stick/paste
+2236	柄	5229	97.8857896377	bing3	authority/handle/hilt
+2237	坑	5223	97.8884888065	keng1	pit/to defraud
+2238	陌	5220	97.8911864249	mo4	raised path/street
+2239	窄	5219	97.8938835265	zhai3	narrow
+2240	湘	5207	97.8965744267	xiang1	name of a river
+2241	兆	5204	97.8992637765	zhao4	omen/million/million million, trillion
+2242	崖	5199	97.9019505424	yai2/ya2	precipice
+2243	骄	5196	97.904635758	jiao1	proud/arrogant
+2244	刹	5185	97.9073152889	cha4/sha1	Buddhist monastery or temple/a brief moment, to brake (car)
+2245	鞭	5176	97.9099901688	bian1	a whip or lash/to flog/slash or whip
+2246	芒	5174	97.9126640151	mang2	Miscanthus sinensis
+2247	筋	5170	97.9153357942	jin1	muscle
+2248	聘	5148	97.9179962041	pin4	betrothed/engage (teacher)/hire
+2249	钩	5140	97.9206524797	gou1	entice/hook
+2250	棍	5140	97.9233087553	gun4	stick
+2251	嚷	5138	97.9259639973	rang3	blurt out/to shout
+2252	腺	5132	97.9286161386	xian4	gland
+2253	弦	5117	97.9312605281	xian2	bow string/string of mus. instr., string of mus. instr.
+2254	焰	5116	97.9339044009	yan4	flame
+2255	耍	5109	97.9365446561	shua3	play with/to juggle
+2256	俯	5100	97.9391802603	fu3	look down/stoop
+2257	厘	5096	97.9418137974	li2	one thousandth
+2258	愣	5088	97.9444432001	leng4	to look distracted/to stare blankly/distracted/stupefied/blank
+2259	厦	5083	97.947070019	sha4/xia4	tall building, tall building
+2260	恳	5081	97.9496958042	ken3	earnest
+2261	饶	5079	97.9523205559	rao2	(surname)/to spare
+2262	钉	5059	97.9549349719	ding1/ding4	nail
+2263	寡	5049	97.9575442201	gua3	few/widowed
+2264	憾	5036	97.96014675	han4	regret
+2265	摔	5035	97.9627487632	shuai1	throw on ground/to fall
+2266	叠	5027	97.9653466421	die2	fold up/repeat
+2267	惹	5018	97.9679398699	re3	to provoke/to exasperate/to annoy
+2268	喻	5012	97.970529997	yu4	allegory
+2269	谱	5009	97.9731185737	pu3	chart/list/score (music)/spectrum (math.)(phys.)
+2270	愧	5008	97.9757066336	kui4	ashamed
+2271	煌	5002	97.9782915929	huang2	brilliant
+2272	徽	5000	97.9808755186	hui1	insignia
+2273	溶	4998	97.9834584107	rong2	dissolve
+2274	坠	4980	97.9860320006	zhui4	fall
+2275	煞	4969	97.988599906	sha1/sha4	decrease/tighten, baleful/bring to a stop/very
+2276	巾	4967	97.9911667777	jin1	towel
+2277	滥	4964	97.9937320991	lan4	excessive/indiscriminate
+2278	洒	4961	97.9962958702	sa3	spill/sprinkle
+2279	堵	4960	97.9988591245	du3	stop up
+2280	瓷	4955	98.0014197948	ci2	chinaware/porcelain
+2281	咒	4931	98.0039680623	zhou4	put a curse on
+2282	姨	4928	98.0065147795	yi2	one's mother's sister/aunt
+2283	棒	4917	98.009055812	bang4	a stick/club or cudgel/smart/capable/strong
+2284	郡	4912	98.0115942605	jun4	canton/county/region
+2285	浴	4911	98.0141321923	yu4	bath/to bathe
+2286	媚	4909	98.0166690906	mei4	flatter/charm
+2287	稣	4907	98.0192049552	su1	revive
+2288	淮	4903	98.0217387527	huai2	name of a river
+2289	哎	4887	98.0242642817	ai1	an interjection/hey/lookout/why etc
+2290	屁	4884	98.0267882603	pi4	to break wind/to fart
+2291	漆	4884	98.0293122389	qi1	paint/lacquer
+2292	淫	4879	98.0318336336	yin2	excessive/wanton/lewd/kinky/obscene
+2293	巢	4874	98.0343524443	chao2	nest
+2294	吩	4866	98.0368671208	fen1	leave instructions/to order
+2295	撰	4863	98.0393802469	zhuan4	compose/compile, compose/compile/discourse in praise
+2296	啸	4850	98.0418866548	xiao4	to hiss/to whistle
+2297	滞	4850	98.0443930627	zhi4	sluggish
+2298	玫	4839	98.0468937859	mei2	rose
+2299	硕	4819	98.0493841735	shuo4	large/big
+2300	钓	4813	98.0518714604	diao4	to fish with a hook and bait
+2301	蝶	4811	98.0543577136	die2	butterfly
+2302	膝	4809	98.0568429334	xi1	knee
+2303	姚	4806	98.0593266027	yao2	Yao (a surname)
+2304	茂	4798	98.0618061378	mao4	luxuriant
+2305	躯	4797	98.0642851561	qu1	human body
+2306	吏	4795	98.0667631408	li4	minor official
+2307	猿	4793	98.069240092	yuan2	ape
+2308	寨	4783	98.0717118753	zhai4	stronghold/stockade
+2309	恕	4779	98.0741815914	shu4	forgive
+2310	渠	4769	98.0766461397	qu2	big/stream or canal/drain/ditch
+2311	戚	4756	98.0791039698	qi1	ashamed/grief, (surname)/relative
+2312	辰	4755	98.0815612831	chen2	5th earthly branch/7-9 a.m.
+2313	舶	4743	98.084012395	bo2	sea-going vessels/ship
+2314	颁	4742	98.0864629901	ban1	promulgate/send out/issue/to grant or confer
+2315	惶	4730	98.0889073838	huang2	frightened
+2316	狐	4718	98.0913455761	hu2	fox
+2317	讽	4713	98.0937811844	feng4/feng3	satirize
+2318	笨	4712	98.096216276	ben4	stupid/foolish/silly/slow-witted/clumsy
+2319	袍	4710	98.098650334	pao2	gown (lined)
+2320	嘲	4709	98.1010838752	chao2/zhao1	ridicule/mock, to ridicule
+2321	啡	4688	98.1035065639	fei1	coffee
+2322	泼	4688	98.1059292526	po1	splash/to spill
+2323	衔	4684	98.1083498742	xian2	hold in mouth, hold in mouth/nominal office
+2324	倦	4682	98.1107694622	juan4	tired
+2325	涵	4681	98.1131885334	han2	contain
+2326	雀	4675	98.1156045039	qiao1/qiao3/que4	lentigo, bird, bird
+2327	旬	4671	98.1180184072	xun2	ten days/ten years
+2328	僵	4668	98.1204307603	jiang1	rigid/deadlock/stiff (corpse), stiff (corpse)
+2329	撕	4668	98.1228431133	si1	to tear
+2330	肢	4651	98.1252466809	zhi1	limb
+2331	垄	4642	98.1276455975	long3	monopolize
+2332	夷	4638	98.130042447	yi2	a barbarian
+2333	逸	4638	98.1324392964	yi4	escape/leisurely/outstanding
+2334	茅	4637	98.1348356291	mao2	(surname)/thatch
+2335	侨	4633	98.1372298946	qiao2	emigrant/reside abroad
+2336	舆	4628	98.1396215762	yu2	carriage/sedan chair/world
+2337	窑	4611	98.1420044725	yao2	kiln/oven
+2338	涅	4601	98.1443822009	nie4	blacken
+2339	蒲	4595	98.1467568286	pu2	calamus
+2340	谦	4588	98.1491278388	qian1	modest
+2341	杭	4583	98.1514962651	hang2	(surname)/Hangzhou
+2342	噢	4582	98.1538641745	o1	Oh!
+2343	弊	4579	98.1562305337	bi4	detriment/fraud/harm/defeat
+2344	勋	4568	98.1585912082	xun1	medal/merit
+2345	刮	4565	98.1609503323	gua1	to scrape/to blow, blow (of the wind)
+2346	郊	4565	98.1633094564	jiao1	suburb
+2347	凄	4552	98.1656618624	qi1	intense cold/mournful, sorrowful
+2348	捧	4533	98.1680044494	peng3	hold or offer with both hands
+2349	浸	4529	98.1703449693	jin4	immerse/soak/steep
+2350	砖	4512	98.1726767038	zhuan1	brick
+2351	鼎	4507	98.1750058544	ding3	tripod
+2352	篮	4490	98.1773262197	lan2	basket/goal
+2353	蒸	4443	98.179622296	zheng1	to steam
+2354	饼	4439	98.1819163052	bing3	round flat cake/cookie/cake/pastry
+2355	亩	4439	98.1842103144	mu3	about 1/6 acre (M)
+2356	肾	4437	98.1865032901	shen4	kidney
+2357	陡	4421	98.1887879972	dou3	steep
+2358	爪	4419	98.1910716707	zhua3/zhao3	claw
+2359	兔	4418	98.1933548274	tu4	rabbit
+2360	殷	4417	98.1956374673	yan1/yin1/yin3	dark red, (surname)/dynasty/flourishing, roll of thunder
+2361	贞	4414	98.1979185569	zhen1	chaste
+2362	荐	4406	98.2001955122	jian4	recommend (a person)
+2363	哑	4406	98.2024724675	ya1/ya3	(onomat.), dumb/mute
+2364	炭	4405	98.204748906	tan4	carbon/charcoal
+2365	坟	4402	98.2070237942	fen2	a grave
+2366	眨	4393	98.2092940313	zha3	wink
+2367	搏	4392	98.2115637516	bo2	fight/combat/seize
+2368	咳	4390	98.2138324384	hai1/ke2	sound of sighing, cough
+2369	拢	4390	98.2161011251	long3	collect/draw near to
+2370	舅	4385	98.2183672279	jiu4	maternal uncle
+2371	昧	4375	98.2206281629	mei4	conceal/dark
+2372	擅	4372	98.2228875475	shan4	usurp/without authority
+2373	爽	4368	98.225144865	shuang3	invigorating/straightforward/frank/open/bright/clear
+2374	咖	4366	98.2274011488	ka1	coffee
+2375	搁	4359	98.2296538153	ge1	to place
+2376	禄	4356	98.2319049313	lu4	good fortune/official salary
+2377	雌	4355	98.2341555306	ci2	female
+2378	哨	4354	98.236405613	shao4	a whistle/sentry
+2379	巩	4344	98.2386505277	gong3	secure/solid
+2380	绢	4335	98.2408907912	juan4	thick but loosely woven silk
+2381	螺	4327	98.2431269205	luo2	screw/snail
+2382	裹	4322	98.2453604658	guo3	wrap around
+2383	昔	4320	98.2475929776	xi1	past/former
+2384	轩	4304	98.2498172208	xuan1	covered carriage/pavilion
+2385	谬	4290	98.2520342291	miu4	absurd/erroneous
+2386	谍	4274	98.2542429687	die2	to spy
+2387	龟	4265	98.2564470573	gui1	tortoise/turtle
+2388	媳	4262	98.2586495956	xi2	daughter in law
+2389	姜	4261	98.260851617	jiang1	(surname)/ginger, ginger
+2390	瞎	4260	98.2630531217	xia1	blind
+2391	冤	4243	98.265245841	yuan1	injustice/to wrong
+2392	鸦	4236	98.2674349429	ya1	crow
+2393	蓬	4225	98.2696183601	peng2	(grass)/disheveled
+2394	巷	4221	98.2717997101	xiang4	lane/alley
+2395	琳	4218	98.2739795098	lin2	gem
+2396	栽	4215	98.2761577592	zai1	to force/to stick in/to plant
+2397	沾	4201	98.2783287735	zhan1	infected by/moisten/receive favors, moisten
+2398	诈	4200	98.2804992711	zha4	crafty/dishonest
+2399	斋	4194	98.2826666679	zhai1	a fast/studio
+2400	瞒	4191	98.2848325144	man2	conceal from
+2401	彪	4186	98.286995777	biao1	a tiger-cat/stripes/streaks/veins
+2402	厄	4184	98.289158006	e4	distressed
+2403	咨	4180	98.2913181679	zi1	consult
+2404	纺	4175	98.2934757458	fang3	spin
+2405	罐	4169	98.295630223	guan4	can/jar/pot
+2406	桶	4167	98.2977836667	tong3	pail/bucket/bin/barrel
+2407	壤	4165	98.2999360768	rang3	soil/earth
+2408	糕	4142	98.3020766008	gao1	cake
+2409	颂	4142	98.3042171248	song4	to praise
+2410	膨	4141	98.3063571321	peng2	swollen
+2411	谐	4135	98.3084940386	xie2	harmonious
+2412	垒	4134	98.3106304284	lei3	rampart
+2413	咕	4132	98.3127657845	gu1	mutter
+2414	隙	4130	98.3149001071	xi4	crack/occasion for dislike
+2415	辣	4124	98.317031329	la4	hot (spicy)/pungent
+2416	绑	4112	98.3191563495	bang3	to tie/bind or fasten together
+2417	宠	4108	98.3212793028	chong3	to love/to pamper/to spoil/to favor
+2418	嘿	4102	98.3233991555	hei1	hey
+2419	兑	4101	98.3255184913	dui4	to cash
+2420	霉	4098	98.3276362768	mei2	bacteria/fungi/moldy
+2421	挫	4089	98.3297494112	cuo4	be obstructed/fail/oppress/repress/lower the tone/bend back/dampen
+2422	稽	4085	98.3318604785	ji1/qi3	inspect/check, bow to the ground
+2423	辐	4084	98.333971029	fu2	spoke of a wheel
+2424	乞	4073	98.3360758948	qi3	beg
+2425	纱	4069	98.3381786935	sha1	cotton yarn/muslin
+2426	裙	4062	98.3402778747	qun2	skirt
+2427	嘻	4056	98.3423739553	xi1	laugh/giggle
+2428	哇	4055	98.344469519	wa1/wa	sound of child's crying
+2429	绣	4046	98.3465604316	xiu4	to embroider
+2430	杖	4037	98.3486466932	zhang4	cane, walking stick
+2431	塘	4033	98.3507308877	tang2	pond
+2432	衍	4031	98.3528140485	yan3	to spread out/to develop/to overflow/to amplify
+2433	轴	4011	98.3548868737	zhou2/zhu2	axis/axle, axis/axle
+2434	攀	3998	98.3569529807	pan1	climb up/pull
+2435	膊	3989	98.3590144366	bo2	shoulder/upper arm
+2436	譬	3985	98.3610738254	pi4	give an example
+2437	斌	3981	98.363131147	bin1	ornamental/refined
+2438	祈	3965	98.3651802	qi2	implore/pray/please
+2439	踢	3959	98.3672261524	ti1	kick/play (football or soccer)
+2440	肆	3956	98.3692705544	si4	four (fraud-proof)/market
+2441	坎	3948	98.3713108221	kan3	pit/threshold
+2442	轿	3942	98.3733479891	jiao4	sedan chair
+2443	棚	3929	98.3753784379	peng2	shed
+2444	泣	3929	98.3774088867	qi4	to sob
+2445	屡	3925	98.3794372683	lu:3/lv3	time and again
+2446	躁	3917	98.3814615157	zao4	hot-tempered/impatient
+2447	邱	3912	98.3834831791	qiu1	(surname)/mound
+2448	凰	3911	98.3855043258	huang2	phoenix
+2449	溢	3909	98.3875244389	yi4	overflow
+2450	椎	3888	98.3895336995	chui2/zhui1	a hammer, spine
+2451	砸	3881	98.3915393426	za2	smash/smashed
+2452	趟	3879	98.3935439521	tang4	a time/a trip
+2453	帘	3875	98.3955464945	lian2	wine shop sign
+2454	帆	3874	98.3975485202	fan1	sail
+2455	栖	3867	98.3995469283	qi1/xi1	to roost/to inhabit/to stay/habitat, to roost/to inhabit/to stay/habitat
+2456	窜	3865	98.4015443028	cuan4	flee/escape/run away/leap
+2457	丸	3847	98.4035323752	wan2	pill
+2458	斩	3844	98.4055188973	zhan3	behead/chop
+2459	堤	3840	98.4075033522	di1	dike
+2460	塌	3839	98.4094872903	ta1	collapse
+2461	贩	3837	98.4114701949	fan4	deal in/trade in/to peddle/to sell
+2462	厢	3837	98.4134530995	xiang1	box (in theater)/side room
+2463	掀	3831	98.4154329033	xian1	lift (cover)
+2464	喀	3830	98.4174121904	ka1	(onomat.)
+2465	乖	3828	98.4193904439	guai1	(of a child) obedient, well-behaved/clever
+2466	谜	3828	98.4213686974	mi2	riddle
+2467	捏	3824	98.4233448837	nie1	to pinch (with one's fingers)/to knead/to make up
+2468	阎	3823	98.4253205533	yan2	(surname)/gate of village
+2469	滨	3811	98.4272900214	bin1	shore/beach/coast/bank
+2470	虏	3811	98.4292594896	lu3	take captive
+2471	匙	3809	98.4312279242	chi2/shi	spoon
+2472	芦	3806	98.4331948084	lu2	rush/reed/Phragmites communis
+2473	苹	3805	98.4351611758	pin2/ping2	marsiliaceae/clover fern, (artemisia)/duckweed, apple
+2474	卸	3795	98.4371223754	xie4	unload/take off
+2475	沼	3791	98.4390815079	zhao3	pond/pool
+2476	钥	3772	98.4410308214	yao4/yue4	key, key
+2477	株	3771	98.4429796181	zhu1	(a measure word, use with plants)/trunk of tree
+2478	祷	3769	98.4449273813	dao3	prayer/pray/supplication
+2479	剖	3767	98.4468741109	pou1	to cut
+2480	熙	3766	98.4488203237	xi1	prosperous/splendid
+2481	哗	3759	98.450762919	hua1/hua2	crashing sound, cat-calling sound/clamor/noise, clamor/noise
+2482	劈	3759	98.4527055144	pi1/pi3	hack/chop/split open, split in two/divide
+2483	怯	3759	98.4546481097	qie4	afraid/rustic
+2484	棠	3758	98.4565901882	tang2	cherry-apple
+2485	胳	3753	98.4585296828	ge1	armpit
+2486	桩	3746	98.4604655599	zhuang1	item/stump/stake/pile
+2487	瑰	3744	98.4624004035	gui1	(semi-precious stone)/extraordinary
+2488	娱	3740	98.4643331799	yu2	amuse
+2489	娶	3733	98.4662623388	qu3	take a wife
+2490	沫	3731	98.4681904641	mo4	foam/suds
+2491	嗓	3724	98.470114972	sang3	throat/voice
+2492	蹲	3720	98.4720374127	dun1	crouch/squat
+2493	焚	3718	98.4739588198	fen2	burn
+2494	淘	3718	98.4758802269	tao2	cleanse/eliminate/to clean out/to wash
+2495	嫩	3707	98.4777959494	nen4	tender/soft
+2496	韵	3705	98.4797106384	yun4	rhyme
+2497	衬	3700	98.4816227434	chen4	give alms/underwear/to line/lining/contrast/assist
+2498	匈	3700	98.4835348484	xiong1	Hungary/thorax/chest
+2499	钧	3698	98.4854459198	jun1	30 catties/great/your (hon.)
+2500	竖	3698	98.4873569912	shu4	(straight down character stroke)/to erect/vertical
+2501	峻	3688	98.4892628948	jun4	steep
+2502	豹	3683	98.4911662144	bao4	leopard/panther
+2503	捞	3681	98.4930685005	lao1	fish up
+2504	菊	3676	98.4949682027	ju2	chrysanthemum
+2505	鄙	3670	98.4968648041	bi3	rustic/low/base/mean
+2506	魄	3664	98.4987583049	po4	soul
+2507	兜	3663	98.5006512888	dou1	pocket
+2508	哄	3660	98.5025427224	hong1/hong3/hong4	resound with laughter, deceive/coax, have a hilarious time/riot
+2509	颖	3658	98.5044331224	ying3	clever/gifted
+2510	镑	3657	98.5063230057	bang4	pound (sterling)
+2511	屑	3655	98.5082118553	xie4	crumbs/filings/worth while
+2512	蚁	3653	98.5100996714	yi3	ant
+2513	壶	3652	98.5119869707	hu2	pot/(a measure word)
+2514	怡	3649	98.5138727197	yi2	harmony/pleased
+2515	渗	3647	98.5157574351	shen4	to seep/to ooze/to horrify
+2516	秃	3640	98.517638533	tu1	bald/blunt
+2517	迦	3637	98.5195180805	jia1	Buddha/Shakyamuni
+2518	旱	3636	98.5213971112	han4	drought
+2519	哟	3635	98.5232756252	yo/yo1	(interj) Oh, sound made when expressing surprise/(idiom) used at end of sentence as an exclamation
+2520	咸	3627	98.5251500049	xian2	all/in all cases/salty, salty
+2521	焉	3626	98.5270238678	yan1	where/how
+2522	谴	3619	98.5288941132	qian3	punishment/scold
+2523	宛	3619	98.5307643586	wan3	(surname)/similar/winding
+2524	稻	3607	98.5326284026	dao4	paddy/rice
+2525	铸	3604	98.5344908962	zhu4	cast metals/to coin (money)
+2526	锻	3596	98.5363492555	duan4	forge/wrought/to discipline
+2527	伽	3596	98.5382076149	qie2/ga1	(phonetic)
+2528	詹	3595	98.5400654575	zhan1	(surname)/excellent/verbose
+2529	毙	3588	98.5419196825	bi4	die violently
+2530	恍	3584	98.5437718404	huang3	disappointed/flurried/indistinct
+2531	贬	3580	98.5456219312	bian3	to diminish/to demote/reduce or devaluate/disparage/censure/depreciate
+2532	烛	3578	98.5474709884	zhu2	candle
+2533	骇	3577	98.5493195289	hai4	astonish/startle
+2534	芯	3568	98.5511634182	xin1	lamp pith/core
+2535	汁	3564	98.5530052404	zhi1	juice
+2536	桓	3551	98.5548403445	huan2	(surname)/Sapindus mukurosi
+2537	坊	3546	98.5566728645	fang1	subdivision of a city
+2538	驴	3532	98.5584981496	lu:2/lv2	donkey
+2539	朽	3526	98.560320334	xiu3	rotten
+2540	靖	3521	98.5621399345	jing4	pacify/quiet
+2541	佣	3517	98.5639574678	yong1/yong4	hire/servant, commission (for middleman)
+2542	汝	3503	98.5657677661	ru3	thou
+2543	碌	3497	98.5675749637	lu4	laborious/small stone/to record/to tape/to write down/to hire/to employ
+2544	迄	3496	98.5693816446	qi4	as yet/until
+2545	冀	3487	98.5711836743	ji4	Hebei/to hope
+2546	荆	3479	98.5729815698	jing1	(surname)/thorns/brambles
+2547	崔	3476	98.5747779149	cui1	(surname)/high mountain/precipitous
+2548	雁	3474	98.5765732265	yan4	wild goose
+2549	绅	3472	98.5783675045	shen1	member of gentry
+2550	珊	3465	98.580158165	shan1	coral
+2551	榜	3458	98.581945208	bang3	a notice or announcement/a list of names/public roll of successful examinees
+2552	诵	3447	98.5837265663	song4	read aloud
+2553	傍	3444	98.5855063743	bang1/bang4	near (approaching), near/nestle
+2554	彦	3437	98.5872825649	yan4	accomplished/elegant
+2555	醇	3433	98.5890566882	chun2	rich/pure/good wine/sterols
+2556	笛	3409	98.5908184087	di2	flute
+2557	禽	3408	98.5925796125	qin2	birds/fowl
+2558	勿	3400	98.5943366819	wu4	do not
+2559	娟	3385	98.5960859996	juan1	beautiful/graceful
+2560	瞄	3383	98.5978342837	miao2	to aim
+2561	幢	3376	98.5995789503	chuang2/zhuang4	(measure word for houses)/tents
+2562	寇	3354	98.6013122477	kou4	bandit
+2563	睹	3346	98.6030414107	du3	observe/see
+2564	贿	3346	98.6047705738	hui4	bribe/bribery
+2565	踩	3343	98.6064981865	cai3	step upon/tread on/stamp
+2566	霆	3342	98.6082252824	ting2	clap of thunder
+2567	呜	3341	98.6099518616	wu1	(onomat. for humming)
+2568	拱	3339	98.6116774071	gong3	fold hands in salute/to arch
+2569	妃	3338	98.6134024359	fei1	imperial concubine
+2570	蔑	3330	98.6151233304	mie4	belittle/nothing
+2571	谕	3330	98.6168442249	yu4	order (from above)
+2572	缚	3326	98.6185630523	fu2/fu4	to bind/to tie
+2573	诡	3323	98.6202803293	gui3	sly/crafty
+2574	篷	3315	98.621993472	peng2	sail
+2575	淹	3315	98.6237066147	yan1	drown/submerge
+2576	腕	3314	98.6254192406	wan4	wrist
+2577	煮	3313	98.6271313498	zhu3	to cook/to boil
+2578	倩	3311	98.6288424254	qian4	niece/plagiarize/winsome
+2579	卒	3306	98.630550917	cu4/zu2	abruptly/hurriedly, die/soldier
+2580	勘	3303	98.6322578583	kan1	to investigate/to survey/to collate
+2581	馨	3281	98.6339534304	xin1	fragrant
+2582	逗	3271	98.6356438345	dou4	linger
+2583	甸	3270	98.6373337219	dian4	imperial domain/suburb
+2584	贱	3270	98.6390236093	jian4	inexpensive/lowly
+2585	炒	3260	98.6407083289	chao3	saute/pan-fry/to fry/fried
+2586	灿	3254	98.6423899477	can4	glorious/bright/brilliant/lustrous/resplendent
+2587	敞	3248	98.6440684658	chang3	spacious/uncovered
+2588	蜡	3246	98.6457459504	la4	candle/wax
+2589	囚	3242	98.6474213678	qiu2	prisoner
+2590	栗	3240	98.6490957516	li4	afraid/trembling, (surname)/chestnut
+2591	辜	3235	98.6507675515	gu1	(surname)/crime/sin
+2592	垫	3233	98.6524383178	dian4	pad/cushion/mat
+2593	妒	3228	98.6541065003	du4	jealous
+2594	魁	3227	98.6557741659	kui2	chief/head
+2595	谣	3219	98.6574376972	yao2	popular ballad/rumor
+2596	寞	3217	98.659100195	mo4	lonesome
+2597	蜀	3208	98.6607580417	shu3	Sichuan
+2598	甩	3208	98.6624158884	shuai3	fling
+2599	涯	3206	98.6640727016	ya2	border/horizon/shore
+2600	枕	3206	98.6657295147	zhen3	pillow
+2601	丐	3201	98.6673837439	gai4	beg for alms/beggar
+2602	泳	3198	98.6690364228	yong3	swimming/to swim
+2603	奎	3194	98.6706870345	kui2	name of constellation/stride
+2604	泌	3192	98.6723366127	bi4/mi4	secrete/pour off
+2605	逾	3189	98.6739846405	yu2	exceed/jump over, to exceed/to go beyond/to jump over
+2606	叮	3188	98.6756321515	ding1	sting (of mosquito)/to ask
+2607	黛	3187	98.6772791457	dai4	umber-black dye for painting the eyebrow
+2608	燥	3171	98.6789178714	zao4	dry/parched/impatient
+2609	掷	3170	98.6805560802	zhi4	toss
+2610	枢	3169	98.6838314644	shu1	hinge/pivot
+2611	憎	3169	98.6854691565	zeng1	detest
+2612	鲸	3158	98.687101164	jing1	whale
+2613	弘	3153	98.6887305875	hong2	great/liberal
+2614	倚	3149	98.6903579439	yi3	to lean on/rely upon
+2615	侮	3144	98.6919827163	wu3	insult
+2616	藩	3138	98.6936043881	fan1	
+2617	拂	3135	98.6952245095	fu2	brush away
+2618	鹤	3133	98.6968435973	he4	crane
+2619	蚀	3131	98.6984616516	shi2	eat up slowly/eclipse
+2620	浆	3130	98.7000791891	jiang1/jiang4	broth/serum/to starch, starch paste
+2621	芙	3130	98.7016967265	fu2	lotus
+2622	垃	3127	98.7033127136	la1	
+2623	烤	3125	98.7049276672	kao3	to roast/bake/to broil
+2624	晒	3124	98.7065421039	shai4	to sun
+2625	霜	3119	98.7081539568	shuang1	frost
+2626	剿	3112	98.7097621921	chao1/jiao3	destroy (bandits), destroy (bandits)
+2627	蕴	3110	98.7113693939	yun4	bring together/collect
+2628	圾	3102	98.7129724614	ji1	
+2629	绸	3098	98.7145734617	chou2	(light) silk
+2630	屿	3098	98.7161744621	yu3	islet
+2631	氢	3092	98.7177723617	qing1	hydrogen
+2632	驼	3084	98.7193661271	tuo2	humpback
+2633	妆	3083	98.7209593756	zhuang1	adornment/adorn
+2634	捆	3079	98.7225505571	kun3	a bunch/tie together/bundle
+2635	铅	3075	98.7241396714	qian1	lead (metal)
+2636	逛	3074	98.7257282689	guang4	to stroll/to visit
+2637	淑	3069	98.7273142824	shu1	
+2638	榴	3068	98.7288997792	liu2	pomegranate
+2639	丙	3055	98.7304785578	bing3	the third of the ten heavenly stems/the third position/third/number three
+2640	痒	3055	98.7320573364	yang3	to itch/to tickle
+2641	钞	3049	98.7336330143	chao1	money/paper money
+2642	蹄	3045	98.735206625	ti2	hoof/pork shoulder
+2643	犬	3042	98.7367786854	quan3	dog
+2644	躬	3037	98.7383481618	gong1	body/oneself/personally/to bow
+2645	昼	3036	98.7399171215	zhou4	daytime
+2646	藻	3035	98.7414855644	zao3	(aquatic grasses)/elegant
+2647	蛛	3033	98.7430529737	zhu1	spider
+2648	褐	3032	98.7446198662	he4	
+2649	颊	3025	98.7461831413	jia2	cheeks
+2650	奠	3020	98.7477438324	dian4	libation
+2651	募	3018	98.7493034899	mu4	canvass for contributions/to recruit/to collect/to raise
+2652	耽	3005	98.7508564292	dan1	indulge/delay
+2653	蹈	3004	98.7524088518	dao3	tread on/trample/stamp/fulfill
+2654	陋	2995	98.7539566233	lou4	low/humble/plain/ugly/mean/vulgar
+2655	侣	2994	98.755503878	lu:3/lv3	companion
+2656	魅	2991	98.7570495823	mei4	demon/magic/to charm
+2657	岚	2988	98.7585937363	lan2	mist/name of a mountain
+2658	侄	2987	98.7601373735	zhi2	nephew, nephew (of the same surname)
+2659	虐	2979	98.7616768764	nue4	oppressive/tyrannical
+2660	堕	2977	98.7632153457	duo4	degenerate/fall
+2661	陛	2976	98.7647532983	bi4	the steps to the throne
+2662	莹	2973	98.7662897005	ying2	luster of gems
+2663	荫	2972	98.7678255859	yin4/yin1	shade
+2664	狡	2971	98.7693609546	jiao3	crafty/cunning/sly
+2665	阀	2970	98.7708958064	fa2	clique/valve
+2666	绞	2963	98.7724270408	jiao3	hang (a criminal)/to turn/to twist/to wind
+2667	膏	2958	98.7739556912	gao1	ointment/paste
+2668	垮	2958	98.7754843416	kua3	collapse
+2669	茎	2956	98.7770119585	jing1	stalk/stem
+2670	缅	2945	98.7785338907	mian3	Burma/distant
+2671	喇	2939	98.7800527222	la1/la3	(onomat.), (phonetic)
+2672	绒	2929	98.7815663859	rong2	velvet/woolen
+2673	搅	2922	98.783076432	jiao3	to disturb/to annoy/to mix/to stir
+2674	凳	2921	98.7845859614	deng4	bench/stool
+2675	梭	2913	98.7860913565	suo1	shuttle
+2676	丫	2912	98.7875962348	ya1	slave girl
+2677	姬	2909	98.7890995628	ji1	(surname)/women
+2678	诏	2907	98.7906018572	zhao4	imperial order
+2679	钮	2906	98.7921036348	niu3	(surname)/button
+2680	棺	2901	98.7936028284	guan1	coffin
+2681	耿	2899	98.7951009885	geng3	(surname)/bright
+2682	缔	2897	98.7965981151	di4	closely joined/connection/knot
+2683	懈	2893	98.7980931745	xie4	lax/negligent
+2684	嫉	2892	98.7995877171	ji2	jealousy/be jealous of
+2685	灶	2891	98.8010817429	zao4	kitchen stove
+2686	匀	2890	98.802575252	yun2	even/evenly (divided)/uniform
+2687	嗣	2889	98.8040682442	si4	to connect, inherit/descendants, heirs
+2688	鸽	2886	98.8055596861	ge1	pigeon/dove
+2689	澡	2882	98.8070490609	zao3	bath
+2690	凿	2880	98.8085374021	zao2/zuo4	chisel, chisel
+2691	纬	2874	98.8100226425	wei3	latitude
+2692	沸	2860	98.811500648	fei4	boil
+2693	畴	2858	98.8129776199	chou2	arable fields/cultivated field/class/category
+2694	刃	2858	98.8144545918	ren4	edge of blade
+2695	遏	2849	98.8159269127	e4	to stop/check
+2696	烁	2847	98.8173982	shuo4	bright/luminous
+2697	嗅	2843	98.8188674201	xiu4	sense of smell
+2698	叭	2842	98.8203361235	ba1	denote a sound or sharp noise (gunfire, etc.)
+2699	熬	2841	98.82180431	ao1/ao2	to boil/stew/to simmer, endure/to boil
+2700	瞥	2840	98.8232719798	pie1	blink/glance
+2701	骸	2836	98.8247375825	hai2	bones of the body
+2702	奢	2835	98.8262026683	she1	extravagant
+2703	拙	2833	98.8276667206	zhuo2/zhuo1	awkward/clumsy/dull/inelegant/(polite) my
+2704	栋	2830	98.8291292225	dong4	roof beam
+2705	毯	2827	98.8305901741	tan3	blanket/rug
+2706	桐	2821	98.832048025	tong2	Aleurites cordata
+2707	砂	2820	98.833505359	sha1	sand/gravel/granule
+2708	莽	2816	98.834960626	mang3	Illicium anisatum/rude
+2709	泻	2816	98.8364158929	xie4	to flow (out) swiftly/diarrhea
+2710	坪	2815	98.8378706431	ping2	a plain
+2711	梳	2806	98.8393207422	shu1	comb
+2712	杉	2805	98.8407703245	sha1/shan1	fir, (pine)
+2713	晤	2805	98.8422199068	wu4	meet (socially)
+2714	稚	2803	98.8436684555	zhi4	infantile/young
+2715	蔬	2799	98.8451149371	shu1	vegetables
+2716	蝇	2761	98.8465417809	ying2	fly/musca
+2717	捣	2753	98.8479644903	dao3	pound/beat/hull/attack/disturb/stir
+2718	顷	2753	98.8493871998	qing3	100 mu/a short while ago/a 'ching' (unit of area)/approx. (with dates)/a short while
+2719	麽	2751	98.8508088757	mo2/me	dimi.
+2720	尴	2748	98.8522290013	gan1	embarrassed/ill at ease
+2721	镖	2744	98.8536470597	biao1	a throwing weapon/dart
+2722	诧	2743	98.8550646013	cha4	surprised/to wander/to be astonished
+2723	尬	2743	98.8564821429	ga4	in an embarrassing situation
+2724	硫	2742	98.8578991678	liu2	sulfur
+2725	嚼	2739	98.8593146422	jiao2/jue2	to chew, to chew
+2726	羡	2739	98.8607301167	xian4	to envy
+2727	沦	2738	98.8621450744	lun2	perish
+2728	沪	2737	98.8635595153	hu4	Shanghai
+2729	旷	2731	98.8649708555	kuang4	waste/wilderness
+2730	彬	2724	98.8663785782	bin1	ornamental/refined
+2731	芽	2717	98.8677826835	ya2	bud/sprout
+2732	狸	2715	98.8691857551	li2	(dog)/wild cat
+2733	冥	2715	98.8705888267	ming2	dark/deep
+2734	碳	2711	98.8719898312	tan4	carbon
+2735	咧	2707	98.8733887686	lie1/lie3	child's cry, draw back corners of mouth
+2736	惕	2698	98.8747830549	ti4	fearful/respectful
+2737	暑	2697	98.8761768244	shu3	heat/hot weather/summer heat
+2738	咯	2694	98.8775690436	ge1/lo/luo4	(phonetic), part. indicating obviousness, cough (blood)/to argue/debate
+2739	萝	2694	98.8789612627	luo2	radish
+2740	汹	2684	98.880348314	xiong1	scared, nervous, torrential rush/tumultuous
+2741	腥	2677	98.8817317478	xing1	fishy (smell)
+2742	窥	2673	98.8831131145	kui1	peep/pry into
+2743	俺	2671	98.8844934476	an3	I (northern dialects)
+2744	潭	2665	98.88587068	tan2	(surname)/deep
+2745	崎	2662	98.887246362	qi2	mountainous
+2746	麟	2659	98.8886204937	lin2	female unicorn
+2747	捡	2653	98.8899915246	jian3	pick up/collect/gather
+2748	拯	2650	98.8913610052	zheng3	to raise/to aid/to support/to save/to rescue
+2749	厥	2650	98.8927304858	jue2	his/its
+2750	澄	2649	98.8940994497	cheng2/deng4	clear and still water, clear/limpid/clarify/purify/(a surname), settle (liquid)
+2751	萎	2647	98.8954673799	wei1/wei3	spiritless/withered, wither
+2752	哉	2647	98.8968353102	zai1	(exclamatory or interrog. part.)
+2753	涡	2644	98.8982016901	guo1/wo1	name of a river, eddy/whirlpool
+2754	滔	2642	98.8995670364	tao1	overflow/torrent-dash
+2755	暇	2641	98.9009318659	xia2	leisure
+2756	溯	2639	98.9022956619	su4	go upstream/trace the source
+2757	鳞	2635	98.9036573907	lin2	scales (of fish)
+2758	酿	2633	98.905018086	niang4	ferment/brew
+2759	茵	2631	98.9063777477	yin1	Skimmia japonica/cushion
+2760	愕	2631	98.9077374094	e4	startled
+2761	瞅	2626	98.9090944871	chou3	to see/look/take a look at
+2762	暮	2626	98.9104515649	mu4	evening/sunset
+2763	衙	2625	98.9118081259	ya2	(surname)/office/yamen
+2764	诫	2614	98.9131590022	jie4	commandment/prohibit
+2765	斧	2598	98.91450161	fu3	hatchet
+2766	兮	2597	98.915843701	xi1	(part.)
+2767	焕	2595	98.9171847584	huan4	brilliant/lustrous
+2768	棕	2590	98.9185232319	zong1	palm
+2769	佑	2589	98.9198611886	you4	bless/protect, protect
+2770	嘶	2587	98.9211981118	si1	hiss/neigh
+2771	妓	2582	98.922532451	ji4	prostitute
+2772	喧	2579	98.9238652398	xuan1	clamor/noise, clamor/noise/deceitful
+2773	蓉	2578	98.9251975119	rong2	lotus
+2774	删	2577	98.9265292672	shan1	to delete
+2775	樱	2572	98.9278584386	ying1	cherry
+2776	伺	2570	98.9291865764	ci4/si4	wait on, to watch/to wait/to examine/to spy
+2777	嗡	2565	98.9305121302	weng1	-oin (chem.) as in anisoin
+2778	娥	2557	98.9318335498	e2	good/beautiful
+2779	梢	2555	98.9331539359	shao1	tip of branch
+2780	坝	2552	98.9344727715	ba4	dam/dyke/embankment
+2781	蚕	2549	98.9357900568	can2	silkworm
+2782	敷	2548	98.9371068253	fu1	announce/apply
+2783	澜	2539	98.9384189428	lan2	swelling water
+2784	杏	2538	98.9397305435	xing4	apricot
+2785	绥	2529	98.9410374931	sui2	pacify
+2786	冶	2525	98.9423423755	ye3	smelt
+2787	庇	2523	98.9436462244	bi4	to protect/cover/shelter/hide or harbor
+2788	挠	2523	98.9449500733	nao2	to scratch
+2789	搂	2512	98.9462482376	lou1/lou3	graft (money)/solicit/to gather/to collect, to hug/to embrace
+2790	倏	2505	98.9475427844	shu1	sudden/abrupt
+2791	聂	2503	98.9488362975	nie4	(surname)/whisper
+2792	婉	2503	98.9501298107	wan3	graceful/tactful
+2793	噪	2501	98.9514222904	zao4	chirp/mixture of voices/noise/buzzing/clamor, disturbance/noise of crowd
+2794	稼	2500	98.9527142532	jia4	sow grain
+2795	鳍	2491	98.954001565	qi2	fins/supporting surfaces
+2796	菱	2489	98.9552878432	ling2	Trapa natans/water caltrop
+2797	盏	2486	98.956572571	zhan3	M for lamp, wine cup
+2798	匿	2479	98.9578536814	ni4	to hide
+2799	吱	2478	98.9591342749	zi1	(phonetic)
+2800	寝	2475	98.9604133181	qin3	lie down
+2801	揽	2474	98.9616918446	lan3	monopolize/seize
+2802	髓	2474	98.962970371	sui3	marrow
+2803	秉	2472	98.9642478638	bing3	(surname)/to grasp/hold/maintain
+2804	哺	2466	98.965522256	bu1/bu3	evening meal, feed
+2805	矢	2466	98.9667966481	shi3	arrow/dart
+2806	啪	2452	98.9680638053	pa1	syllable
+2807	帜	2452	98.9693309624	zhi4	flag
+2808	邵	2445	98.9705945021	shao4	(surname)/place name
+2809	嗽	2438	98.9718544242	sou4	cough
+2810	挟	2438	98.9731143464	jia1/xie2	hold between, clasp under the arm/coerce
+2811	缸	2437	98.9743737518	gang1	jar/vat
+2812	揉	2427	98.9756279893	rou2	knead/massage/rub
+2813	腻	2425	98.9768811932	ni4	greasy/tired of
+2814	驯	2423	98.9781333636	xun2/xun4	attain gradually/tame
+2815	缆	2410	98.9793788158	lan4/lan3	cable/hawser
+2816	晌	2401	98.9806196169	shang3	around noon
+2817	瘫	2399	98.9818593844	tan1	paralyzed
+2818	贮	2398	98.9830986352	zhu4	to store/to save/stockpile
+2819	觅	2396	98.9843368524	mi4	seek
+2820	朦	2394	98.985574036	meng2	deceive/indistinct
+2821	僻	2391	98.9868096692	pi4	low/rustic/secluded
+2822	隋	2391	98.9880453025	sui2	name of a dynasty
+2823	蔓	2390	98.989280419	man2/man4	Brassica campestris, creeper/to spread
+2824	咋	2389	98.9905150187	ze2/zha4/za3	gnaw, loud noise/shout/suddenly
+2825	嵌	2387	98.9917485848	qian4	deep valley/inlay
+2826	虔	2380	98.9929785334	qian2	devout
+2827	畔	2378	98.9942074484	pan4	bank/field-path
+2828	琐	2377	98.9954358467	suo3	fragmentary/trifling
+2829	碟	2375	98.9966632114	die2	dish/plate
+2830	涩	2373	98.9978895425	se4	grating (of surfaces)/tart/acerbic
+2831	胧	2365	98.9991117394	long2	rising moon, hazy/unclear
+2832	嘟	2360	99.0003313523	du1	toot/honk
+2833	蹦	2358	99.0015499316	beng4	to jump/bounce or hop
+2834	冢	2357	99.0027679942	zhong3	great/mound, mound
+2835	浏	2355	99.0039850232	liu2	clear/deep (of water)/swift
+2836	裔	2350	99.0051994683	yi4	descendents/frontier
+2837	襟	2346	99.0064118462	jin1	overlapping part of Chinese gown
+2838	叨	2344	99.0076231905	dao1/tao1	grumble/garrulous, be in receipt of
+2839	诀	2341	99.0088329845	jue2	farewell/secrets (of an art)
+2840	旭	2341	99.0100427785	xu4	dawn/rising sun
+2841	虾	2338	99.0112510222	xia1	shrimp/prawn
+2842	簿	2333	99.0124566819	bu4	a book/a register/account-book
+2843	啤	2332	99.0136618248	pi2	beer
+2844	擒	2328	99.0148649006	qin2	capture
+2845	枣	2319	99.0160633254	zao3	jujube
+2846	嘎	2307	99.0172555487	ga2/ga1	cackling sound
+2847	苑	2303	99.0184457048	yuan4	(surname)/park
+2848	牟	2299	99.0196337939	mou2	barley/to moo/usurp
+2849	呕	2292	99.0208182654	ou3	vomit
+2850	骆	2290	99.0220017033	luo4	camel
+2851	凸	2287	99.0231835909	tu1	(adj) convex; stick out
+2852	熄	2284	99.0243639282	xi1	(v) extinguish; quench/go out (of fire)
+2853	兀	2283	99.0255437487	wu4/wu1	(surname)/cut off the feet/rising to a height; towering/bald
+2854	喔	2276	99.0267199516	o1/wo1	I see/oh
+2855	裳	2274	99.027895121	chang2/shang	lower garment/skirts/petticoats/garments
+2856	凹	2273	99.0290697736	ao1	a depression/indentation/concave/hollow
+2857	赎	2271	99.0302433927	shu2	redeem/to ransom
+2858	屯	2268	99.0314154614	tun2/zhun1	to station (soldiers)/to store up, difficult/stingy
+2859	膛	2266	99.0325864965	tang2	chest (of body)/hollow space/throat
+2860	浇	2265	99.0337570148	jiao1	to water
+2861	灼	2262	99.0349259828	zhuo2	brilliant/cauterize
+2862	裘	2262	99.0360949508	qiu2	(surname)/fur/fur coat
+2863	砰	2261	99.0372634019	peng1	sound of crashing/thunder
+2864	棘	2256	99.0384292692	ji2	thorns
+2865	橡	2251	99.0395925525	xiang4	oak/Quercus serrata
+2866	碱	2250	99.0407553191	jian3	alkali/soda
+2867	聋	2250	99.0419180856	long2	deaf
+2868	姥	2249	99.0430803354	lao3/mu3	grandma (maternal), governess/old woman
+2869	瑜	2239	99.0442374173	yu2	excellence/luster of gems
+2870	毋	2232	99.0453908818	wu2	no/not
+2871	娅	2230	99.0465433126	ya4	address term between sons-in-law
+2872	沮	2229	99.0476952267	ju3	destroy/to stop
+2873	萌	2229	99.0488471407	meng2	people/sprout
+2874	俏	2229	99.0499990548	qiao4	smart
+2875	黯	2221	99.0511468346	an4	deep black/dark
+2876	撇	2219	99.0522935808	pie1/pie3	cast away, (downwards-left curved character stroke)/throw
+2877	粟	2219	99.053440327	su4	grain/millet
+2878	粪	2217	99.0545860397	fen4	manure/dung
+2879	尹	2217	99.0557317523	yin3	(surname)/to rule
+2880	苟	2213	99.0568753978	gou3	(surname)/if indeed/thoughtless
+2881	癫	2210	99.0580174929	dian1	convulsions/crazy
+2882	蚂	2206	99.059157521	ma1/ma3/ma4	dragonfly, ant, grasshopper
+2883	禹	2199	99.0602939315	yu3	name of an emperor
+2884	廖	2197	99.0614293084	liao4	(surname)
+2885	俭	2193	99.0625626182	jian3	frugal/to be in need
+2886	帖	2191	99.0636948944	tie1/tie3/tie4	fit snugly, invitation card/notice, rubbing from incised inscription
+2887	煎	2183	99.0648230364	jian1	pan-fry
+2888	缕	2181	99.0659501448	lu:3/lv3	state in detail/strand/thread
+2889	窦	2181	99.0670772531	dou4	(surname)/sinus (anatom.)
+2890	簇	2173	99.0682002272	cu4	crowded/frame work for silkworms/gather foliage/a measure word/bunch
+2891	棱	2168	99.0693206174	leng2	corner/square beam
+2892	叩	2165	99.0704394572	kou4	knock
+2893	呐	2163	99.0715572635	na4/ne/na	battle cry, (final part.)
+2894	瑶	2153	99.0726699019	yao2	(jade)/Yao/mother-of-pearl
+2895	墅	2152	99.0737820235	shu4	villa
+2896	莺	2152	99.0748941451	ying1	golden oriole
+2897	烫	2149	99.0760047163	tang4	to scald/to burn/to iron/hot
+2898	蛙	2149	99.0771152876	wa1	frog
+2899	歹	2148	99.0782253421	dai3	bad/wicked/evil
+2900	伶	2148	99.0793353965	ling2	clever
+2901	葱	2147	99.0804449342	cong1	scallion/green onion
+2902	哮	2146	99.0815539551	xiao1	pant/roar/bark (of animals)
+2903	眩	2145	99.0826624592	xuan4	dizzy/dazzled
+2904	坤	2141	99.0837688962	kun1	the earth-/female-principle
+2905	廓	2141	99.0848753332	kuo4	big/empty/open
+2906	讳	2139	99.0859807366	hui4	avoid mentioning/to taboo
+2907	啼	2138	99.0870856232	ti2	mourn/to cry/hoof
+2908	乍	2131	99.0881868923	zha4	for the first time/suddenly
+2909	瓣	2127	99.0892860943	ban4	petal/section
+2910	矫	2126	99.0903847795	jiao3	dissemble/rectify
+2911	跋	2124	99.0914824311	ba2	travel/walk
+2912	枉	2124	99.0925800828	wang3	in the wrong/in vain
+2913	梗	2121	99.093676184	geng3	stem
+2914	厕	2118	99.0947707349	ce4	rest-room/toilet/lavatory
+2915	琢	2117	99.0958647691	zhuo2	to cut (gems)
+2916	讥	2114	99.0969572528	ji1	ridicule
+2917	釉	2113	99.0980492198	you4	glaze (of porcelain)
+2918	窟	2109	99.0991391197	ku1	cave/hole
+2919	敛	2107	99.100227986	lian3	arrange/control oneself/gather
+2920	轼	2100	99.1013132347	shi4	crossbar in carriage front
+2921	庐	2097	99.1023969332	lu2	hut
+2922	胚	2093	99.1034785645	pei1	fetus
+2923	呻	2092	99.104559679	shen1	groan
+2924	绰	2089	99.1056392431	chuo4/chao1	generous/ample/wide/spacious/well-off
+2925	扼	2087	99.1067177737	e4	hold (strategic position)
+2926	懿	2086	99.1077957875	yi4	restrain/virtuous
+2927	炯	2084	99.1088727677	jiong3	bright/clear
+2928	竿	2083	99.1099492311	gan1	pole
+2929	慷	2078	99.1110231106	kang1	generous/magnanimous
+2930	虞	2072	99.1120938894	yu2	forewarned/peace/worry
+2931	锤	2071	99.1131641515	chui2	to hammer/weight of steel yard
+2932	栓	2068	99.1142328631	shuan1	bottle stopper/wooden pin/plug
+2933	桨	2067	99.115301058	jiang3	oar/paddle
+2934	蚊	2065	99.1163682193	wen2	mosquito
+2935	磅	2064	99.1174348638	bang4/pang2	a measure word/pound (unit of measurement)/scale/weigh
+2936	孽	2063	99.1185009915	nie4	consequence of sin
+2937	惭	2062	99.1195666025	can2	ashamed
+2938	戳	2051	99.1206265288	chuo1	poke/pierce/prick/wooden or rubber stamp or seal
+2939	禀	2048	99.1216849048	bing3	natural property or endowment/report to (a superior)
+2940	鄂	2047	99.1227427639	e4/E4	hupeh
+2941	馈	2032	99.1237928713	kui4	food/make a present
+2942	垣	2030	99.1248419451	yuan2	wall
+2943	溅	2019	99.1258853343	jian4	splash
+2944	咚	2019	99.1269287235	dong1	boom (of a drum)
+2945	钙	2017	99.1279710791	gai4	calcium
+2946	礁	2017	99.1290134347	jiao1	reef/shoal rock
+2947	彰	2014	99.13005424	zhang1	manifest
+2948	豁	2013	99.1310945285	hua2/huo1/huo4	play Chinese finger game, opening/stake all/sacrifice/crack/slit, clear/open/exempt (from)/liberal-minded
+2949	眯	2013	99.132134817	mi1/mi3	to squint, blind (as with dust)
+2950	磷	2012	99.1331745887	lin2	phosphorus/water in rocks
+2951	雯	2012	99.1342143603	wen2	multicolored clouds
+2952	墟	2010	99.1352530985	xu1	old burial grounds
+2953	迂	2007	99.1362902862	yu1	literal-minded
+2954	瞻	2005	99.1373264404	zhan1	gaze/view
+2955	颅	2004	99.1383620778	lu2	forehead/skull
+2956	琉	2000	99.1393956481	liu2	precious stone
+2957	悼	1997	99.140427668	dao4	mourn/lament
+2958	蝴	1991	99.1414565872	hu2	butterfly
+2959	拣	1981	99.1424803386	jian3	choose/pick up
+2960	渺	1980	99.1435035731	miao3	vague/remote
+2961	眷	1973	99.1445231902	juan4	concern/wife and children
+2962	悯	1970	99.1455412569	min3	sympathize/to pity
+2963	汰	1968	99.1465582901	tai4	to discard/to eliminate/too
+2964	慑	1966	99.1475742896	she4	afraid/be feared/to fear/to frighten/to intimidate
+2965	婶	1965	99.1485897724	shen3	wife of father's younger brother
+2966	斐	1963	99.1496042217	fei3	(phonetic)/(surname)/elegant
+2967	嘘	1958	99.1506160869	xu1	exhale/hiss
+2968	镶	1950	99.151623818	xiang1	to inlay/to embed/ridge/border
+2969	炕	1949	99.1526310322	kang4	kang (a heatable brick bed)
+2970	宦	1948	99.1536377296	huan4	an official
+2971	趴	1942	99.1546413264	pa1	to lie on one's stomach
+2972	绷	1941	99.1556444063	beng1/beng3	to stretch/taut/to tie/to bind, to have a taut face
+2973	窘	1935	99.1566443855	jiong3	distressed/embarrassed
+2974	襄	1934	99.157643848	xiang1	assist
+2975	珀	1932	99.1586422769	po4	amber
+2976	嚣	1930	99.1596396722	xiao1	clamor
+2977	拚	1929	99.1606365507	pan4/pin1	disregard/reject, stake all
+2978	酌	1928	99.1616329124	zhuo2	consider/pour wine
+2979	浊	1924	99.162627207	zhuo2	impure/muddy
+2980	毓	1924	99.1636215016	yu4	nourish/rear
+2981	撼	1922	99.1646147627	han4	shake/to incite
+2982	嗜	1922	99.1656080237	shi4	addicted to/fond of
+2983	扛	1921	99.1666007679	gang1/kang2	lift overhead with both hands, carry on one's shoulder
+2984	峭	1918	99.1675919618	qiao4	steep hill
+2985	磕	1909	99.1685785047	ke1	to tap/knock
+2986	翘	1909	99.1695650475	qiao2/qiao4	outstanding/to raise
+2987	槽	1908	99.1705510735	cao2	manger/trough/groove
+2988	淌	1906	99.171536066	tang3	drip/to shed (tears)
+2989	栅	1906	99.1725210585	zha4/shan1	fence
+2990	颓	1900	99.1735029502	tui2	become bald/decadent
+2991	熏	1900	99.174484842	xun1	to smoke/scent/fumigate
+2992	瑛	1900	99.1754667337	ying1	(crystal)/lustrous
+2993	颐	1890	99.1764434576	yi2	cheeks/nourish
+2994	忖	1890	99.1774201815	cun3	ponder/consider/guess
+2995	牡	1889	99.1783963886	mu3	male
+2996	缀	1887	99.1793715622	zhui4	
+2997	徊	1885	99.1803457022	huai2	irresolute/move back and forth
+2998	梨	1884	99.1813193254	li2	pear
+2999	肪	1882	99.182291915	fang2	animal fat
+3000	涕	1880	99.183263471	ti4	nasal mucus/tears
+3001	惫	1879	99.1842345103	bei4	exhausted
+3002	摹	1879	99.1852055496	mo2	imitate/copy
+3003	踱	1878	99.1861760721	duo2	
+3004	肘	1877	99.1871460778	zhou3	elbow/pork shoulder
+3005	熔	1873	99.1881140163	rong2	to smelt/fuse
+3006	挚	1873	99.1890819549	zhi4	(surname)/sincere
+3007	氯	1872	99.1900493766	lu:4/lv4	chlorine
+3008	凛	1870	99.1910157649	lin3	shiver with cold or fear
+3009	绎	1870	99.1919821531	yi4	continuous/explain/unravel
+3010	庶	1863	99.1929449238	shu4	ordinary
+3011	脯	1860	99.1939061441	fu3/pu2	candied fruit, chest (thorax)
+3012	迭	1859	99.1948668477	die2	alternately/repeatedly
+3013	睦	1859	99.1958275512	mu4	friendly
+3014	窍	1856	99.1967867044	qiao4	intelligence/opening
+3015	粥	1854	99.1977448241	zhou1	congee/gruel/porridge
+3016	庵	1851	99.1987013934	an1	hut/Buddhist convent/small Buddhist temple
+3017	沧	1848	99.1996564123	cang1	blue/green(color of water)/cold/vast (of water)
+3018	怠	1847	99.2006109144	dai4	idle/lazy/negligent/careless
+3019	沁	1847	99.2015654166	qin4	name of a river
+3020	奕	1847	99.2025199187	yi4	abundant/graceful
+3021	咙	1845	99.2034733873	long2	throat
+3022	氨	1843	99.2044258223	an1	ammonia
+3023	矗	1843	99.2053782573	chu4	lofty/upright
+3024	盔	1842	99.2063301755	kui1	helmet
+3025	拇	1839	99.2072805434	mu3	thumb
+3026	沛	1834	99.2082283273	pei4	copious/abundant
+3027	榻	1832	99.2091750777	ta4	couch
+3028	揣	1829	99.2101202777	chuai1/chuai3	put into, estimate/guess/figure/surmise
+3029	崭	1827	99.2110644442	zhan3	precipitous peak
+3030	鞘	1825	99.212007577	qiao4	scabbard/sheath
+3031	鞠	1821	99.2129486428	ju1	to bring up/to rear/Ju (a surname)
+3032	垦	1819	99.2138886749	ken3	reclaim (land)
+3033	洽	1809	99.2148235392	qia4	accord/make contact
+3034	唾	1809	99.2157584035	tuo4	saliva/spit at
+3035	橱	1806	99.2166917175	chu2	a wardrobe/case/cabinet
+3036	仕	1805	99.2176245146	shi4	an official
+3037	蜘	1804	99.218556795	zhi1	spider
+3038	痰	1791	99.2194823572	tan2	phlegm/spittle
+3039	袜	1790	99.2204074026	wa4	socks/stockings
+3040	峙	1784	99.2213293473	zhi4	peak/to store
+3041	柬	1772	99.2222450905	jian3	card/note/letter
+3042	蝉	1771	99.223160317	chan2	cicada
+3043	蟹	1771	99.2240755435	xie4	crab
+3044	谏	1769	99.2249897364	jian4	admonish
+3045	鹃	1768	99.2259034125	juan1	cuckoo
+3046	擎	1768	99.2268170886	qing2	to raise (hand)
+3047	皓	1767	99.227730248	hao4	bright/d (19th)/white
+3048	朕	1766	99.2286428905	zhen4	I/we (imperial use)/subtle
+3049	疤	1765	99.2295550163	ba1	scar
+3050	禺	1757	99.2304630078	yu2	(place)/district
+3051	铲	1756	99.2313704824	chan3	level off/root up, spade/shovel
+3052	酶	1755	99.2322774404	mei2	enzyme/ferment
+3053	钝	1752	99.2331828479	dun4	blunt/stupid
+3054	氓	1747	99.2340856715	mang2/meng2	vagrant/ruffian, people
+3055	匣	1747	99.2349884952	xia2	box
+3056	弧	1742	99.2358887349	hu2	arc
+3057	峨	1740	99.236787941	e2	lofty/name of a mountain
+3058	锥	1738	99.2376861136	zhui1	awl/to bore
+3059	揪	1735	99.2385827358	jiu1	to clutch
+3060	杠	1732	99.2394778076	gang1/gang4	footbridge, carrying pole/horizontal bar
+3061	吭	1731	99.2403723627	hang2/keng1	throat
+3062	崛	1731	99.2412669178	jue2	towering as a peak
+3063	诬	1725	99.2421583721	wu1	accuse falsely
+3064	冉	1724	99.2430493097	ran3	(surname)/passing (of time)
+3065	抒	1724	99.2439402473	shu1	to strain/pour out
+3066	庚	1719	99.2448286009	geng1	7th heavenly stem/age
+3067	悍	1715	99.2457148874	han4	violent
+3068	靡	1715	99.2466011739	mi2/mi3	wasted, extravagant/go with fashion/not
+3069	晦	1714	99.2474869437	hui4	dark/night/unlucky
+3070	醋	1712	99.2483716798	cu4	vinegar
+3071	壕	1709	99.2492548656	hao2	air-raid shelter/trench
+3072	锯	1709	99.2501380514	ju1/ju4	to mend (china) with staples, a saw/to saw
+3073	夭	1709	99.2510212372	yao1	tender/gentle/to die prematurely
+3074	咦	1704	99.2519018391	yi2	expression of surprise
+3075	侈	1703	99.2527819241	chi3	extravagant/wasteful/exaggerating
+3076	婢	1698	99.2536594253	bi4	slave girl/maid servant
+3077	猾	1697	99.2545364097	hua2	sly
+3078	徘	1695	99.2554123605	pai2	irresolute
+3079	硝	1695	99.2562883113	xiao1	saltpeter/to tan (leather)
+3080	煽	1694	99.2571637453	shan1	fan into a flame/incite
+3081	皂	1691	99.258037629	zao4	black
+3082	舵	1689	99.2589104791	duo4	helm/rudder
+3083	嗦	1689	99.2597833292	suo1	suck
+3084	狈	1688	99.2606556625	bei4	a legendary wolf/distressed/wretched
+3085	靴	1688	99.2615279958	xue1	boots
+3086	捂	1687	99.2623998123	wu3	resist, (v) seal up; muffle
+3087	疮	1681	99.2632685281	chuang1	sore/skin ulcer
+3088	郝	1681	99.2641372439	hao3	(surname)/ancient place name
+3089	苛	1679	99.2650049262	ke1	severe/exacting
+3090	秽	1676	99.265871058	hui4	dirt/filth
+3091	茜	1675	99.2667366731	qian4	Rubia cordiolia
+3092	搓	1673	99.2676012547	cuo1	to rub or roll between the hands or fingers/to twist
+3093	芸	1671	99.2684648026	yun2	Ruta graveolens
+3094	酱	1668	99.2693268002	jiang4	jam/thick sauce
+3095	赁	1668	99.2701887978	lin4	to rent
+3096	檐	1667	99.2710502787	yan2	eaves
+3097	饷	1664	99.2719102091	xiang3	soldier's pay
+3098	蕉	1663	99.2727696228	jiao1	banana
+3099	铀	1661	99.2736280029	you2	uranium
+3100	苔	1660	99.2744858662	tai1/tai2	coating (of tongue), moss
+3101	赦	1659	99.2753432128	she4	to pardon (a convict)
+3102	缎	1658	99.2762000425	duan4	satin
+3103	舷	1654	99.2770548051	xian2	sides of boat
+3104	筷	1652	99.2779085342	kuai4	chopstick
+3105	朔	1645	99.2787586457	shuo4	beginning/first day of lunar month
+3106	婪	1642	99.2796072069	lan2	avaricious
+3107	紊	1639	99.2804542178	wen3/wen4	involved/tangled/disorder, involved/tangled
+3108	厮	1636	99.2812996782	si1	
+3109	婿	1635	99.2821446219	xu4	son-in-law
+3110	寥	1633	99.2829885321	liao2	empty/lonesome/very few
+3111	兢	1632	99.2838319254	jing1	to be fearful/apprehensive
+3112	糙	1631	99.2846748019	cao1	rough/coarse (in texture)
+3113	卦	1628	99.2855161281	gua4	divinatory trigram
+3114	槐	1627	99.2863569376	huai2	Sophora japonica
+3115	扒	1623	99.2871956798	ba1/pa2	climb/pull (out)/to strip/hold on to/cling to/dig up/rake/push aside, climb/crawl/snatch
+3116	裴	1622	99.2880339053	pei2	(surname)
+3117	祀	1621	99.288871614	si4	offer sacrifice to
+3118	埔	1618	99.2897077724	pu3	port
+3119	絮	1617	99.2905434139	xu4	line with cotton wadding
+3120	芭	1615	99.2913780219	ba1	a herb/banana
+3121	屉	1612	99.2922110796	ti4	drawer/tier/tray
+3122	痪	1611	99.2930436204	huan4	illness/numbness of the limbs
+3123	霄	1611	99.2938761613	xiao1	firmament/heaven
+3124	绽	1607	99.294706635	zhan4	ripped seam
+3125	宵	1604	99.2955355583	xiao1	night
+3126	邑	1604	99.2963644817	yi4	city
+3127	霖	1602	99.2971923715	lin2	continued rain
+3128	岔	1599	99.2980187109	cha4	branch in a road/astray/diverge
+3129	饵	1596	99.2988435	er3	bait/cakes
+3130	茄	1596	99.2996682891	qie2	eggplant
+3131	韧	1593	99.3004915278	ren4	annealed/pliable but strong/tough/tenacious
+3132	琪	1592	99.3013142497	qi2	(white gem)/angel
+3133	邹	1591	99.3021364549	zou1	(surname)/name of district in Shandong
+3134	瑚	1590	99.3029581432	hu2	coral
+3135	憋	1588	99.303778798	bie1	hold in (urine)/to hold (breath)/to choke/stifle/restrain/hold back
+3136	殆	1588	99.3045994528	dai4	dangerous/perilous/endanger/almost/probably/only
+3137	噜	1587	99.3054195908	lu1	grumble/chatter
+3138	忒	1579	99.3062355945	te4/tui1	excessive/to change
+3139	忿	1578	99.3070510815	fen4	vehement
+3140	衅	1578	99.3078665684	xin4	offer blood in sacrifice
+3141	淳	1577	99.3086815386	chun2	genuine/pure/honest
+3142	悖	1576	99.309495992	bei4	perverse/rebellious/to rebel
+3143	髦	1575	99.3103099286	mao2	bang (hair)/fashionable/mane
+3144	孜	1573	99.3111228316	zi1	hard-working/industrious
+3145	粤	1572	99.3119352178	yue4	Cantonese/Guangdong
+3146	隘	1570	99.3127465705	ai4	a pass or defile/narrow/confined/in distress
+3147	濒	1569	99.3135574063	bin1	near
+3148	铮	1565	99.3143661751	zheng1	clang of metals/small gong
+3149	畸	1562	99.3151733935	ji1	fractional remains/odd
+3150	剔	1559	99.3159790615	ti1	pick (as teeth)
+3151	坞	1559	99.3167847295	wu4	dock/low wall
+3152	篱	1558	99.3175898807	li2	a fence
+3153	淀	1557	99.3183945152	dian4	shallow water, sediment/precipitate
+3154	蓦	1555	99.3191981161	mo4	leap on or over/suddenly
+3155	唬	1554	99.3200012002	hu3	intimidate/tiger's roar/to fool
+3156	锣	1552	99.3208032507	luo2	gong
+3157	汀	1552	99.3216053012	ting1	sand-bank
+3158	趾	1552	99.3224073518	zhi3	toe
+3159	缉	1549	99.3232078519	qi1/ji1	to stitch finely
+3160	嫦	1549	99.3240083521	chang2	a legendary beauty who flew to the moon/the lady in the moon
+3161	斟	1547	99.3248078187	zhen1	pour/to deliberate
+3162	鞍	1545	99.3256062518	an1	saddle
+3163	扳	1540	99.3264021009	ban1/pan1	to pull or draw (up or out), climb up/pull
+3164	拴	1537	99.3271963996	shuan1	tie up
+3165	诅	1535	99.3279896648	zu3	curse/swear (oath)
+3166	谟	1534	99.3287824132	mo2	plan/to practice
+3167	呃	1532	99.329574128	e4/e	hiccough
+3168	懦	1531	99.3303653261	nuo4	imbecile/timid
+3169	逞	1530	99.3311560073	cheng3	please oneself/presume on/boast
+3170	犁	1530	99.3319466886	li2	plow
+3171	忏	1530	99.3327373698	chan4	feel remorse/regret/repent
+3172	拧	1529	99.3335275343	ning2/ning3/ning4	to pinch/wring, mistake/to twist, stubborn
+3173	亥	1528	99.334317182	hai4	12th earthly branch/9-11 p.m.
+3174	佟	1528	99.3351068297	tong2	(surname)
+3175	叱	1528	99.3358964774	chi4	to scold/shout at/to hoot at
+3176	舜	1527	99.3366856083	shun4	name of an emperor
+3177	绊	1525	99.3374737056	ban4	to trip/stumble/hinder
+3178	龚	1525	99.3382618029	gong1	(surname)
+3179	腮	1522	99.3390483499	sai1	gills/lower part of cheeks
+3180	邸	1521	99.3398343801	di3	(surname)/lodging-house
+3181	椒	1518	99.3406188599	jiao1	pepper
+3182	蔚	1518	99.3414033397	wei4/yu4	Artemisia japonica/luxuriant, (surname)/place name
+3183	湛	1514	99.3421857524	zhan4	deep/clear (water)
+3184	狩	1514	99.3429681651	shou4	hunting-dog/imperial tour
+3185	眶	1511	99.3437490275	kuang4	eye socket
+3186	栈	1507	99.3445278227	zhan4	warehouse
+3187	薇	1504	99.3453050675	wei1	
+3188	肮	1499	99.3460797284	ang1	filthy, dirty/filthy
+3189	瀑	1497	99.3468533558	bao4/pu4	shower (rain), waterfall
+3190	渣	1495	99.3476259496	zha1	dregs
+3191	褂	1493	99.3483975098	gua4	coat
+3192	叽	1492	99.3491685532	ji1	grumble
+3193	臀	1489	99.3499380462	tun2	butt/buttocks
+3194	妞	1487	99.3507065057	niu1	little girl
+3195	巍	1485	99.3514739317	wei1	high/lofty/towering/majestic
+3196	唔	1481	99.3522392905	en2	
+3197	疚	1480	99.3530041325	jiu4	chronic disease
+3198	鲤	1479	99.3537684577	li3	carp
+3199	戎	1479	99.3545327829	rong2	(surname)/weapon
+3200	肇	1478	99.3552965913	zhao4	at first/devise/originate
+3201	笃	1473	99.3560578158	du3	serious (illness)/sincere/true
+3202	辙	1466	99.3568154228	che4/zhe2	to remove/to withdraw, rut/track
+3203	娴	1466	99.3575730298	xian2	elegant/refined
+3204	阮	1465	99.35833012	ruan3	Ruan (a surname)
+3205	札	1465	99.3590872103	zha2	write down, short note
+3206	懊	1462	99.3598427501	ao4	to regret
+3207	焘	1461	99.3605977732	dao4/tao1	cover over/to envelope
+3208	恤	1459	99.3613517627	xu4	give relief/sympathy
+3209	疹	1458	99.3621052355	zhen3	measles/rash
+3210	潇	1457	99.3628581914	xiao1	river name/sound of rain and wind
+3211	铝	1453	99.3636090802	lu:3/lv3	aluminum
+3212	涤	1452	99.3643594522	di2	wash/cleanse
+3213	恃	1445	99.3651062067	shi4	rely upon
+3214	喽	1445	99.3658529613	lou2/lou	subordinates in gang of bandits, (part. expressing chagrin or resentment)
+3215	砌	1442	99.3665981654	qi4	to build by laying bricks or stones
+3216	遁	1436	99.3673402689	dun4	disappear/to escape
+3217	楞	1436	99.3680823723	leng2	corner/square beam
+3218	阱	1433	99.3688229254	jing3	hole/pitfall
+3219	咎	1431	99.369562445	jiu4	blame
+3220	洼	1430	99.3703014477	wa1	winding ditch, depression/sunken/swamp
+3221	炳	1429	99.3710399337	bing3	bright/brilliant/luminous
+3222	噬	1419	99.3717732518	shi4	devour/to bite
+3223	枫	1418	99.3725060531	feng1	maple
+3224	拷	1418	99.3732388544	kao3	to beat/to flog/to examine by torture
+3225	哆	1417	99.3739711389	duo1	quiver/woolen cloth
+3226	矶	1417	99.3747034235	ji1	breakwater/jetty
+3227	苇	1416	99.3754351912	wei3	reed/rush/Phragmites communis
+3228	翩	1414	99.3761659254	pian1	fly fast
+3229	窒	1413	99.3768961428	zhi4	obstruct/stop up
+3230	侬	1412	99.3776258434	nong2	you (Shanghai dial.)
+3231	靶	1411	99.3783550272	ba3	target/mark
+3232	胰	1411	99.3790842111	yi2	soap
+3233	芜	1409	99.3798123613	wu2	overgrown with weeds
+3234	辫	1408	99.3805399948	bian4	a braid or queue/to plait
+3235	嚎	1408	99.3812676283	hao2	howl/bawl
+3236	妾	1408	99.3819952617	qie4	concubine
+3237	幌	1403	99.3827203113	huang3	advertising sign
+3238	踉	1403	99.3834453608	liang2/liang4	jump, stagger/sway from side to side
+3239	佃	1401	99.3841693768	dian4	farmer
+3240	葫	1399	99.3848923592	hu2	Allium scorodoprasum/bottle gourd
+3241	皖	1396	99.3856137912	wan3	Anhui
+3242	拽	1396	99.3863352233	ye4/zhuai1/zhuai4	drag, throw, drag
+3243	滤	1394	99.3870556218	lu:4/lv4	to strain/to filter
+3244	睬	1392	99.3877749867	cai3	pay attention/take notice of/to care for
+3245	俞	1388	99.3884922844	yu2	(surname)/accede
+3246	匕	1388	99.3892095822	bi1/bi3	an ancient type of spoon, dagger/ladle
+3247	谤	1387	99.3899263632	bang4	to slander/defame/speak ill of
+3248	嗤	1387	99.3906431442	chi1	laugh at/jeer/scoff at/sneer at
+3249	捍	1385	99.3913588916	han4	ward off (a blow)
+3250	孵	1383	99.3920736054	fu1	hatch
+3251	倪	1380	99.3927867689	ni2	(surname)
+3252	瘾	1379	99.3934994156	yin3	addiction/craving
+3253	敝	1378	99.3942115455	bi4	my (polite)/poor/ruined/shabby/worn out/defeated
+3254	匡	1378	99.3949236754	kuang1	correct
+3255	磋	1377	99.3956352886	cuo1	deliberate/to polish
+3256	绫	1377	99.3963469017	ling2	damask/thin silk
+3257	淆	1375	99.3970574813	xiao2	
+3258	尧	1375	99.3977680608	yao2	(surname)/emperor Yao
+3259	蕊	1373	99.3984776068	rui3	stamen/pistil
+3260	烘	1371	99.3991861192	hong1	bake/heat by fire
+3261	璋	1371	99.3998946316	zhang1	ancient stone ornament
+3262	亢	1367	99.4006010769	kang4	overbearing
+3263	轧	1367	99.4013075222	ya4/zha2	crush/in the first place
+3264	赂	1362	99.4020113836	lu4	bribe/bribery
+3265	蝗	1360	99.4027142113	huang2	locust
+3266	榆	1360	99.4034170391	yu2	elm
+3267	骏	1358	99.4041188333	jun4	spirited horse
+3268	诛	1358	99.4048206275	zhu1	execute/punish
+3269	勺	1357	99.405521905	shao2	spoon
+3270	梵	1355	99.4062221488	fan4	Brahma/Sanskrit
+3271	炽	1354	99.4069218759	chi4	flame/blaze
+3272	笠	1354	99.407621603	li4	bamboo rain hat
+3273	颌	1353	99.4083208133	he2	maxilla and mandible
+3274	闸	1352	99.4090195068	zha2	gear/watergate
+3275	狒	1349	99.4097166499	fei4	hamadryad baboon
+3276	樊	1346	99.4104122427	fan2	(surname)/cage/fence
+3277	镕	1342	99.4111057684	rong2	
+3278	垢	1341	99.4117987772	gou4	dirt/disgrace
+3279	瘟	1341	99.4124917861	wen1	epidemic/pestilence/plague
+3280	缪	1341	99.413184795	miao4/mou2	(surname), to wind round
+3281	菇	1339	99.4138767702	gu1	mushroom
+3282	琦	1338	99.4145682288	qi2	curio/valuable stone
+3283	剃	1337	99.4152591705	ti4	shave, shave/to weed
+3284	迸	1329	99.4159459779	beng4	to burst forth/to spurt/to crack/split
+3285	溺	1329	99.4166327854	ni4/niao4	drown/indulge/be addicted to/spoil (a child), urinate/urine
+3286	炫	1329	99.4173195928	xuan4	dazzle/to show off, to boast/to show off
+3287	惚	1327	99.4180053667	hu1	indistinct
+3288	嗨	1326	99.4186906238	hai1/hei1	oh alas
+3289	陨	1324	99.4193748473	yun3	fall/meteor/perish
+3290	赃	1321	99.4200575205	zang1	booty/spoils
+3291	羁	1320	99.4207396768	ji1	halter/restrain
+3292	臻	1318	99.4214207996	zhen1	to reach/utmost
+3293	嘀	1318	99.4221019225	di2/di1	backbite
+3294	膳	1315	99.4227814949	shan4	meals
+3295	赣	1312	99.423459517	gan4	Jiangxi
+3296	踌	1310	99.4241365055	chou2	pace back and forth/hesitate/waver
+3297	殉	1310	99.4248134941	xun4	buried with dead/die for a cause
+3298	桔	1309	99.4254899658	jie2/ju2	Platycodon grandiflorus, tangerine
+3299	瞿	1309	99.4261664375	ju4/qu2	startled, (surname)
+3300	闽	1307	99.4268418757	min3	(N) abbreviation for Fujian Province
+3301	豚	1305	99.4275162803	tun2	suckling pig
+3302	掺	1303	99.4281896513	chan1/shan3	mix, to grasp
+3303	沌	1303	99.4288630224	dun4	confused/turbid
+3304	惰	1302	99.4295358766	duo4	lazy
+3305	喳	1302	99.4302087309	cha1/zha1	twitter/chirp
+3306	椭	1301	99.4308810683	tuo3	ellipse
+3307	咪	1298	99.4315518554	mi1	sound to call cat
+3308	霎	1296	99.432221609	sha4	all of a sudden/drizzle
+3309	侃	1295	99.4328908457	kan3	bold
+3310	猝	1293	99.4335590489	cu4	abrupt/hurried
+3311	窖	1292	99.4342267353	jiao4	cellar
+3312	戮	1292	99.4348944217	lu4	kill
+3313	祠	1291	99.4355615913	ci2	ancestral hall/temple
+3314	瞩	1284	99.4362251434	zhu3	to gaze at/to stare at
+3315	菁	1284	99.4368886955	jing1	flower of leek
+3316	躇	1283	99.4375517308	chu2	hesitate
+3317	佬	1283	99.4382147662	lao3	male/man (Cantonese)
+3318	肋	1282	99.4388772847	lei4	rib
+3319	咄	1282	99.4395398033	duo1	noise of rage, cry out in anger
+3320	忡	1273	99.4401976707	chong1	grieved/distressed/sad/uneasy
+3321	雍	1272	99.4408550214	yong1	(surname)/harmonious
+3322	忱	1268	99.441510305	chen2	sincerity/honesty
+3323	蕾	1268	99.4421655885	lei3	bud
+3324	跄	1265	99.4428193217	qiang1/qiang4	walk rapidly, stagger/sway from side to side
+3325	硅	1264	99.4434725381	gui1	silicon
+3326	伎	1264	99.4441257545	ji4	craft
+3327	炊	1262	99.4447779374	chui1	dress food/to steam/to cook food
+3328	钊	1261	99.4454296034	zhao1	encourage/to cut/to strain
+3329	蝠	1259	99.4460802359	fu2	bat
+3330	屎	1257	99.4467298348	shi3	stool/feces
+3331	拭	1257	99.4473794337	shi4	wipe
+3332	谛	1257	99.4480290327	di4	examine/truth (Buddhist)
+3333	褪	1256	99.4486781148	tun4/tui4	fade/take off (clothes)
+3334	丞	1254	99.4493261633	cheng2	deputy
+3335	卉	1253	99.4499736951	hui4	plants
+3336	隧	1252	99.4506207101	sui4	subterranean/underground passage
+3337	茸	1247	99.4512651412	rong2	confused/fluffy/luxuriant growth
+3338	钳	1243	99.4519075051	qian2	pincers/pliers/tongs/claw (of animal)/to grasp with pincers/to pinch/to clamp/to restrain/to restrict/to gag
+3339	啃	1242	99.4525493522	ken3	to gnaw/to nibble/to bite
+3340	伢	1242	99.4531911994	ya2	child (collequial)
+3341	闺	1236	99.4538299458	gui1	women's apartment
+3342	舔	1236	99.4544686922	tian3	to lick/to lap
+3343	蹬	1233	99.4551058883	deng4/deng1	step into (as tight shoe)
+3344	挛	1230	99.455741534	luan2	twisted/bent/crooked/cramped
+3345	眺	1230	99.4563771797	tiao4	gaze afar
+3346	袱	1227	99.4570112751	fu2	bundle wrapped in cloth
+3347	陇	1225	99.4576443369	long3	Gansu
+3348	殴	1221	99.4582753315	ou1	brawl
+3349	柿	1221	99.4589063262	shi4	persimmon
+3350	梧	1218	99.4595357705	wu2	Sterculia platanifolia
+3351	惺	1216	99.4601641812	xing1	tranquil/understand
+3352	弛	1215	99.4607920751	chi2	unstring a bow/slacken/relax/loosen
+3353	侥	1215	99.4614199691	jiao3/yao2	by mere luck
+3354	琛	1215	99.462047863	chen1	precious stone/gem
+3355	捅	1211	99.4626736898	tong3	poke through
+3356	酝	1206	99.4632969327	yun4	to brew
+3357	薯	1204	99.463919142	shu3	potato/yam
+3358	曳	1203	99.4645408345	ye4	drag
+3359	澈	1202	99.4651620102	che4	clear (water)/thorough
+3360	锈	1198	99.4657811188	xiu4	rust
+3361	稠	1194	99.4663981603	chou2	dense/crowded/thick/many
+3362	眸	1193	99.4670146849	mou2	pupil of the eye
+3363	咆	1191	99.467630176	pao2	to roar
+3364	簧	1190	99.4682451503	huang2	metallic reed/spring of lock
+3365	鸥	1189	99.4688596079	ou1	common gull
+3366	疡	1189	99.4694740654	yang2	ulcers/sores
+3367	渎	1186	99.4700869726	du2	ditch/trouble (some one to do)
+3368	汲	1183	99.4706983294	ji2	draw water from well
+3369	嬉	1183	99.4713096862	xi1	amusement
+3370	脓	1180	99.4719194926	nong2	pus
+3371	骡	1178	99.4725282655	luo2	mule
+3372	穗	1178	99.4731370384	sui4	ear of grain
+3373	槛	1176	99.4737447777	jian4/kan3	bar/railing, door sill/threshold
+3374	拎	1176	99.4743525171	ling1/lin1	to haul/to lift/to take
+3375	巳	1176	99.4749602564	si4	6th earthly branch/9-11 a.m.
+3376	邢	1176	99.4755679957	xing2	(surname)/place name
+3377	廿	1175	99.4761752182	nian4	twenty
+3378	搀	1172	99.4767808904	chan1	assist by the arm/mix/support/sustain
+3379	曙	1171	99.4773860458	shu3	dawn/the dawn of a new epoch (metaphor)
+3380	樵	1169	99.4779901676	qiao2	firewood/gather wood
+3381	隅	1167	99.4785932559	yu2	corner
+3382	筛	1166	99.4791958273	shai1	to filter/to sift/to sieve
+3383	谒	1163	99.4797968485	ye4	to visit (a superior)
+3384	倭	1160	99.4803963192	wo1	Japanese/dwarf
+3385	痹	1158	99.4809947564	bi4	paralysis, numbness, numb/paralysis
+3386	猖	1157	99.4815926768	chang1	mad/wild
+3387	佯	1154	99.4821890468	yang2	pretend
+3388	肛	1147	99.4827817994	gang1	anus
+3389	奚	1147	99.4833745519	xi1	what why
+3390	甭	1146	99.4839667877	beng2	need not
+3391	抨	1146	99.4845590235	peng1	attack/impeach
+3392	蛾	1145	99.4851507425	e2	moth
+3393	唠	1143	99.4857414279	lao2/lao4	to chatter
+3394	荧	1142	99.4863315965	ying2	Polyeonatum officinale/glimmer/glimmering/dazzling/perplexed
+3395	嵩	1142	99.4869217651	song1	lofty/name of a mountain in Henan
+3396	漱	1139	99.4875103834	shu4	to rinse (mouth)
+3397	酋	1138	99.4880984849	qiu2	tribal chief
+3398	攘	1138	99.4886865863	rang3	throw into confusion
+3399	诘	1138	99.4892746878	jie2	investigate/restrain/scold
+3400	篡	1137	99.4898622725	cuan4	to seize/to usurp
+3401	睿	1134	99.4904483069	rui4	astute/perspicacious/farsighted
+3402	噩	1133	99.4910338244	e4	startling
+3403	怅	1132	99.4916188252	chang4	regretful/upset/despair/depressed
+3404	盎	1131	99.4922033092	ang4	abundant/bowl/dish/pot
+3405	徙	1131	99.4927877932	xi3	change one's residence
+3406	鞅	1130	99.4933717604	yang3/yang1	martingale
+3407	漓	1127	99.4939541772	li2	pattering (of rain)/seep through
+3408	祟	1127	99.4945365941	sui4	evil spirit
+3409	睫	1126	99.4951184941	jie2	eyelashes
+3410	攸	1126	99.4957003942	you1	distant, far/adverbial prefix
+3411	翎	1125	99.4962817775	ling2	tail feathers
+3412	呛	1120	99.4968605768	qiang1/qiang4	against wind, choke/pungent
+3413	筐	1119	99.4974388594	kuang1	basket
+3414	堑	1119	99.4980171419	qian4	moat around a city
+3415	檀	1119	99.4985954245	tan2	sandal wood
+3416	寅	1117	99.4991726735	yin2	3-5 a.m./3rd earthly branch
+3417	磊	1114	99.4997483722	lei3	lumpy/rock pile/uneven
+3418	驭	1114	99.5003240708	yu4	manage/to drive
+3419	惘	1114	99.5008997694	wang3	desolate
+3420	吠	1113	99.5014749513	fei4	to bark
+3421	驮	1111	99.5020490996	duo4/tuo2	carry on back, carry on back
+3422	瑙	1108	99.5026216975	nao3	agate
+3423	炬	1107	99.5031937786	ju4	torch
+3424	痉	1106	99.503765343	jing4	spasm
+3425	曝	1105	99.5043363906	pu4	to air/to sun
+3426	恺	1105	99.5049074381	kai3	joyful/kind
+3427	胺	1103	99.5054774522	an4	amine
+3428	萤	1103	99.5060474662	ying2	firefly
+3429	敕	1103	99.5066174802	chi4	imperial orders
+3430	筝	1100	99.5071859438	zheng1	(mus. instr.)
+3431	幡	1097	99.5077528571	fan1	banner
+3432	霹	1095	99.5083187368	pi1	clap of thunder
+3433	竺	1095	99.5088846165	zhu2	(surname)
+3434	烙	1093	99.5094494627	lao4	bake/flat iron/large cake
+3435	毗	1093	99.5100143089	pi2	adjoin/border
+3436	鸠	1092	99.5105786382	jiu1	turtle-dove/Turtur orientalis
+3437	埠	1091	99.5111424508	bu4	a jetty/port/a city/quay
+3438	蒜	1091	99.5117062634	suan4	garlic
+3439	阜	1089	99.5122690424	fu4	abundant/mound
+3440	嘈	1087	99.5128307878	cao2	bustling/tumultuous/noisy
+3441	乒	1086	99.5133920165	ping1	bing (onomat.)
+3442	帷	1086	99.5139532451	wei2	curtain/screen
+3443	啄	1084	99.5145134402	zhuo2	to peck
+3444	鳌	1083	99.5150731185	ao2	sea turtle
+3445	毡	1082	99.51563228	zhan1	felt
+3446	阙	1082	99.5161914416	que1/que4	deficiency, (surname)/imperial city
+3447	褥	1081	99.5167500863	ru4	mattress
+3448	搔	1080	99.5173082142	sao1	disturb/to scratch
+3449	笋	1079	99.5178658254	sun3	bamboo shoot
+3450	冕	1078	99.5184229198	mian3	royal crown
+3451	狞	1078	99.5189800142	ning2	fierce-looking
+3452	韶	1078	99.5195371085	shao2	(music)/excellent/harmonious
+3453	骼	1078	99.5200942029	ge2	skeleton
+3454	蔼	1075	99.5206497469	ai3	friendly
+3455	烹	1074	99.5212047742	peng1	cuisine/cooking
+3456	奄	1073	99.5217592846	yan1/yan3	castrate/to delay, suddenly/to embrace
+3457	嫖	1073	99.5223137951	piao2	visit a prostitute
+3458	沐	1072	99.5228677887	mu4	bathe/cleanse/receive favors
+3459	噗	1070	99.5234207488	pu1	sound of escaping laughter/water
+3460	岑	1069	99.5239731921	cen2	a small hill/(a surname)
+3461	蛟	1069	99.5245256354	jiao1	scaly dragon
+3462	掳	1067	99.5250770452	lu3	take captive
+3463	咏	1067	99.5256284549	yong3	sing
+3464	弩	1067	99.5261798646	nu3	cross-bow
+3465	捻	1066	99.5267307576	nian3	twirl (in the fingers)
+3466	圃	1066	99.5272816506	pu3	garden/orchard
+3467	孚	1066	99.5278325435	fu2	trust
+3468	悴	1064	99.5283824029	cui4	haggard/sad/downcast/distressed
+3469	诣	1063	99.5289317455	yi4	go
+3470	呱	1063	99.5294810881	gu1/gua1	crying sound of child
+3471	祁	1062	99.5300299139	qi2	(surname)
+3472	捶	1061	99.5305782229	chui2	beat with the fist/to hammer/to cudgel
+3473	钠	1061	99.531126532	na4	sodium
+3474	袄	1057	99.5316727738	ao3	coat/jacket/short and lined coat or robe
+3475	澎	1056	99.5322184989	peng2	sound of waves
+3476	氮	1055	99.5327637073	dan4	nitrogen
+3477	恪	1055	99.5333089156	ke4	(surname)/respectful
+3478	雏	1052	99.5338525735	chu2	chick/young bird
+3479	撮	1049	99.5343946811	cuo1	bring together/little bit/shovel/gather up/bring together/pick
+3480	堰	1049	99.5349367888	yan4	weir
+3481	鹦	1049	99.536021004	ying1	parrot
+3482	晖	1046	99.5365615612	hui1	bright/radiant
+3483	犀	1044	99.5371010849	xi1	rhinoceros
+3484	腑	1043	99.5376400918	fu3	internal organs
+3485	沽	1043	99.5381790987	gu1	buy/sell
+3486	橄	1043	99.5387181056	gan3	olive
+3487	掐	1042	99.5392565957	qia1	pick (flowers)/to pinch
+3488	亵	1042	99.5397950858	xie4	licentious
+3489	龋	1040	99.5403325423	qu3	decayed teeth/dental caries
+3490	嗒	1038	99.5408689653	ta4/da1	to despair
+3491	咀	1037	99.5414048715	ju3	chew
+3492	祺	1034	99.5419392273	qi2	felicity
+3493	锚	1033	99.5424730664	mao2	anchor
+3494	匾	1033	99.5430069054	bian3/pian2	a tablet/a board with an inscription/a sign hung above a door, basket-couch in coffin
+3495	乓	1032	99.5435402277	pang1	bang (onomat.)
+3496	萃	1032	99.5440735499	cui4	collect/collection/dense/grassy/thick/assemble/gather
+3497	贻	1032	99.5446068722	yi2	bequeath
+3498	揖	1031	99.5451396777	yi1	greet (by raising the joined hands)
+3499	觑	1031	99.5456724831	qu4	to spy/watch for
+3500	吝	1030	99.5462047718	lin4	stingy
+3501	憔	1030	99.5467370605	qiao2	haggard
+3502	羌	1029	99.5472688324	qiang1	educated/name of a tribe/strong
+3503	诲	1028	99.5478000875	hui4	admonish/instruct
+3504	砾	1028	99.5483313427	li4	gravel/small stone
+3505	蠕	1028	99.5488625978	ru2	to squirm/to wiggle/to wriggle
+3506	肴	1026	99.5493928193	yao2	mixed/viands, meat dishes
+3507	撩	1025	99.5499225241	liao1/liao2	lift up (skirt)/pull up (sleeve), stitch/take/tease
+3508	坍	1015	99.550447061	tan1	collapse
+3509	酥	1014	99.5509710811	su1	flaky
+3510	袅	1012	99.5514940677	niao3	delicate/graceful
+3511	黝	1010	99.5520160207	you3	black/dark green
+3512	俾	1007	99.5525364233	bi3	to cause/to enable
+3513	嫣	1005	99.5530557924	yan1	captivating
+3514	穹	1004	99.5535746446	qiong2	arched/lofty/vast
+3515	秧	1003	99.5540929801	yang1	shoots/sprouts
+3516	妊	1001	99.554610282	ren4	be pregnant
+3517	溉	1000	99.5551270672	gai4	irrigate
+3518	鹊	999	99.5556433355	que4	magpie
+3519	聿	999	99.5561596039	yu4	introductory part./pen
+3520	疙	998	99.5566753554	ge1	pimple/wart
+3521	蘑	998	99.557191107	mo2	mushroom
+3522	睾	996	99.557705825	gao1	bank/marsh/testicles
+3523	楷	994	99.5582195094	kai3	norm/model/(writing)
+3524	酵	992	99.5587321603	jiao4	yeast
+3525	茹	992	99.5592448111	ru2	eat/rubicene (chem.)
+3526	锌	992	99.559757462	xin1	zinc
+3527	滇	991	99.5602695961	dian1	Yunnan
+3528	辗	990	99.5607812133	zhan3/nian3	roll over on side/turn half over
+3529	纂	990	99.5612928306	zuan3	compile
+3530	圭	988	99.5618034143	gui1	jade tablet
+3531	幔	988	99.562313998	man4	curtain
+3532	褒	987	99.562824065	bao1	to praise
+3533	揍	986	99.5633336151	zou4	beat up/break to pieces
+3534	诽	985	99.5638426485	fei3	slander
+3535	倔	985	99.5643516818	jue2/jue4	crabby/tough
+3536	腓	984	99.5648601984	fei2	calf of leg/decay/protect
+3537	颉	984	99.565368715	xie2/jie2	(surname)/fly upwards/neck
+3538	锄	981	99.5658756812	chu2	a hoe/to hoe or dig/to weed/get rid of
+3539	嗔	979	99.5663816138	chen1	to be angry at
+3540	磺	978	99.5668870297	huang2	sulfur
+3541	攒	977	99.5673919288	cuan2/zan3	bring together, collect/hoard
+3542	瘩	974	99.5678952775	da2	sore/boil/scab
+3543	雳	974	99.5683986262	li4	clap of thunder
+3544	吆	973	99.5689014582	yao1	shout
+3545	悚	973	99.5694042901	song3	frightened
+3546	墩	972	99.5699066052	dun1	block/gate pillar/pier
+3547	彝	972	99.5704089204	yi2	normal nature of man/rule
+3548	囱	968	99.5709091684	cong1	window/chimney
+3549	逍	968	99.5714094164	xiao1	leisurely/easy-going
+3550	辄	967	99.5719091476	zhe2	sides of chariot where weapons
+3551	桅	966	99.5724083621	wei2	mast
+3552	俨	966	99.5729075765	yan3	majestic/dignified
+3553	纶	965	99.5734062742	lun2	classify/silk thread/twist silk
+3554	悸	964	99.573904455	ji4	afraid
+3555	殃	964	99.5744026359	yang1	calamity
+3556	帧	962	99.5748997832	zheng4/zhen1	frame/one of a pair (scrolls)/picture
+3557	俐	960	99.5753958969	li4	clever
+3558	绮	958	99.5758909771	qi3	beautiful/open-work silk
+3559	袒	957	99.5763855405	tan3	to bare
+3560	籽	957	99.5768801039	zi3	seeds
+3561	孰	956	99.5773741504	shu2	who/which/what
+3562	愫	952	99.5778661299	su4	guileless/sincere
+3563	拌	950	99.5783570758	ban4	to mix/mix in/to toss (a salad)
+3564	橙	946	99.5788459545	cheng2	orange tree/the color orange/orange
+3565	暨	946	99.5793348332	ji4	and/reach to/the end
+3566	敖	945	99.5798231952	ao2	ramble
+3567	赘	945	99.5803115571	zhui4	superfluous
+3568	抉	944	99.5807994023	jue2	dig/pick
+3569	淤	943	99.5812867307	yu1	silt
+3570	剌	943	99.5817740591	la2/la4	to slash, cruel/obstinate
+3571	娼	943	99.5822613875	chang1	prostitute
+3572	顼	942	99.5827481991	xu4/xu1	grieved/anxious
+3573	葵	941	99.5832344939	kui2	sunflower
+3574	哝	941	99.5837207887	nong2	garrulous
+3575	酣	939	99.5842060499	han1	intoxicated
+3576	麓	939	99.5846913112	lu4	foot of a hill
+3577	钵	938	99.5851760556	bo1	alms bowl/small earthenware basin
+3578	琅	938	99.5856608001	lang2	(gem)/tinkling of pendants
+3579	簸	937	99.5861450277	bo3/bo4	to winnow, dust pan/toss (as waves)
+3580	禾	936	99.5866287386	he2	cereal/grain
+3581	铢	936	99.5871124495	zhu1	forty-eighth part of a tael
+3582	璧	929	99.5875925429	bi4	piece of jade with hole in center
+3583	娠	928	99.5880721195	shen1	pregnant
+3584	彗	926	99.5885506626	hui4	comet
+3585	惋	925	99.5890286888	wan3	regret, be sorry/alarmed
+3586	腋	925	99.589506715	ye4	armpit
+3587	螂	925	99.5899847413	lang2	dragonfly/mantis
+3588	阪	924	99.5904622508	ban3	a slope/hillside
+3589	掣	922	99.5909387267	che4	pull/obstruct/hinder/draw
+3590	劾	922	99.5914152026	he2	impeach
+3591	沥	918	99.5918896113	li4	drip
+3592	粱	918	99.5923640201	liang2	sorghum
+3593	嚓	918	99.5928384288	cha1	
+3594	惮	916	99.593311804	dan4	dread/fear/dislike
+3595	氖	915	99.5937846624	nai3	neon
+3596	捎	913	99.5942564872	shao1	bring or take (along)
+3597	羔	911	99.5947272785	gao1	lamb
+3598	俟	910	99.595197553	si4	until/wait for
+3599	渲	906	99.5956657603	xuan4	wash (color)
+3600	榄	905	99.5961334508	lan3	olive
+3601	茧	904	99.5966006246	jian3	cocoon
+3602	霓	903	99.5970672816	ni2	rainbow
+3603	鹉	901	99.597532905	wu3	parrot
+3604	胥	901	99.5979985284	xu1	all/assist/to store
+3605	琶	900	99.598463635	pa2	(mus. instr.)
+3606	撬	900	99.5989287416	qiao4	to lift
+3607	橘	900	99.5993938482	ju2	tangerine
+3608	拈	898	99.6003225111	nian1	
+3609	笆	896	99.6007855506	ba1	an article made of bamboo strips/fence
+3610	痊	893	99.6012470397	quan2	recover (from illness)
+3611	亟	893	99.6017085289	ji2/qi4	urgent, repeatedly/frequently
+3612	渭	892	99.6021695012	wei4	name of a river
+3613	狙	891	99.6026299568	ju1	(ape)/to spy/lie in ambush
+3614	珂	889	99.6030893787	ke1	jade-like stone
+3615	刨	888	99.6035482839	bao4/pao2	a plane/to plane/level or make smooth, a plane/to plane, eliminate/to dig/to question
+3616	蜕	886	99.6040061556	tui4	exuviae of insects or reptiles
+3617	谚	884	99.6044629936	yan4	proverb
+3618	憧	883	99.6049193149	chong1	irresolute/unsettled
+3619	瞟	883	99.6053756362	piao3	cast a glance
+3620	馒	881	99.6058309239	man2	steamed bread
+3621	拗	881	99.6062862116	ao4/niu4	bend/break in two, stubborn/contrary
+3622	帚	878	99.6067399489	zhou3	broom
+3623	钗	878	99.6071936863	chai1	hairpin
+3624	哧	877	99.6076469068	chi1	
+3625	喋	877	99.6081001274	die2	flowing flood/to chatter
+3626	箫	874	99.6085517976	xiao1	(flute)/pan pipes/xiao - a vertical bamboo flute
+3627	刁	871	99.6090019175	diao1	artful/wicked
+3628	怦	869	99.6094510038	peng1	impulsive
+3629	缭	867	99.6098990565	liao2	lines for a sail/wind round
+3630	迥	866	99.6103465924	jiong3	distant
+3631	湄	866	99.6107941283	mei2	brink/edge
+3632	磐	864	99.6112406307	pan2	firm/stable/rock
+3633	渝	864	99.611687133	yu2	Chongqing
+3634	冗	863	99.6121331186	rong3	extraneous
+3635	闵	863	99.6125791042	min3	(surname)/feel compassion for
+3636	噶	862	99.613024573	ga2	(phonetic)
+3637	黏	862	99.6134700417	nian2	sticky
+3638	蕃	860	99.613914477	fan2/fan1	flourishing/to reproduce
+3639	弼	858	99.6143578786	bi4	assist
+3640	驿	858	99.6148012803	yi4	remount stations
+3641	淄	857	99.6152441651	zi1	black/name of a river
+3642	饺	856	99.6156865332	jiao3	dumplings with meat filling
+3643	踞	854	99.6161278677	ju4	be based upon/squat
+3644	韬	854	99.6165692022	tao1	bow case/to cover
+3645	婷	853	99.6170100199	ting2	graceful
+3646	唆	852	99.6174503209	suo1	incite/suck
+3647	蜒	852	99.6178906218	yan2	slug
+3648	偎	850	99.6183298891	wei1	to cuddle
+3649	榨	849	99.6187686397	zha4	salted vegetable/to extract
+3650	漉	849	99.6192073903	lu4	strain liquids
+3651	碉	848	99.6196456241	diao1	Tibetan stone house
+3652	皈	848	99.6200838579	gui1	comply with/follow
+3653	矜	848	99.6205220917	jin1	boast/esteem/sympathize
+3654	笈	847	99.6209598087	ji2	trunks (for books)
+3655	枷	845	99.6213964921	jia1	cangue
+3656	鲨	845	99.6218331756	sha1	shark
+3657	蹑	844	99.6222693422	nie4	chase/step/tread
+3658	瀚	842	99.6227044753	han4	ocean/vastness
+3659	酪	840	99.6231385748	lao4	Chinese cream/cheese
+3660	谑	840	99.6235726743	xue4	
+3661	癖	840	99.6240067739	pi3	habit/hobby
+3662	烬	837	99.624439323	jin4	ashes/embers
+3663	揩	837	99.6248718722	kai1	wipe
+3664	炙	837	99.6253044213	zhi4	broil
+3665	蜷	837	99.6257369705	quan2	Melania libertina/wriggle (as a worm)
+3666	侏	836	99.6261690029	zhu1	dwarf
+3667	凋	835	99.6266005184	diao1	withered
+3668	漪	833	99.6270310005	yi1	ripple
+3669	悻	832	99.6274609657	xing4	angry
+3670	蹋	826	99.6278878302	ta4	step on
+3671	讪	826	99.6283146947	shan4	abuse/slander
+3672	搐	823	99.6287400089	chu4	lead/pull
+3673	碘	823	99.6291653231	dian3	iodine
+3674	帛	822	99.6295901204	bo2	silk
+3675	诠	821	99.630014401	quan2	explain/comment
+3676	碾	820	99.6304381649	nian3	stone roller
+3677	擂	819	99.6308614119	lei2/lei4	beat/to grind, beat (a drum)
+3678	苯	816	99.6312831086	ben3	benzene
+3679	诃	814	99.6317037716	he1	to blame/ridicule in loud voice
+3680	铎	813	99.632123918	duo2	large ancient bell
+3681	戊	811	99.6325430307	wu4	5th heavenly stem
+3682	荀	811	99.6329621435	xun2	(surname)
+3683	驹	810	99.6333807394	ju1	colt
+3684	攫	810	99.6337993354	jue2	seize (bird or animal)
+3685	憬	809	99.6342174145	jing3	awaken
+3686	哽	805	99.6346334266	geng3	choking
+3687	踵	805	99.6350494386	zhong3	arrive/follow/heel
+3688	蟒	804	99.6354649339	mang3	Python molurus
+3689	漾	803	99.6358799123	yang4	d (23rd)/ripples
+3690	啧	802	99.636294374	ze2	(interj. of admiration or of disgust)/to click one's tongue/to attempt to (find an opportunity to) speak
+3691	吮	800	99.6367078021	shun3	to suck
+3692	楠	800	99.6371212302	nan2	Machilus nanmu
+3693	氟	800	99.6375346583	fu2	fluorine
+3694	怂	799	99.6379475696	song3	arouse
+3695	叼	797	99.6383594474	diao1	(v) hold sth in the mouth
+3696	竣	794	99.6387697748	jun4	complete/finish
+3697	偕	794	99.6391801022	jie1/xie2	in company with, in company with
+3698	漩	794	99.6395904296	xuan2	eddy
+3699	蹭	793	99.6400002402	ceng2/ceng4	rub, rub against/walk slowly
+3700	翌	793	99.6404100508	yi4	bright/tomorrow
+3701	臆	792	99.6408193446	yi4	feelings/opinion/thoughts
+3702	挝	792	99.6412286385	zhua1/wo1	beat
+3703	绚	790	99.6416368987	xuan4	adorned/swift
+3704	崽	790	99.642045159	zai3	young of animals
+3705	糜	789	99.6424529025	mi2	dissolved/rice-gruel/wasted
+3706	瘢	788	99.6428601291	ban1	mark/scar on the skin
+3707	跤	787	99.643266839	jiao1	bones of leg/wrestle
+3708	阑	786	99.6436730322	lan2	door-screen/exhausted/late
+3709	恬	786	99.6440792253	tian2	quiet, calm, tranquil, peaceful
+3710	豢	785	99.6444849016	huan4	feed pigs and dogs/to rear
+3711	汶	783	99.6448895444	wen4	name of a river
+3712	跷	783	99.6452941871	qiao1	raise one's foot
+3713	琵	781	99.6456977963	pi2	(mus. instr.)
+3714	憨	780	99.6461008887	han1	silly/simple-minded
+3715	蜗	780	99.6465039811	wo1	
+3716	螅	779	99.6469065567	xi1	(intestinal worm)
+3717	惴	777	99.6473080988	zhui4	anxious/worried
+3718	戟	775	99.6477086073	ji3	a lance with two points
+3719	匮	773	99.6481080822	kui4	(surname)/lacking/empty/exhausted
+3720	恙	772	99.6485070403	yang4	sickness
+3721	抿	771	99.6489054816	min3	purse up (lips)/to smooth
+3722	桢	771	99.649303923	zhen1	evergreen shrub
+3723	笺	770	99.6497018475	jian1	letter/note-paper
+3724	蛤	769	99.6500992553	ge2/ha2	clam, frog/toad
+3725	瞳	769	99.6504966631	tong2	pupil of the eye
+3726	瓢	766	99.6512888947	piao2	dipper/ladle
+3727	衹	766	99.6516847521	ti3	
+3728	秤	765	99.6520800927	cheng3/cheng4	steel yard/scales, steelyard
+3729	跺	765	99.6524754334	duo4	(v) stamp one's foot
+3730	潦	765	99.652870774	lao3/liao2	flooded/heavy rain
+3731	芹	765	99.6532661146	qin2	Chinese celery
+3732	哒	764	99.6536609385	da1	(phonetic)/command to a horse/clatter (of horses' hoofs)
+3733	饬	763	99.6540552455	chi4	keep in order/stern/to order/direct
+3734	栩	762	99.6544490358	xu3	Quercus serrata
+3735	曦	761	99.6548423093	xi1	light of day
+3736	骷	760	99.655235066	ku1	skeleton
+3737	嫡	758	99.6556267891	di2	first wife/son of first wife
+3738	卤	758	99.6560185122	lu3	brine/salt/gravy, crass/halogen/salt/brine
+3739	丕	758	99.6564102354	pi1	grand
+3740	鬓	758	99.6568019585	bin4	temples/hair on the temples
+3741	梓	755	99.6571921313	zi3	Catalpa kaempferi
+3742	嗖	753	99.6575812705	sou1	
+3743	惦	752	99.6579698929	dian4	think of, remember, miss
+3744	浚	752	99.6583585153	jun4/xun4	deepen/enlighten/profound
+3745	咔	751	99.658746621	ka1	
+3746	藐	750	99.6591342098	miao3	despise/small
+3747	荃	750	99.6595217987	quan2	(fragrant plant)
+3748	唧	749	99.6599088707	ji1	(onomat.)/to pump (water)
+3749	玺	749	99.6602959428	xi3	ruler's seal
+3750	汛	748	99.6606824981	xun4	high water/sprinkle water
+3751	铐	748	99.6610690534	kao4	shackles, manacle
+3752	髅	747	99.6614550919	lou2	skull
+3753	渤	745	99.6618400968	bo2	Gulf of Chili
+3754	皿	745	99.6622251017	min3	
+3755	箍	743	99.6626090731	gu1	hoop/bind with hoops
+3756	馅	742	99.6629925276	xian4	stuffing/forcemeat
+3757	汾	741	99.6633754654	fen2	name of a river
+3758	戍	741	99.6637584032	shu4	garrison
+3759	痔	741	99.664141341	zhi4	piles/hemorrhoid
+3760	褶	740	99.664523762	xi2/zhe3	(arch.) court dress, pleat/crease
+3761	聆	739	99.6649056662	ling2	apprehend/hear/listen
+3762	涎	738	99.6652870536	xian2	saliva/shamelessly
+3763	汞	738	99.6656684411	gong3	mercury
+3764	渍	737	99.6660493117	zi4	saturate/soak
+3765	奂	737	99.6664301823	huan4	(surname)/excellent
+3766	巅	737	99.666811053	dian1	summit
+3767	疣	737	99.6671919236	you2	nodule/wart
+3768	傩	736	99.6675722775	nuo2	exorcise demons
+3769	逵	736	99.6679526314	kui2	crossroads/thoroughfare
+3770	耆	735	99.6683324684	qi2	man of sixty or seventy
+3771	蟋	734	99.6687117887	xi1	cricket
+3772	鳄	734	99.669091109	e4	crocodile/alligator
+3773	讹	729	99.6694678454	e2	error/exhort/false
+3774	膺	726	99.6698430314	ying1	breast/receive
+3775	蹿	724	99.6702171838	cuan1	jump up
+3776	筏	722	99.6705903027	fa2	raft (of logs)
+3777	釜	722	99.6709634215	fu3	kettle/caldron
+3778	沂	722	99.6713365404	yi2	name of a river
+3779	坯	720	99.6717086257	pi1	unburnt earthenware
+3780	峦	718	99.6720796774	luan2	mountain ranges
+3781	茬	717	99.6724502124	cha2	
+3782	摒	717	99.6728207473	bing4	arrange/drive off/expel
+3783	蟀	717	99.6731912823	shuai4	cricket
+3784	撵	716	99.6735613004	nian3	expel
+3785	浒	715	99.6739308018	hu3	bank of a river
+3786	缤	715	99.6743003032	bin1	helter-skelter/mixed colors/in confusion
+3787	嵋	713	99.674668771	mei2	name of a mountain in Sichuan
+3788	珑	713	99.6750372388	long2	tinkling of gem-pendants
+3789	苞	712	99.6754051898	bao1	flower calyx/luxuriant/profuse
+3790	瑾	710	99.6757721072	jin3	brilliancy (of gems)
+3791	泵	709	99.6761385079	beng4	
+3792	钾	709	99.6765049085	jia3	potassium
+3793	暧	709	99.6768713092	ai4	obscure/clandestine
+3794	赓	706	99.6772361595	geng1	continue (as a song)
+3795	叟	703	99.6775994595	sou3	old gentleman
+3796	佚	702	99.6779622426	yi4	(surname)/idle
+3797	沓	699	99.6783234754	ta4	(surname)/again and again/many
+3798	撂	698	99.6786841915	liao4	to leave (it)
+3799	蛊	696	99.6790438739	gu3	insanity/poison
+3800	甥	696	99.6794035564	sheng1	nephew
+3801	璐	696	99.6797632388	lu4	(jade)
+3802	晏	696	99.6801229213	yan4	(surname)/late/quiet
+3803	瘪	694	99.6804815702	bie3	deflated/shriveled/sunken/empty
+3804	漳	694	99.680840219	zhang1	name of a river
+3805	阉	692	99.6811978344	yan1	castrate
+3806	蹂	691	99.6815549329	rou2	trample
+3807	鳃	690	99.6819115146	sai1	gills of fish
+3808	琏	690	99.6822680964	lian3	
+3809	湃	689	99.6826241613	pai4	sound of waves
+3810	辘	689	99.6829802263	lu4	windlass
+3811	僭	688	99.6833357745	jian4	usurp
+3812	躏	688	99.6836913226	lin4	
+3813	鼾	688	99.6840468708	han1	snore
+3814	懵	685	99.6844008686	meng3	stupid
+3815	镰	684	99.6847543496	lian2	scythe/sickle
+3816	寐	684	99.6851078307	mei4	sleep soundly
+3817	褚	684	99.6854613117	chu3	(surname)
+3818	攥	683	99.685814276	zuan4	
+3819	涧	681	99.6861662066	jian4	mountain stream
+3820	蝙	679	99.6865171037	bian1	bat
+3821	脐	677	99.6868669673	qi2	navel
+3822	辕	675	99.6872157972	yuan2	shafts of cart/yamen
+3823	涣	674	99.6875641104	huan4	disperse expansive (of river)
+3824	杞	674	99.6879124236	qi3	(willow)/name of a feudal state
+3825	煜	674	99.6882607368	yu4	brilliant/glorious
+3826	骥	674	99.68860905	ji4	thoroughbred horse/refined and virtuous
+3827	傣	672	99.6889563296	dai3	the Dai minority living in South China
+3828	嗳	672	99.6893036092	ai3/ai4	(interj. of disapproval), (interj. of regret)
+3829	祯	672	99.6896508888	zhen1	auspicious/lucky
+3830	酉	671	99.6899976516	you3	10th earthly branch/5-7 p.m.
+3831	秸	670	99.6903438977	jie1	
+3832	捺	670	99.6906901437	na4	(downwards-right concave character stroke)/press down firmly
+3833	瑕	670	99.6910363897	xia2	blemish/flaw in jade
+3834	鑫	670	99.6913826358	xin1	(used in names)
+3835	馋	669	99.691728365	chan2	gluttonous/greedy
+3836	窿	668	99.6920735775	long2	cavity/hole
+3837	楔	667	99.6924182732	xie1	to wedge/wedge
+3838	胱	667	99.6927629689	guang1	bladder
+3839	荔	665	99.693106631	li4	litchi
+3840	蟆	664	99.6934497763	ma2/ma	toad, toad
+3841	湍	663	99.6937924049	tuan1	to rush (of water)
+3842	屹	663	99.6941350334	yi4	high and steep
+3843	遐	663	99.694477662	xia2	abandon/distant
+3844	轲	663	99.6948202905	ke1	given name of Mencius
+3845	镯	662	99.6951624023	zhuo2	bracelet
+3846	缰	661	99.6955039972	jiang1	
+3847	桦	660	99.6958450754	hua4	Betula japonica
+3848	炖	660	99.6961861536	dun4	stew slowly, stew
+3849	钡	659	99.696526715	bei4	barium
+3850	羚	659	99.6968672764	ling2	antelope
+3851	啬	659	99.6972078378	se4	stingy
+3852	诩	659	99.6975483992	xu3	brag/harmony/make known
+3853	绯	658	99.6978884438	fei1	dark red/purple silk
+3854	掖	656	99.6982274549	ye1/ye4	tuck (in)
+3855	箓	656	99.6985664659	lu4	
+3856	涸	655	99.6989049602	he2	to dry/to dry up
+3857	鸳	654	99.6992429377	yuan1	mandarin duck
+3858	塾	654	99.6995809152	shu2	private tutorage
+3859	呸	653	99.6999183759	pei1	to spit (in contempt)
+3860	抡	652	99.7002553198	lun1/lun2	whirl (one's arm), select
+3861	擞	652	99.7005922637	sou3	shake/trembling
+3862	熹	652	99.7009292076	xi1	bright/warm
+3863	坷	649	99.7012646011	ke3	uneven (path)/unfortunate (in life)
+3864	瓮	648	99.7015994779	weng4	earthen jar/urn
+3865	亘	648	99.7019343547	gen4	extend across/through
+3866	嗟	648	99.7022692314	jie1/jue1	sigh, sigh
+3867	筵	648	99.7026041082	yan2	bamboo mat for sitting
+3868	跛	648	99.702938985	bo3	lame/crippled
+3869	汕	647	99.7032733449	shan4	Swatow
+3870	欤	646	99.7036071881	yu2	(interrog. part.)
+3871	壑	643	99.703939481	he4	gully
+3872	颍	642	99.704271257	ying3	
+3873	溥	640	99.7046019995	pu3	extensive/pervading
+3874	姗	640	99.704932742	shan1	deprecate/lithe (of woman's walk)
+3875	踊	639	99.7052629677	yong3	leap
+3876	枭	638	99.7055926766	xiao1	brave/owl/strix uralensis
+3877	暄	638	99.7059223855	xuan1	genial and warm
+3878	稷	638	99.7062520945	ji4	(millet)
+3879	跚	638	99.7065818034	shan1	limp
+3880	涟	636	99.7069104787	lian2	ripple/tearful
+3881	瀛	636	99.7072391541	ying2	ocean
+3882	笙	636	99.7075678294	sheng1	(mus. instr.)
+3883	滕	635	99.707895988	teng2	(surname)/place name
+3884	踝	635	99.7082241465	huai2	ankle (bone)
+3885	贰	634	99.7085517883	er4	two (fraud-proof)
+3886	瞰	634	99.7088794301	kan4	bird's-eye view/glance
+3887	恻	632	99.7092060383	ce4	sorrowful
+3888	嚏	631	99.7095321297	ti4	sneeze
+3889	迢	629	99.7098571876	tiao2	remote
+3890	獗	629	99.7101822454	jue2	unruly/rude
+3891	邯	628	99.7105067865	han2	name of a district in Hebei
+3892	睑	628	99.7108313275	jian3	eyelid
+3893	赡	627	99.7111553518	shan4	to support/provide for
+3894	萦	627	99.7114793761	ying2	wind around
+3895	珥	627	99.7118034004	er3	pearl or jade earring
+3896	酮	626	99.7121269079	tong2	ketone
+3897	璞	625	99.7124498986	pu2	unpolished gem
+3898	羹	624	99.7127723725	geng1	soup
+3899	缄	623	99.7130943296	jian1	letters/to close/seal
+3900	晾	622	99.71341577	liang4	to dry in the air
+3901	俸	622	99.7137372104	feng4	salary
+3902	媲	622	99.7140586507	pi4	to match/to pair
+3903	鸾	622	99.7143800911	luan2	(mythical bird)
+3904	恿	621	99.7147010146	yong3	urge/incite
+3905	蜿	621	99.7150219382	wan1	to move (as snake)
+3906	犊	620	99.715342345	du2	calf/sacrificial victim
+3907	讷	620	99.7156627518	ne4	large/speak cautiously
+3908	扈	620	99.7159831586	hu4	retinue
+3909	蜈	620	99.7163035653	wu2	centipede
+3910	翟	619	99.7166234553	di2/zhai2	long-tail pheasant, (surname)
+3911	藕	619	99.7169433453	ou3	root of lotus
+3912	戌	619	99.7172632353	xu1	11th earthly branch/7-9 p.m.
+3913	蓓	619	99.7175831253	bei4	(flower) bud
+3914	鋆	619	99.7179030153	yun2	
+3915	谩	618	99.7182223885	man2/man4	deceive, disrespect/neglect/slight
+3916	谀	618	99.7185417618	yu2	flatter
+3917	卯	617	99.7188606182	mao3	4th earthly branch/5-7 a.m.
+3918	谙	617	99.7191794746	an1	be versed in/know well
+3919	岐	617	99.719498331	qi2	divergent/side road/steep
+3920	蝎	616	99.7198166707	xie1	scorpion
+3921	荼	616	99.7201350103	tu2	Sonchus oleraceus
+3922	镀	615	99.7204528332	du4	-plated/to plate
+3923	椰	615	99.720770656	ye1	
+3924	甄	615	99.7210884789	zhen1	(surname)/to mold
+3925	蟾	615	99.7214063018	chan2	moon/(striped) toad
+3926	蹊	615	99.7217241246	xi1/qi1	footpath
+3927	泞	614	99.7220414307	ning4	muddy
+3928	撸	614	99.7223587368	lu1	
+3929	螃	614	99.7226760428	pang2	crab
+3930	檬	613	99.7229928321	meng2	lemon
+3931	猓	612	99.7233091046	guo3	
+3932	蔷	611	99.7236248603	qiang2	wild rose
+3933	羲	611	99.7239406161	xi1	(surname)/name of an emperor
+3934	瘸	609	99.7242553382	que2	lame
+3935	蘸	609	99.7245700603	zhan4	to dip in (ink, sauce, etc.)
+3936	蔗	607	99.7248837489	zhe4	sugar cane
+3937	傀	606	99.7251969207	gui1/kui3	grand/strange/exotic, puppet
+3938	蚌	605	99.7255095757	bang4	oysters/mussels
+3939	锢	605	99.7258222307	gu4	obstinate disease/restrain/to stop
+3940	遽	604	99.726134369	ju4	hurry/fast/suddenly
+3941	邃	604	99.7264465072	sui4	deep/distant/mysterious
+3942	恚	604	99.7267586454	hui4	rage
+3943	皑	602	99.72706975	ai2	white (of snow, etc.)
+3944	锵	602	99.7273808547	qiang1	tinkling of small bells
+3945	簌	602	99.7276919593	su4	dense vegetation/sieve
+3946	焙	601	99.7280025472	bei4	to dry over a fire/to bake
+3947	昊	601	99.7283131351	hao4	clear summer sky/vast
+3948	鹳	601	99.7286237229	guan4	crane/stork
+3949	睽	600	99.728933794	kui2	separated/stare
+3950	刽	599	99.7292433483	gui4	amputate, cut off
+3951	鳖	598	99.7295523858	bie1	turtle
+3952	噎	598	99.7298614233	ye1	choke
+3953	呗	598	99.7301704609	bai4/bei	to chant
+3954	寰	598	99.7304794984	huan2	large domain
+3955	唷	597	99.7307880191	yo1	(exclamatory part.)
+3956	殡	597	99.7310965398	bin4	a funeral/to encoffin a corpse/to carry to burial
+3957	淖	596	99.7314045438	nao4	(surname)/slush/mud
+3958	诰	596	99.7317125477	gao4	enjoin/grant (a title)
+3959	恣	596	99.7320205516	zi4	throw off restraint
+3960	睐	596	99.7323285556	lai4	gaze/stare
+3961	婵	595	99.7326360427	chan2	beautiful/graceful
+3962	榈	595	99.7329435299	lu:2/lv2	palm tree
+3963	氦	594	99.7332505003	hai4	helium
+3964	靳	592	99.7335564371	jin4	(surname)/martingale/stingy
+3965	蛹	592	99.7338623739	yong3	chrysalis/pupa
+3966	鸯	591	99.7341677939	yang1	mandarin duck
+3967	惬	591	99.7344732139	qie4	cheerful/satisfied
+3968	蹙	591	99.7347786339	cu4	urgent/wrinkled/contracted/to kick
+3969	诙	590	99.7350835371	hui1	whimsical/humorous
+3970	眈	590	99.7353884404	dan1	gaze intently
+3971	罡	590	99.7356933436	gang1	(stars)
+3972	缮	589	99.73599773	shan4	make a fair copy of
+3973	胤	589	99.7363021165	yin4	heir/inherit
+3974	皋	588	99.7366059861	gao1	bank/marsh
+3975	蛀	588	99.7369098558	zhu4	termite/to bore (of insects)
+3976	偌	587	99.7372132087	ruo4	so/such/to such a degree
+3977	疵	586	99.7375160448	ci1	blemish/flaw/defect
+3978	绛	586	99.7378188808	jiang4	purple-red
+3979	葆	583	99.7381201666	bao3	dense foliage/to cover
+3980	黔	582	99.7384209355	qian2	an old name for Guizhou (贵州) province
+3981	喙	582	99.7387217045	hui4	beak/to pant
+3982	烽	581	99.7390219566	feng1	beacon fire
+3983	儡	581	99.7393222088	lei3	injure/puppet
+3984	佼	581	99.739622461	jiao3	handsome
+3985	斓	581	99.7399227131	lan2	variegated/parti-colored
+3986	嫔	579	99.7402219317	pin2	virtuous woman
+3987	颚	579	99.7405211503	e4	jaw/palate
+3988	龈	579	99.7408203689	ken3/yin2	gnaw/bite, gums
+3989	盅	578	99.7411190707	zhong1	cup
+3990	娓	578	99.7414177725	wei3	active/comply with
+3991	坂	576	99.7417154408	ban3	
+3992	町	576	99.742013109	ting3/ding1	raised path between fields
+3993	芥	575	99.7423102605	jie4	mustard
+3994	瘠	575	99.7426074119	ji2	barren/lean
+3995	阂	574	99.7429040466	he2	obstruct
+3996	挎	574	99.7432006812	kua4	(v) carry on one's arm/(v) carry over one's shoulder or slung on one's side
+3997	橇	574	99.7434973159	qiao1	
+3998	荟	574	99.7437939506	hui4	flourish
+3999	啜	574	99.7440905852	chuo4	drink/taste/sip/suck
+4000	垛	573	99.7443867031	duo3/duo4	battlement/target, pile
+4001	淇	573	99.744682821	qi2	name of a river
+4002	瓒	573	99.7449789389	zan4	libation cup
+4003	篓	572	99.74527454	lou3	deep basket
+4004	虱	572	99.7455701411	shi1	louse
+4005	跻	572	99.7458657422	ji1	go up
+4006	龛	571	99.7461608265	kan1	niche/shrine
+4007	蹒	571	99.7464559108	pan2	limp
+4008	髯	571	99.7467509951	ran2	beard/whiskers
+4009	瞠	568	99.7470445291	cheng1	stare at something beyond reach
+4010	痫	568	99.747338063	xian2	epilepsy/insanity
+4011	掂	567	99.7476310802	dian1	weigh in the hand
+4012	潼	567	99.7479240974	tong2	high/name of a pass
+4013	酰	567	99.7482171145	xian1	(chem.) -acyl/acid radical
+4014	镁	567	99.7485101317	mei3	magnesium
+4015	灸	566	99.7488026321	jiu3	cauterize
+4016	腆	566	99.7490951325	tian3	make strong (as liquors)/virtuous
+4017	筱	566	99.7493876329	xiao3	dwarf bamboo/thin bamboo
+4018	谆	565	99.7496796165	zhun1	repeatedly (in giving advice)
+4019	骋	564	99.7499710833	cheng3	hasten/run/open up/gallop
+4020	壬	564	99.7502625501	ren2	9th heavenly stem
+4021	茗	564	99.7505540169	ming2	Thea sinensis/young leaves of tea
+4022	椋	564	99.7508454837	liang2	fruit
+4023	蛔	563	99.7511364338	hui2	roundworm/Ascaris lumbricoides
+4024	潺	562	99.751426867	chan2	flow/trickle (of water)
+4025	扉	561	99.7517167835	fei1	door with only one leaf
+4026	耘	560	99.7520061831	yun2	to weed
+4027	槟	559	99.752295066	bin1/bing1	areca/the areca nut palm, areca
+4028	雹	558	99.7525834321	bao2	hail
+4029	甬	558	99.7528717982	yong3	5 pecks (M)/Ningpo
+4030	谥	557	99.7531596476	shi4	confer such title/posthumous title
+4031	淞	557	99.7534474969	song1	name of a river
+4032	燎	556	99.7537348294	liao2	singe
+4033	蕙	556	99.754022162	hui4	Coumarouna odorata
+4034	蚪	556	99.7543094945	dou3	tadpole
+4035	蜻	555	99.7545963102	qing1	dragonfly
+4036	郸	554	99.7548826092	dan1	name of a district in Hebei
+4037	轶	554	99.7551689082	yi4	disperse/put in order/surpass
+4038	狰	553	99.7554546904	zheng1	hideous/fierce-looking
+4039	楣	553	99.7557404725	mei2	lintel
+4040	捋	552	99.7560257379	lu:3/luo1/lv3	stroke (beard), strip (cow, leaves, branch)
+4041	涓	552	99.7563110033	juan1	(surname)/brook/to select
+4042	荪	552	99.7565962687	sun1	fragrant grass
+4043	娄	551	99.7568810173	lou2	(star)/(surname)
+4044	麝	551	99.7571657659	she4	musk deer
+4045	蚤	548	99.7574489642	zao3	flea
+4046	醮	548	99.7580153607	jiao4	perform sacrifice
+4047	搪	547	99.7582980422	tang2	keep out
+4048	谧	546	99.7585802068	mi4	quiet
+4049	湮	546	99.7588623715	yan1/yin1	obscured/submerged, obscured/submerged
+4050	辍	546	99.7591445362	chuo4	stop/cease/suspend
+4051	瞌	546	99.7594267009	ke1	doze off/sleepy
+4052	梆	545	99.7597083488	bang1	watchman's rattle
+4053	樟	545	99.7599899967	zhang1	camphor/Cinnamonum camphara
+4054	茉	545	99.7602716446	mo4	jasmine
+4055	岖	544	99.7605527757	qu1	rugged
+4056	臼	543	99.76083339	jiu4	mortar
+4057	癣	543	99.7611140044	xuan3	ringworm
+4058	穑	543	99.7613946187	se4	gather in harvest
+4059	玷	541	99.7616741994	dian4	blemish/disgrace/flaw in jade
+4060	馍	540	99.7619532634	mo2	small loaf of steamed bread
+4061	呷	539	99.7622318106	xia1/ga1	suck, swallow, drink
+4062	萼	538	99.762509841	e4	stem and calyx of flower
+4063	妩	538	99.7627878714	wu3	flatter/to please
+4064	伫	537	99.763065385	zhu4	wait/look towards/turn one's back on
+4065	彤	536	99.7633423819	tong2	(surname)/red
+4066	莓	535	99.7636188619	mei2	strawberry
+4067	岬	535	99.763895342	jia3	cape (geog.)
+4068	媛	535	99.764171822	yuan2/yuan4	a beauty, a beauty
+4069	惆	534	99.7644477853	chou2	forlorn/vexed/disappointed
+4070	鳎	534	99.7647237485	ta3	
+4071	啾	533	99.764999195	jiu1	wailing of child/chirp
+4072	囔	533	99.7652746415	nang1	muttering, indistinct speech
+4073	蜓	533	99.765550088	ting2	dragonfly
+4074	孺	532	99.7658250176	ru2	(surname)/child
+4075	徇	531	99.7660994306	xun4	buried with dead/die for a cause, follow/quick
+4076	焊	530	99.7666477396	han4	welding, to solder/weld by heat
+4077	岱	530	99.7669216357	dai4	name of a mountain in Shandong
+4078	昵	530	99.7671955318	ni4	familiar/to approach
+4079	卅	529	99.7674689112	sa4	thirty
+4080	飙	529	99.7677422905	biao1	whirlwind
+4081	邙	529	99.7680156698	mang2	name of a hill
+4082	痞	527	99.7682880156	pi3	swelling of the liver
+4083	隼	527	99.7685603614	sun3	
+4084	恫	526	99.7688321903	dong4	frighten
+4085	怆	525	99.7691035025	chuang4	mournful/sad/grieved/sorry
+4086	桀	525	99.7693748147	jie2	(emperor of Xia dynasty)/cruel
+4087	绶	524	99.7696456101	shou4	cord on a seal
+4088	裆	523	99.7699158888	dang1	crotch/seat of a pair of trousers
+4089	盂	522	99.7701856506	yu2	container/cup
+4090	桧	522	99.7704554125	gui4	Juniperus chinensis
+4091	蚓	521	99.7707246575	yin3	earthworm
+4092	抠	520	99.7709933858	kou1	dig out (with finger)/stingy
+4093	嗷	520	99.7712621141	ao2	loud clamor/the sound of wailing
+4094	槌	520	99.7715308423	chui2	hammer/mallet/pestle
+4095	痘	519	99.7717990538	dou4	small pox
+4096	痢	519	99.7720672653	li4	dysentery
+4097	芮	519	99.7723354768	rui4	(surname)/small
+4098	蚣	519	99.7726036883	gong1	scolopendra centipede
+4099	闩	517	99.7728708662	shuan1	to bolt
+4100	铿	517	99.7731380441	keng1	jingling of metals/to strike
+4101	飓	516	99.7734047052	ju4	hurricane
+4102	疱	514	99.7736703328	pao4	
+4103	蝌	514	99.7739359603	ke1	tadpole
+4104	撅	513	99.7742010711	jue1	break off/stick up (as a tail)
+4105	蚯	513	99.7744661819	qiu1	earthworm
+4106	斡	512	99.7747307759	wo4	to turn
+4107	窠	512	99.7749953699	ke1	nest
+4108	荚	511	99.7752594471	jia2	pod
+4109	耷	510	99.7755230075	da1	
+4110	砚	509	99.7757860511	yan4	ink-stone
+4111	牒	509	99.7760490948	die2	(official) document/dispatch
+4112	赈	508	99.7763116216	zhen4	to relieve (the distressed)
+4113	煦	508	99.7765741484	xu4	
+4114	嗫	507	99.7768361585	nie4	move the mouth as in speaking
+4115	耙	506	99.7770976518	ba4/pa2	a rake/harrow, a rake
+4116	榕	505	99.7773586283	rong2	banyan tree/Ficus wightiana
+4117	鞑	505	99.7776196048	da2	Tartar/a tribe in China
+4118	袤	503	99.7778795477	mao4	length/distance from north to south
+4119	谌	503	99.7781394906	chen2	(surname)/faithful/sincere
+4120	醺	503	99.7783994335	xun1	helplessly intoxicated
+4121	秆	502	99.7786588597	gan3	stalks of grain
+4122	徨	501	99.778917769	huang2	irresolute
+4123	橹	501	99.7791766784	lu3	sculling oar
+4124	翡	501	99.7794355877	fei3	green jade/kingfisher
+4125	缨	500	99.7796939803	ying1	tassel of hat
+4126	锹	499	99.7799518561	qiao1	shovel/to dig
+4127	嵇	498	99.7802092151	ji1	(surname)/name of a mountain
+4128	圪	497	99.7804660573	ge1	(phonetic)
+4129	髻	494	99.7807213492	ji4	
+4130	嗬	493	99.7809761242	he1	
+4131	辎	492	99.7812303825	zi1	milit. supply
+4132	痣	492	99.7814846408	zhi4	birthmark/mole
+4133	娩	491	99.7817383823	mian3/wan3	give birth to a child, complaisant/agreeable
+4134	谄	491	99.7819921238	chan3	flatter/cajole
+4135	蛐	491	99.7822458653	qu1	cricket
+4136	鹞	490	99.78249909	yao4	sparrow hawk/Accipiter nisus
+4137	翱	489	99.7827517979	ao2	soar/hover
+4138	庖	488	99.7830039891	pao2	kitchen
+4139	籁	487	99.7832556635	lai4	music/musical pipe with 3 reeds
+4140	蓿	486	99.783506821	xu	
+4141	鳗	486	99.7837579786	man2	eel/Anguilla lostoniensis
+4142	疟	485	99.7840086194	nue4/yao4	malaria, malaria
+4143	鲇	484	99.7842587434	nian2	
+4144	嚅	482	99.7847574411	ru2	chattering
+4145	瘀	482	99.7850065315	yu1	hematoma/contusion/extravasted
+4146	颔	482	99.7852556219	han4	chin/nod assent
+4147	黜	482	99.7855047124	chu4	dismiss/expel
+4148	黠	482	99.7857538028	xia2	(phonetic)/crafty
+4149	濑	480	99.7860018597	lai4	name of a river/rushing of water
+4150	馁	479	99.7862493997	nei3	hungry
+4151	洵	479	99.7864969398	xun2	truly/whirlpool
+4152	忐	479	99.7867444799	tan3	nervous
+4153	忑	478	99.7869915032	te4	nervous
+4154	砥	478	99.7872385265	di3	baffle (pier)/whetstone
+4155	咂	476	99.7874845162	za1	smack one's lips
+4156	罹	476	99.7877305059	li2	happen to/sorrow/suffer from
+4157	糠	475	99.7879759789	kang1	husk
+4158	匝	474	99.788220935	za1	go round
+4159	偃	474	99.7884658912	yan3	(surname)/to lie supine/to stop/to fall down
+4160	淙	474	99.7887108473	cong2	noise of water
+4161	纫	473	99.7889552867	ren4	to string/to thread (needle)
+4162	喏	473	99.7891997261	re3/nuo4	to salute/make one's curtsy
+4163	闾	473	99.7894441654	lu:2/lv2	gate of a village/village
+4164	祛	473	99.7896886048	qu1	to exercise
+4165	蛰	472	99.7899325274	zhe2/zhi2	hibernate, hibernate
+4166	腼	472	99.79017645	mian3	
+4167	涝	471	99.7904198558	lao4	flooded
+4168	曜	471	99.7906632616	yao4	dazzle/glorious
+4169	厩	470	99.7909061506	jiu4	a stable
+4170	疽	470	99.7911490396	ju1	gangrene
+4171	闰	470	99.7913919286	run4	intercalary
+4172	洄	470	99.7916348176	hui2	eddy/whirlpool
+4173	煊	470	99.7918777066	xuan1	
+4174	汐	469	99.7921200789	xi1	
+4175	藓	469	99.7923624511	xian3	mosses on damp walls
+4176	璜	469	99.7926048233	huang2	semi-circular jade ornament
+4177	铬	469	99.7928471956	ge4	chromium
+4178	渥	468	99.7933314232	wo4	enrich/moisten
+4179	靼	468	99.7935732787	da2	(phonetic)/dressed leather
+4180	酗	467	99.7938146173	xu4	drunk
+4181	苓	467	99.794055956	ling2	fungus/tuber
+4182	噤	467	99.7942972946	jin4	unable to speak/silent
+4183	咫	466	99.7945381165	zhi3	8 in. length unit of Zhou dynasty
+4184	椿	465	99.7947784216	chun1/chun2	Cedrela chinensis/father, tree of heaven
+4185	鲫	464	99.7950182099	ji4	bastard carp/sand perch
+4186	锭	461	99.7952564479	ding4	ingot
+4187	罔	461	99.7954946858	wang3	deceive/there is none
+4188	锺	461	99.7957329237	zhong1	(ancient measure)/(surname)
+4189	匍	460	99.7959706449	pu2	crawl/lie prostrate
+4190	祗	460	99.7962083661	zhi1	respectful (ly)
+4191	锰	459	99.7964455704	meng3	manganese
+4192	岌	458	99.796682258	ji2	lofty peak/perilous
+4193	馀	457	99.7969184288	yu2	remainder
+4194	畹	457	99.7971545997	wan3	a field of 20 or 30 mu
+4195	糯	455	99.7973897369	nuo4	glutinous rice
+4196	胫	455	99.7976248741	jing4	lower part of leg
+4197	熠	455	99.7978600114	yi4	to glow/flash
+4198	銮	455	99.7980951486	luan2	imperial
+4199	沅	454	99.798329769	yuan2	name of a river
+4200	棣	454	99.7985643895	di4	Kerria japonica
+4201	旌	454	99.79879901	jing1	banner/make manifest
+4202	豌	453	99.7990331136	wan1	peas
+4203	孢	453	99.7992672173	bao1	spore
+4204	镭	452	99.7995008042	lei2	radium
+4205	驸	452	99.799734391	fu4	prince consort
+4206	腌	452	99.7999679779	yan1	to salt/pickle
+4207	盹	452	99.8002015648	dun3	doze/nap
+4208	熵	452	99.8004351517	shang1	entropy
+4209	镐	451	99.8006682218	gao3/hao4	a pick, bright/place name/stove
+4210	馐	451	99.8009012919	xiu1	delicacies
+4211	嘤	450	99.8011338452	ying1	calling of birds
+4212	癞	450	99.8013663985	lai4	scabies/skin disease
+4213	骰	450	99.8015989518	tou2	cuboid bone/dice
+4214	韭	449	99.8018309883	jiu3	leek
+4215	阖	449	99.8020630249	ge2/he2	council-chamber/shelf/side door, entire (family)
+4216	瞑	449	99.8022950614	ming2	close the eyes
+4217	裨	449	99.8025270979	bi4/pi2	to benefit/to aid/advantageous/profitable, (surname)/assistant/small
+4218	宕	448	99.8027586177	dang4	dissipated/put off
+4219	戾	448	99.8029901374	li4	do violence/go against
+4220	镌	448	99.8032216571	juan1	degrade/engrave (wood or stone)
+4221	溟	447	99.8034526601	ming2	drizzle/sea
+4222	牍	447	99.803683663	du2	documents
+4223	隽	447	99.803914666	jun4	smart/eminent/talented
+4224	婊	445	99.8041446354	biao3	prostitute
+4225	鹄	445	99.8043746048	gu3/hu2	swan/white-haired
+4226	埂	444	99.8046040574	geng3	channel for irrigation
+4227	拄	444	99.80483351	zhu3	post/prop
+4228	娲	443	99.8050624458	wa1	(surname)/sister of Fu2 Xi1
+4229	虬	443	99.8052913816	qiu2	young dragon with horns
+4230	萱	442	99.8055198006	xuan1	Hemerocallis flava
+4231	啵	441	99.8057477029	bo	
+4232	蠡	441	99.8059756051	li2/li3	calabash, wood-boring insect
+4233	芋	440	99.8062029906	yu4	Colocasia antiquorum
+4234	胭	439	99.8064298592	yan1	rouge
+4235	豺	438	99.8066562111	chai2	ravenous beast/wolves (collect.)
+4236	啻	437	99.8068820462	chi4	(not) just/(not) only
+4237	褛	437	99.8071078813	lu:3/lv3	soiled/tattered
+4238	蛆	435	99.8073326829	qu1	maggot
+4239	柠	434	99.8075569676	ning2	lemon
+4240	掰	434	99.8077812524	bai1	to break with both hands
+4241	篆	433	99.8080050203	zhuan4	seal characters
+4242	倌	432	99.8082282715	guan1	a groom
+4243	咛	432	99.8084515227	ning2	enjoin
+4244	蛭	432	99.8086747739	zhi4	fluke/leech/hirudinea
+4245	谡	431	99.8088975083	su4	composed/rise/to begin
+4246	荨	431	99.8091202427	qian2	
+4247	莞	431	99.8093429771	guan1/guan3/wan3	Skimmia japonica, (district), smile
+4248	澹	431	99.8095657114	dan4/tan2	tranquil/placid/quiet, (surname)
+4249	纭	431	99.8097884458	yun2	confused/numerous
+4250	潞	430	99.8100106634	lu4	(surname)/name of a river
+4251	郅	429	99.8102323643	zhi4	(surname)/extremely
+4252	弋	428	99.8104535483	yi4	to shoot
+4253	飕	428	99.8106747323	sou1	blow (as of wind)/sound of wind
+4254	螳	428	99.8108959164	tang2	praying mantis
+4255	胄	427	99.8111165836	zhou4	helmet, descendants
+4256	蟑	427	99.8113372509	zhang1	cockroach
+4257	猥	426	99.8115574014	wei3	humble/rustic/plentiful
+4258	宓	426	99.8117775518	mi4	(surname)/still/silent
+4259	昙	426	99.8119977023	tan2	dark clouds
+4260	锏	426	99.8122178528	jian3	
+4261	蟠	426	99.8124380032	pan2	Trichina spiralis/to coil
+4262	柑	425	99.8128777874	gan1	large tangerine
+4263	烯	425	99.8130974211	xi1	alkene
+4264	匐	425	99.8133170547	fu2	fall prostrate
+4265	濮	425	99.8135366884	pu2	name of a river
+4266	蟮	425	99.8137563221	shan4	
+4267	祐	424	99.813975439	you4	
+4268	仄	424	99.8141945559	ze4	oblique tone
+4269	偈	424	99.8144136728	ji4/jie2	Buddhist hymn/gatha/Buddhist verse, forceful/martial
+4270	蜃	424	99.8146327897	shen4	(mythical animal)/clam/sea-serpent
+4271	箴	424	99.8148519066	zhen1	warn
+4272	粼	424	99.8150710235	lin2	clear (as of water)
+4273	嗥	423	99.8152896236	hao2	howl/bawl/to bark/roar
+4274	褴	423	99.8155082237	lan2	ragged garments
+4275	蕨	422	99.815726307	jue2	Pteridium aquilinum
+4276	蓟	421	99.8159438736	ji4	cirsium/thistle
+4277	圩	421	99.8161614401	wei2/xu1	dike
+4278	孪	420	99.8163784899	luan2	twins
+4279	杳	420	99.8165955396	yao3	dark and quiet/disappear
+4280	魇	420	99.8168125894	yan3	nightmare
+4281	荤	419	99.8170291224	hun1	meat dish
+4282	诿	419	99.8172456553	wei3	shirk/give excuses
+4283	簪	419	99.8174621883	zan1	hairpin
+4284	氲	418	99.8176782045	yun1	heavy atmosphere
+4285	摞	417	99.8178937039	luo4	pile up
+4286	飒	417	99.8181092033	sa4	declining/sound of wind
+4287	镂	417	99.8183247027	lou4	engrave/hard steel
+4288	舀	415	99.8185391685	yao3	to scoop
+4289	夙	415	99.8187536344	su4	morning
+4290	臧	413	99.8189670666	zang1	(surname)/good/lucky
+4291	蒿	412	99.8191799821	hao1	wormwood
+4292	貂	412	99.8193928976	diao1	sable/marten
+4293	蜥	411	99.8196052963	xi1	chameleon/Eumeces latiscutatus
+4294	蹩	411	99.8198176949	bie2	limp
+4295	噼	410	99.8200295769	pi1	
+4296	钛	410	99.8202414588	tai4	titanium
+4297	钚	409	99.8204528239	bu4	
+4298	獾	408	99.8206636722	huan1	badger
+4299	濂	408	99.8208745205	lian2	name of a river in Hunan
+4300	铠	408	99.8210853689	kai3	armor
+4301	皙	408	99.8212962172	xi1	white
+4302	霭	408	99.8215070656	ai3	cloudy sky/friendly
+4303	鲈	408	99.8217179139	lu2	common perch
+4304	叵	407	99.8219282454	po3	not/thereupon
+4305	霾	407	99.822138577	mai2	dust-storm
+4306	泯	406	99.8223483918	min3	obliterate/submerge
+4307	碴	405	99.8225576897	cha2	fault/glass fragment/quarrel
+4308	鸵	405	99.8227669877	tuo2	ostrich
+4309	峪	404	99.8229757689	yu4	valley
+4310	饕	403	99.8231840333	tao1	gluttonous
+4311	瘁	402	99.8233917809	cui4	care-worn/distressed/tired/overworked/sick/weary
+4312	睢	402	99.8235995286	sui1	(surname)/stare
+4313	鬃	401	99.8238067594	zong1	bristles/horse's mane
+4314	迩	401	99.8240139902	er3	near
+4315	纣	401	99.8242212211	zhou4	name of an emperor/saddle crupper
+4316	夔	400	99.8244279351	kui2	one-legged monster/respectful
+4317	垠	399	99.8246341324	yin2	bank
+4318	饨	399	99.8248403297	tun2	Chinese ravioli
+4319	榭	399	99.8250465269	xie4	pavilion
+4320	隍	398	99.8252522074	huang2	dry moat/god of city
+4321	娑	398	99.8254578879	suo1	(phonetic)/loose
+4322	篝	398	99.8256635684	gou1	bamboo frame for drying clothes
+4323	榔	397	99.8258687321	lang2	(tree)
+4324	洌	397	99.8260738958	lie4	pure/cleanse
+4325	浜	397	99.8262790595	bang1	stream/creek
+4326	鲑	397	99.8264842232	gui1	
+4327	谔	396	99.8266888701	e4	honest speech
+4328	汩	396	99.826893517	gu3	confused/extinguished
+4329	浣	396	99.8270981639	huan4	to wash/to rinse/10 day period in the month (during Tang dynasty)
+4330	舐	396	99.8273028108	shi4	to lick/lap
+4331	忻	395	99.8277110711	xin1	happy
+4332	咻	394	99.8279146844	xiu1	call out/jeer
+4333	鹑	394	99.8281182978	chun2	quail
+4334	唑	394	99.8283219111	zuo4	(phonetic)/-z + ole (chem.)
+4335	懋	393	99.8285250077	mao4	be great/exert the mind
+4336	皎	393	99.8287281042	jiao3	bright/white
+4337	诒	392	99.828930684	yi2	a present in writing/bequeath
+4338	麾	391	99.829132747	hui1	signal flag/to signal
+4339	辏	390	99.8293342932	cou4	converge/hub of wheel
+4340	氐	389	99.8295353226	di1/di3	name of an ancient tribe, foundation/on the whole
+4341	冽	389	99.829736352	lie4	cold and raw
+4342	箕	388	99.8299368647	ji1	winnow basket
+4343	俚	387	99.8301368605	li3	rustic
+4344	汴	386	99.8303363396	bian4	name of a river in Henan/Henan
+4345	宸	386	99.8305358186	chen2	imperial apartments
+4346	芍	385	99.8307347809	shao2	Paeonia albiflora
+4347	捱	385	99.8309337432	ai2	dawdle/suffer
+4348	摈	384	99.8311321887	bin4	reject/expel/discard/exclude/renounce
+4349	簦	384	99.8315290797	deng1	large umbrella for stalls
+4350	箔	383	99.8317270084	bo2	bamboo screen/door screen/metal foil/leaf/sheet/tinsel
+4351	咝	383	99.8319249371	si1	
+4352	孀	382	99.832122349	shuang1	widow
+4353	怏	381	99.8323192441	yang4	discontented
+4354	谝	380	99.8325156225	pian3	brag
+4355	砧	379	99.8327114841	zhen1	anvil
+4356	馕	379	99.8329073456	nang2	
+4357	耄	379	99.8331032072	mao4	aged
+4358	罂	379	99.8332990688	ying1	earthen jar with small mouth
+4359	漕	379	99.8334949303	cao2	transport by water/watercourse/canal
+4360	沣	378	99.8336902751	feng1	name of a river
+4361	栾	378	99.8338856199	luan2	Koelreuteria paniculata
+4362	榘	378	99.8340809647	ju3	
+4363	烷	378	99.8342763094	wan2	alkane
+4364	榷	375	99.8344701039	que4	footbridge/toll, levy/monopoly
+4365	俑	375	99.8346638983	yong3	wooden figures buried with the dead
+4366	沱	375	99.8348576927	tuo2	tearful/to branch (of river)
+4367	缜	375	99.8350514871	zhen3	fine and close
+4368	鹫	375	99.8352452816	jiu4	black eagle/condor/cruel
+4369	蛳	374	99.8354385592	si1	snail
+4370	剽	373	99.8356313201	piao1	to rob/swift/nimble
+4371	衢	373	99.8358240809	qu2	thoroughfare
+4372	泗	373	99.8360168418	si4	place name/snivel
+4373	臊	372	99.8362090858	sao1/sao4	smell of urine, bashfulness
+4374	瘴	371	99.8364008131	zhang4	malaria/miasma
+4375	酚	370	99.8365920236	fen1	phenol
+4376	纾	370	99.8367832341	shu1	slow/to free from
+4377	晁	370	99.8369744446	chao2	(surname)
+4378	孛	368	99.8371646216	bei4/bo2	comet
+4379	炀	368	99.8373547985	yang2	molten/smelt
+4380	叁	367	99.8375444586	san1	
+4381	憩	366	99.837733602	qi4	to rest
+4382	掬	365	99.8379222286	ju1	
+4383	椤	365	99.8381108551	luo2	
+4384	啮	364	99.8382989649	nie4	gnaw
+4385	畿	364	99.8384870747	ji1	territory around the capital
+4386	掸	363	99.8386746677	dan3	brush away/dust off/a brush or duster/to dust
+4387	镣	363	99.8388622607	liao4	
+4388	骁	363	99.8390498537	xiao1	brave/good horse/strong
+4389	椽	362	99.83923693	chuan2	beam/rafters
+4390	侗	362	99.8394240062	dong4/tong2	(ethnic group), ignorant
+4391	滦	361	99.8396105656	luan2	name of a river
+4392	荩	361	99.839797125	jin4	Arthraxon ciliare/loyal
+4393	泓	361	99.8399836845	hong2	clear/vast and deep
+4394	蚱	361	99.8401702439	zha4	grasshopper
+4395	癜	361	99.8403568033	dian4	erythema/leucoderm
+4396	酯	361	99.8405433628	zhi3	ester
+4397	癸	360	99.8409159649	gui3	10th heavenly stem
+4398	蚜	360	99.8411020075	ya2	aphis
+4399	扪	360	99.8412880502	men2	lay hands on/to cover
+4400	庑	360	99.8414740928	wu3	veranda
+4401	歆	360	99.8416601354	xin1	pleased/moved
+4402	蝮	360	99.8418461781	fu4	venomous snake
+4403	蹶	360	99.8420322207	jue2/jue3	stumble/trample/to kick (as a horse)
+4404	弈	358	99.8422172298	yi4	Chinese chess game
+4405	庋	357	99.8424017221	gui3	a cupboard or pantry to store
+4406	喟	356	99.8425856976	kui4	to sigh
+4407	滂	356	99.8427696731	pang1	rushing (water)
+4408	啕	355	99.8429531319	tao2	wail
+4409	蛎	355	99.8431365906	li4	oyster
+4410	獭	354	99.8433195325	ta3	otter
+4411	槁	354	99.8435024745	gao3	dry/rotten (as wood)
+4412	翊	354	99.8436854164	yi4	assist/ready to fly/respect
+4413	龊	354	99.8438683583	chuo4	dirty/small-minded
+4414	邺	353	99.8440507835	ye4	(surname)/name of ancient district
+4415	莘	353	99.8442332086	shen1/xin1	long/numerous, Asarum sieboldi
+4416	燮	353	99.8444156338	xie4	(surname)/harmony/harmonize
+4417	剁	352	99.8445975422	duo4	chop (meat)
+4418	觐	352	99.8447794505	jin4	
+4419	铛	352	99.8449613589	cheng1/dang1	frying pan/griddle, clank/clang/sound of metal
+4420	谗	351	99.8451427505	chan2	slander/defame/misrepresent/to speak maliciously
+4421	镍	351	99.8453241421	nie4	nickel
+4422	臃	351	99.8455055336	yong1	
+4423	墒	350	99.8456864084	shang1	
+4424	晔	350	99.8458672832	ye4	bright light/to sparkle
+4425	燔	350	99.846048158	fan2	burn/to roast meat for sacrifice
+4426	嘭	349	99.846228516	peng1	
+4427	涿	349	99.8464088741	zhuo1	place name
+4428	醯	349	99.8465892321	xi1	acyl
+4429	箩	348	99.8467690733	luo2	basket
+4430	鄱	347	99.8469483977	po2	name of a lake
+4431	睨	347	99.8471277222	ni4	look askance
+4432	诤	346	99.8473065298	zheng4	
+4433	坳	346	99.8474853375	ao4	a depression/cavity/hollow
+4434	鹭	346	99.8476641451	lu4	heron
+4435	砷	346	99.8478429528	shen1	arsenic
+4436	唏	345	99.8480212437	xi1	sound of sobbing
+4437	伲	343	99.848198501	ni4	
+4438	猬	343	99.8483757583	wei4	
+4439	琥	343	99.8485530156	hu3	amber
+4440	殁	343	99.8487302729	mo4	to end/to die
+4441	蚩	343	99.8489075302	chi1	(surname)/ignorant/worm
+4442	泾	342	99.8490842707	jing1	name of a river
+4443	缥	341	99.8492604944	piao3/piao1	misty/indistinct
+4444	殓	340	99.8494362014	lian4	prepare body for coffin
+4445	鳅	340	99.8496119083	qiu1	loach
+4446	氰	339	99.8497870985	qing2	
+4447	诋	339	99.8499622886	di3	defame/to slander
+4448	刍	339	99.8501374788	chu2	(surname)/cut grass/hay/straw/fodder
+4449	芷	339	99.850312669	zhi3	(plant root used for medicine)
+4450	嶙	339	99.8504878591	lin2	ranges of hills
+4451	逅	339	99.8506630493	hou4	meet unexpectedly
+4452	舫	339	99.8508382394	fang3	2 boats lashed together/large boat
+4453	呓	338	99.8510129128	yi4	talk in sleep
+4454	唰	338	99.8511875862	shua1	
+4455	茁	337	99.8513617428	zhuo2	increase/sprout
+4456	馑	337	99.8515358994	jin3	time of famine or crop failure
+4457	妫	337	99.851710056	gui1	(surname)/name of a river
+4458	骧	337	99.8518842126	xiang1	prance (as a horse)
+4459	苷	336	99.8520578524	gan1	
+4460	擢	336	99.8522314922	zhuo2	pull out/select
+4461	峋	336	99.852405132	xun2	ranges of hills
+4462	袂	336	99.8525787718	mei4	sleeve of a robe
+4463	懑	335	99.8527518948	men4	melancholy
+4464	蓑	334	99.852924501	suo1	
+4465	涞	333	99.8532691967	lai2	brook/ripple
+4466	祉	333	99.8534412862	zhi3	felicity
+4467	踹	333	99.8536133756	chuai4	kick/trample
+4468	掇	331	99.8537844315	duo1	
+4469	沏	331	99.8539554874	qi1	to steep (tea)
+4470	诳	331	99.8541265433	kuang2	deceive/lies
+4471	噫	331	99.8542975991	yi1	(interj. of approval)/belch
+4472	饽	331	99.854468655	bo1	cake/biscuit
+4473	饪	330	99.8546391941	ren4	cooked food/cook until well done
+4474	绺	330	99.8548097332	liu3	skein/tuft/lock
+4475	谘	329	99.8549797555	zi1	consult
+4476	飧	328	99.855149261	sun1	supper
+4477	迳	328	99.8553187666	jing4	way/path/direct/diameter
+4478	铡	327	99.8554877553	zha2	lever-knife
+4479	枞	326	99.8556562273	cong1	abies firma
+4480	熨	325	99.8558241824	yu4/yun4	reconciled/smooth, an iron/to iron
+4481	鋈	324	99.8559916208	wu4	-plated/to plate
+4482	荭	324	99.8561590592	hong2	herb
+4483	赊	323	99.8563259808	she1	buy on credit
+4484	俦	323	99.8564929024	chou2	comrades/friends/companions
+4485	戛	323	99.856659824	jia2	a lance/standing alone
+4486	湎	322	99.8568262288	mian3	drunk
+4487	幺	322	99.8569926336	yao1	
+4488	凇	321	99.8571585216	song1	
+4489	芪	321	99.8573244097	qi2	
+4490	觯	321	99.8574902977	zhi4	goblet
+4491	龌	321	99.8576561857	wo4	dirty/small-minded
+4492	挞	320	99.857821557	ta4	flog/rapid
+4493	嬴	320	99.8579869282	ying2	full/profit/win
+4494	苻	320	99.8581522995	fu2	Angelica anomala
+4495	嘁	320	99.8583176707	qi1	whispering sound
+4496	鞯	320	99.8584830419	jian1	saddle blanket
+4497	肽	319	99.8586478964	tai4	peptide
+4498	恸	318	99.8588122341	tong4	grief
+4499	迨	317	99.858976055	dai4	catch/seize/until
+4500	钰	317	99.8591398758	yu4	hard metals
+4501	儆	316	99.8593031799	jing3	warn/admonish
+4502	觎	315	99.8594659673	yu2	passionately desire
+4503	讫	315	99.8596287546	qi4	finished
+4504	滓	314	99.8597910251	zi3	dregs/sediment
+4505	僮	314	99.8599532956	tong2/zhuang4	boy, name of an ethnic group in Guangxi
+4506	媾	314	99.8601155662	gou4	to marry/to copulate
+4507	龇	314	99.8602778367	zi1	projecting teeth
+4508	胯	313	99.8604395905	kua4	thigh/leg
+4509	涮	313	99.8606013442	shuan4	rinse
+4510	绾	313	99.860763098	wan3	bind up/string together
+4511	杈	313	99.8609248517	cha1/cha4	fork of a tree/pitchfork, branches of a tree/fork of a tree
+4512	赳	313	99.8610866054	jiu1	
+4513	斛	313	99.8612483592	hu2	5 pecks (M)
+4514	觥	313	99.8614101129	gong1	big/cup made of horn/horn wine container
+4515	疸	313	99.8615718667	dan3/da	jaundice
+4516	卞	312	99.8617331037	bian4	(surname)/hurried
+4517	愠	312	99.8618943406	yun4	indignant/feel hurt
+4518	拮	311	99.8620550608	jie2	antagonistic/laboring hard/pressed
+4519	庠	311	99.862215781	xiang2	asylum for the aged/school
+4520	烨	311	99.8623765011	ye4	blaze of fire/glorious
+4521	龢	311	99.8625372213	he2	
+4522	菠	310	99.8626974247	bo1	spinach
+4523	窈	310	99.8628576281	yao3	deep/quiet and elegant
+4524	罄	309	99.8630173147	qing4	entirely/exhausted/stern
+4525	囤	308	99.8631764845	dun4/tun2	bin for grain, to store/hoard
+4526	弁	308	99.8633356544	bian4	cap
+4527	奘	308	99.8634948242	zang4/zhuang3	great, fat/stout
+4528	咣	308	99.863653994	guang1	
+4529	缫	308	99.8638131638	sao1	reel silk from cocoons
+4530	腴	308	99.8639723336	yu2	fat on belly/fertile/rich
+4531	缈	307	99.8641309867	miao3	indistinct
+4532	喵	306	99.8642891229	miao1	meow (onomat. for cat's mewing)
+4533	潢	306	99.8644472592	huang2	dye paper/lake/pond/mount scroll
+4534	遛	306	99.8646053954	liu4/liu2	to stroll/walk a horse/to linger
+4535	柚	306	99.8647635317	you4	pomelo/shaddock
+4536	郏	305	99.8649211511	jia2	name of a district in Henan
+4537	荻	305	99.8650787706	di2	Anaphalis yedoensis
+4538	藜	305	99.8652363901	li2	Chenopodium album
+4539	琨	305	99.8653940095	kun1	(jade)
+4540	镳	304	99.8655511122	biao1	darts/escort/horsebit
+4541	雉	303	99.8657076981	zhi4	ringed pheasant
+4542	橐	302	99.8658637672	tuo2	sack/tube for blowing fire
+4543	骈	301	99.8661753887	pian2	literary style
+4544	蛉	301	99.866330941	ling2	sandfly
+4545	艮	301	99.8664864933	gen4	a sign in trigram
+4546	搽	300	99.8666415289	cha2	apply (ointment, powder)/smear/paint on
+4547	濡	300	99.8667965644	ru2	dilatory/to moisten
+4548	寮	300	99.8669515999	liao2	Laos/fellow-official/hut
+4549	柩	300	99.8671066355	jiu4	bier
+4550	佗	299	99.8672611542	tuo2	carry on the back
+4551	啷	299	99.867415673	lang1	
+4552	诜	298	99.867569675	shen1	inform/inquire
+4553	偻	297	99.8678771621	lou2/lv3	hunchback
+4554	夯	296	99.8680301305	hang1/ben4	drive piles
+4555	闱	296	99.8681830989	wei2	door to women's room/gate to palace
+4556	谖	295	99.8683355505	xuan1	Hemerocallis flava/false/forget
+4557	枸	295	99.8686404538	gou1/gou3/ju3	Acgle sepiaria, Lycium chinense, Citrus medica
+4558	膑	295	99.8687929054	bin4	kneecap/patella
+4559	虻	295	99.868945357	meng2	Tabanus trigonus/house fly
+4560	筠	295	99.8690978086	yun2/jun1	skin of bamboo
+4561	埽	294	99.8692497434	sao4	broom/dike
+4562	笞	294	99.8694016783	chi1	to whip with bamboo strips
+4563	臾	294	99.8695536131	yu2	(surname)/a moment/little while
+4564	婀	293	99.8697050311	e1	graceful/willowy/unstable
+4565	珞	292	99.8698559324	luo4	neck-ornament
+4566	粑	292	99.8700068337	ba1	tsamba (food in Tibet)
+4567	怵	291	99.8701572181	chu4	fearful/timid/to fear
+4568	绻	291	99.8703076026	quan3	bound in a league
+4569	殒	291	99.8704579871	yun3	perish/die
+4570	觊	291	99.8706083716	ji4	covet/long for
+4571	崂	291	99.870758756	lao2	name of a mountain in Shandong
+4572	颧	290	99.8709086237	quan2	cheek bones
+4573	嗑	290	99.8710584914	ke4/ke1	to crack (seeds) with front teeth
+4574	榛	290	99.8712083591	zhen1	hazel tree/Corylus heterophylla
+4575	昱	290	99.8713582268	yu4	bright light
+4576	蜴	289	99.8715075777	yi4	chameleon/Eumeces latiscutatus
+4577	鳝	289	99.8716569286	shan4	Chinese yellow eel
+4578	噙	288	99.8718057627	qin2	hold in the mouth
+4579	淼	288	99.8719545968	miao3	a flood/infinity
+4580	矾	287	99.8721029142	fan2	alum
+4581	硼	287	99.8722512315	peng2	boron
+4582	囿	287	99.8723995488	you4	park/to limit/be limited to
+4583	泅	286	99.8725473494	qiu2	submerge/swim under water
+4584	邂	286	99.8726951499	xie4	meet unexpectedly
+4585	钜	286	99.8728429505	ju4	great/hard iron
+4586	蠹	286	99.872990751	du4	bookworm/Lepisma saccharina
+4587	垩	285	99.8731380348	e4	to whitewash/to plaster
+4588	乩	283	99.873284285	ji1	to divine
+4589	嗝	283	99.8734305352	ge2	hiccup/belch
+4590	淦	283	99.8735767854	gan4	name of a river
+4591	樽	282	99.8737225188	zun1	goblet/bottle/wine-jar
+4592	诮	280	99.8738672186	qiao4	ridicule/to blame
+4593	揆	279	99.8740114017	kui2	consider/estimate
+4594	啐	279	99.8741555847	cui4	sip/spit
+4595	淅	279	99.8742997678	xi1	sound of rain/sleet etc.
+4596	榉	279	99.8744439508	ju3	Zeikowa acuminata
+4597	馗	278	99.8745876171	kui2	cheekbone/crossroads/high
+4598	辔	278	99.8747312834	pei4	bridle/reins
+4599	暹	278	99.8748749496	xian1	Siam
+4600	骛	278	99.8750186159	wu4	fast/greedy/run rapidly
+4601	鱿	278	99.8751622822	you2	cuttlefish
+4602	苫	277	99.8753054316	shan1	straw mat/thatch
+4603	犷	277	99.8754485811	guang3	
+4604	獠	277	99.8755917306	liao2	fierce/hunt/name of a tribe
+4605	詈	277	99.8757348801	li4	curse/scold
+4606	竦	277	99.8758780296	song3	horrified/incite/raise
+4607	篙	276	99.8760206623	gao1	pole for punting boats
+4608	诨	276	99.876163295	hun4	jest/nickname
+4609	铰	275	99.8763054109	jiao3	scissors/to cut (with scissors)
+4610	馄	275	99.8764475268	hun2	Chinese ravioli
+4611	蜚	275	99.8765896427	fei3/fei1	gad-fly
+4612	峒	275	99.8767317586	tong2/dong4	name of a mountain
+4613	滢	275	99.8768738745	ying2	clear/limpid (of water)
+4614	琬	274	99.8770154737	wan3	ensign of royalty
+4615	靓	274	99.8771570728	jing4/liang4	make up (face)
+4616	狻	273	99.8772981551	suan1	(mythical animal)
+4617	璨	273	99.8774392375	can4	gem/luster of gem
+4618	犟	273	99.8775803198	jiang4	
+4619	鸬	272	99.8777208854	lu2	fishing cormorant
+4620	螨	272	99.8778614509	man3	
+4621	芩	271	99.8780014997	qin2	Phragmites japonica
+4622	嘹	271	99.8781415485	liao2	clear sound/cry (of cranes etc.)
+4623	锟	271	99.8782815972	kun1	steel sword
+4624	蜇	271	99.878421646	zhe1/zhe2	to sting, jellyfish
+4625	洹	270	99.878561178	huan2	name of a river
+4626	栉	270	99.87870071	zhi4	
+4627	俪	269	99.8788397252	li4	husband and wife
+4628	钍	269	99.8789787404	tu3	thorium
+4629	锨	268	99.8791172388	xian1	
+4630	瑁	268	99.8792557372	mao4	(jade)
+4631	壹	267	99.8793937188	yi1	one (alternate form of 一 used on checks)
+4632	痿	267	99.8795317005	wei3	atrophy
+4633	竑	267	99.8796696821	hong2	
+4634	粕	266	99.879807147	po4	grains in distilled liquor
+4635	犄	266	99.8799446118	ji1	ox-horns/wing of an army
+4636	瘙	266	99.8800820766	sao4	
+4637	饯	265	99.8802190247	jian4	farewell dinner/preserves
+4638	抟	265	99.8803559728	tuan2	roll round with hand
+4639	衲	265	99.8804929208	na4	cassock/to line
+4640	踮	264	99.8806293521	dian3	tip toe
+4641	龅	264	99.8807657834	pao2/bao1	projecting teeth
+4642	愎	262	99.8809011811	bi4	perverse/obstinate
+4643	馥	262	99.8810365788	fu4	
+4644	梏	261	99.8811714597	gu4	braces (med.)/fetters/manacles
+4645	讣	260	99.8813058238	fu4	obituary notice
+4646	邝	260	99.881440188	kuang4	(surname)
+4647	艿	260	99.8815745521	nai3	
+4648	趺	260	99.8817089162	fu1	instep/tarsus
+4649	鲟	260	99.8818432804	xun2	acipenser sp./sturgeon
+4650	剜	259	99.8819771277	wan1	scoop out
+4651	绉	259	99.8821109751	zhou4	crepe/wrinkle
+4652	罅	259	99.8822448224	xia4	crack/grudge
+4653	笥	259	99.8823786698	si4	hamper/trunk
+4654	衩	258	99.8825120003	cha3/cha4	open seam of a garment/shorts/panties, slit on either side of robe
+4655	姣	257	99.8826448141	jiao1	(surname)/cunning/pretty
+4656	斫	257	99.8827776279	zhuo2	chop/carve wood
+4657	鹗	257	99.8829104417	e4	fish eagle/fish hawk/osprey
+4658	爻	256	99.8831755525	yao2	lines on a trigram
+4659	猕	256	99.8833078495	mi2	macaque
+4660	晗	256	99.8834401464	han2	
+4661	铩	256	99.8835724434	sha1	spear
+4662	窕	256	99.8837047404	tiao3	quiet and elegant
+4663	仨	255	99.8838365206	sa1	three (of)
+4664	搡	255	99.8839683009	sang3	push back/push over
+4665	崴	255	99.8841000811	wei1/wai3	high, lofty/precipitous
+4666	酢	255	99.8842318613	zuo4	toast to host by guest
+4667	檄	254	99.8843631247	xi2	dispatch/order
+4668	佞	254	99.8844943881	ning4	eloquent/talent
+4669	孑	254	99.8846256515	jie2	alone/mosquito larvae/small
+4670	璀	254	99.884756915	cui3	luster of gems
+4671	岷	253	99.8848876616	min2	name of a river in Sichuan
+4672	舛	253	99.8850184082	chuan3	mistaken/erroneous/contradictory
+4673	邕	253	99.8851491549	yong1	harmonious
+4674	闿	253	99.8852799015	kai3	
+4675	铂	252	99.8854101314	bo2	platinum
+4676	霁	252	99.8855403612	ji4	sky clearing up
+4677	犒	251	99.8856700743	kao4	give a bonus to
+4678	馏	250	99.8857992706	liu4/liu2	reheat by steaming
+4679	阈	250	99.8859284669	yu4	threshold
+4680	麋	250	99.8860576632	mi2	(surname)/moose/river bank
+4681	麒	250	99.8861868594	qi2	mythical unicorn
+4682	苁	249	99.8863155389	cong1	Boschniakia glabra
+4683	摁	249	99.8864442184	en4	to press (with finger)
+4684	涔	249	99.8865728979	cen2	overflow/rainwater/tearful
+4685	宥	249	99.8867015774	you4	forgive/help/profound
+4686	妍	249	99.8868302569	yan2	beautiful
+4687	铤	249	99.8869589364	ding4/ting3	ingot, big arrow/walk fast
+4688	锷	249	99.8870876159	e4	blade edge/sharp
+4689	嗲	248	99.8872157786	dia3	
+4690	恽	248	99.8873439414	yun4	(surname)
+4691	麂	248	99.8874721041	ji3	Moschus chinensis
+4692	赝	247	99.88759975	yan4	false
+4693	胛	247	99.8877273959	jia3	shoulder blade
+4694	哂	246	99.8878545251	shen3	smile
+4695	撷	245	99.8879811374	xie2	collect
+4696	呶	245	99.8881077498	nao2	clamor
+4697	噘	245	99.8882343621	jue1	pout
+4698	懔	245	99.8883609745	lin3	fear
+4699	栎	245	99.8884875869	li4	oak/Quercus serrata
+4700	桎	245	99.8886141992	zhi4	fetters
+4701	霰	245	99.8887408116	xian4	sleet
+4702	飨	245	99.8888674239	xiang3	offer or enjoy sacrifice
+4703	揄	244	99.8889935195	yu2	draw out/let hanging
+4704	噔	244	99.8891196151	deng1	
+4705	娣	244	99.8892457106	di4	wife of a younger brother
+4706	薏	243	99.8893712894	yi4	Coix lacryma
+4707	忝	243	99.8894968682	tian3	to shame
+4708	咤	243	99.889622447	zha4	
+4709	嗵	242	99.889747509	tong1	
+4710	迤	242	99.889872571	yi2/yi3	winding, extending to
+4711	贲	242	99.889997633	ben1/bi4	energetic, bright
+4712	胪	242	99.890122695	lu2	belly/skin/to state
+4713	鍪	242	99.890247757	mou2	iron pot/metal cap
+4714	泸	242	99.890372819	lu2	name of a river/place name
+4715	蔫	241	99.8904973642	nian1	fade/wither
+4716	刈	241	99.8906219095	yi4	mow
+4717	僖	241	99.8907464547	xi1	(surname)/cautious/merry/joyful
+4718	咿	241	99.8908709999	yi1	(onomat.)
+4719	鹌	241	99.8909955451	an1	quail
+4720	嗪	240	99.8911195735	qin2	
+4721	茏	239	99.8912430852	long2	Polygonum posumbu
+4722	茯	239	99.8913665968	fu2	Pachyma cocos/china root
+4723	岫	239	99.8914901085	xiu4	cave/mountain peak
+4724	嵘	239	99.8916136201	rong2	lofty
+4725	轱	239	99.8917371318	gu1	
+4726	怼	239	99.8918606434	dui4	dislike/hate
+4727	铨	239	99.8919841551	quan2	estimate/select
+4728	昕	237	99.8921066332	xin1	dawn
+4729	郢	236	99.8922285944	ying3	name of an ancient city
+4730	咩	236	99.8923505557	mie1	the bleating of sheep
+4731	馊	236	99.892472517	sou1	rancid/soured (as food)
+4732	髡	236	99.8925944783	kun1	make the head bald
+4733	澧	236	99.8927164396	li3	(surname)/name of a river
+4734	苣	235	99.8928378841	ju4	(lettuce)
+4735	濯	235	99.8929593286	zhuo2	rinse/to cleanse
+4736	盥	235	99.8930807731	guan4	wash (especially hands)
+4737	囡	234	99.8932017009	nan1	one's daughter/to filch/to secrete
+4738	砺	234	99.8933226286	li4	grind/sandstone
+4739	佘	233	99.8934430395	she2	(surname)
+4740	谶	233	99.8935634504	chen4	prophecy/omen
+4741	弑	233	99.8936838614	shi4	murder a superior
+4742	楂	233	99.8938042723	cha2/zha1	fell trees/raft/to hew, Chinese quince/hawthorn
+4743	翦	233	99.8939246833	jian3	cut with scissors/scissors
+4744	怩	232	99.8940445774	ni2	shy, timid, bashful/look ashame
+4745	蠼	232	99.8941644716	qu2	
+4746	霏	232	99.8942843657	fei1	fall of snow
+4747	楹	232	99.8944042599	ying2	pillar
+4748	讴	231	99.8945236372	ou1	sing ballads/songs
+4749	锲	231	99.8946430146	qie4	cut/to carve
+4750	慵	230	99.8947618752	yong1	careless
+4751	胝	230	99.8948807358	zhi1	callous
+4752	砭	230	99.8949995963	bian1	a stone probe/acupuncture
+4753	潍	229	99.8951179401	wei2	name of a river
+4754	杵	229	99.8952362839	chu3	pestle/to poke
+4755	樾	229	99.8953546277	yue4	shade of trees
+4756	帼	228	99.8954724547	guo2	cap worn by women/feminine
+4757	碣	228	99.8955902817	jie2	stone tablet
+4758	诌	227	99.895707592	zou1/zhou1	make up (a story)
+4759	徕	227	99.8958249022	lai2	to come
+4760	胴	227	99.8959422124	dong4	large intestine/torso
+4761	钴	227	99.8960595227	gu3	cobalt
+4762	裟	227	99.8961768329	sha1	Buddhist monk's robe
+4763	啶	227	99.8962941431	ding4	-d + ine (chem.)
+4764	铣	226	99.8964109365	xian3/xi3	shining metal
+4765	铱	226	99.89652773	yi1	iridium
+4766	楫	226	99.8966445234	ji2	oar/to row
+4767	赭	226	99.8967613169	zhe3	ocher
+4768	碛	225	99.8968775935	qi4	moraine/rocks in shallow water
+4769	酊	225	99.8969938702	ding3	intoxicated
+4770	魑	225	99.8971101468	chi1	mountain elf
+4771	醛	225	99.8972264235	quan2	aldehyde
+4772	剐	224	99.8973421834	gua3	cut off the flesh as punishment
+4773	畦	224	99.8974579432	qi2	furrow/small plot of farm land
+4774	陂	224	99.8975737031	pi2/po1/bei1	reservoir, rugged/uneven
+4775	闶	224	99.897689463	kang1	
+4776	阄	224	99.8978052228	jiu1	(draw) lots/lot (in a game of chance)
+4777	祚	223	99.8979204659	zuo4	blessing/the throne
+4778	鹘	223	99.898035709	hu2/gu3	falcon/migratory bird
+4779	泱	222	99.8981504353	yang1	agitated (wind, cloud)/boundless
+4780	趄	222	99.8982651616	ju1/qie4	hesitate/mark time, recline
+4781	骅	222	99.8983798879	hua2	chestnut horse
+4782	陲	222	99.8984946142	chui2	frontier
+4783	郧	221	99.8986088237	yun2	name of a feudal state
+4784	倜	221	99.8987230332	ti4	energetic/exalted/magnanimous
+4785	呤	221	99.8988372427	ling2/ling4	purine in chem. compound/whisper
+4786	燧	221	99.8989514523	sui4	fire/speculum
+4787	铉	221	99.8990656618	xuan4	stand for bronze tripod (archeol.)/used in names, e.g. 卢武铉 President Loh Roh Mu-hyun of South Korea
+4788	粲	220	99.8991793545	can4	beautiful/bright/splendid/smilingly
+4789	骶	220	99.8992930472	di3	
+4790	峁	219	99.8994062232	mao3	
+4791	忸	219	99.8995193991	niu3	accustomed to/blush/be shy
+4792	渌	219	99.8996325751	lu4	clear (water)/strain liquids
+4793	骞	219	99.899745751	qian1	defective/raise
+4794	髭	219	99.899858927	zi1	mustache
+4795	戡	219	99.8999721029	kan1	kill/suppress
+4796	钨	218	99.9000847621	wu1	tungsten
+4797	谲	218	99.9001974212	jue2	deceitful
+4798	苋	218	99.9003100804	xian4	Amarantus mangostanus
+4799	锃	218	99.9004227395	zeng4	
+4800	蜊	218	99.9005353987	li2	clam
+4801	幄	217	99.9006475411	wo4	tent
+4802	闼	217	99.9007596835	ta4	door of an inner room
+4803	戕	217	99.9008718258	qiang1	
+4804	骊	217	99.9009839682	li2	black horse/good horse
+4805	虢	217	99.9010961106	guo2	name of an ancient state
+4806	烩	216	99.9012077362	hui4	cooked in soy and vinegar
+4807	傥	216	99.9013193618	tang3	if/unexpectedly
+4808	妲	216	99.9014309873	da2	concubine of last Shang emperor
+4809	绌	216	99.9015426129	chu4	crimson silk/deficiency/to stitch
+4810	桠	216	99.9016542385	ya1	forking branch
+4811	袈	216	99.9017658641	jia1	Buddhist monk's robe
+4812	鎗	216	99.9018774897	qiang1	
+4813	薮	215	99.9019885985	sou3	marsh/place of concourse
+4814	揿	215	99.9020997073	qin4	to press (bell)
+4815	杲	215	99.9022108161	gao3	high/sun shines brightly/to shine
+4816	肓	215	99.9023219249	huang1	region between heart and diaphragm
+4817	厝	214	99.9024325169	cuo4	bury/to place/dispose
+4818	莅	214	99.9025431089	li4	attend (official functions)
+4819	氤	214	99.902653701	yin1	generative forces/magic emanation
+4820	缙	214	99.902764293	jin4	red silk
+4821	衮	213	99.9028743682	gun3	imperial robe
+4822	诟	213	99.9029844435	gou4	sense of shame/to abuse
+4823	旖	213	99.9030945187	yi3	fluttering of flag
+4824	硒	213	99.9032045939	xi1	selenium
+4825	唁	212	99.9033141524	yan4	condole with
+4826	嬗	212	99.9034237108	shan4	changes and succession
+4827	硎	212	99.9035332693	xing2	whetstone
+4828	裱	212	99.9036428277	biao3	hang (paper)/mount (painting)
+4829	颦	212	99.9037523862	pin2	knit the brows
+4830	靥	211	99.9039709863	ye4	dimple
+4831	纥	211	99.9040800279	ge1/he2	knot, tassels
+4832	煨	211	99.9041890696	wei1	simmer/to roast in ashes
+4833	礴	211	99.9042981113	bo2	fill/extend
+4834	鏖	211	99.9044071529	ao2	violent fighting
+4835	蝈	210	99.9045156778	guo1	cyrtophyllus sp.
+4836	笏	210	99.9046242027	hu4	tablet held at an audience
+4837	羿	210	99.9047327276	yi4	name of a famous archer
+4838	鼐	209	99.9048407357	nai4	incense tripod
+4839	湟	209	99.9049487438	huang2	name of a river
+4840	甑	209	99.9050567518	zeng4	caldron/rice pot
+4841	炜	209	99.9051647599	wei3	glow/raging fire
+4842	煲	209	99.905272768	bao1	pot or saucepan/to boil/cook or heat
+4843	锉	209	99.9053807761	cuo4	to file, a file (tool for shaping metal)/to file
+4844	笕	209	99.9054887842	jian3	bamboo water pipe
+4845	喑	208	99.9055962755	yin1	dumb
+4846	嶂	208	99.9057037668	zhang4	cliff/range of peaks
+4847	浔	208	99.9058112581	xun2	name of a river/steep bank
+4848	弭	208	99.9059187494	mi3	to stop/repress
+4849	妪	208	99.9060262408	yu4	brood over/old woman/protect
+4850	锂	208	99.9061337321	li3	lithium
+4851	苡	207	99.9062407066	yi3	plantago major l. var. asiatica
+4852	孳	207	99.9063476811	zi1	industrious/produce/bear
+4853	颏	207	99.9064546556	ke1/ke2	chin, chin
+4854	醴	207	99.9065616302	li3	sweet wine
+4855	渚	206	99.9067750624	zhu3	islet/bank
+4856	轭	206	99.9068815202	e4	restrain/yoke
+4857	鹬	206	99.9069879779	yu4	common snipe
+4858	蚝	206	99.9070944356	hao2	
+4859	膘	205	99.9073068343	biao1	fat of a stock animal
+4860	邛	205	99.9074127753	qiong2	mound/place name
+4861	痨	205	99.9075187162	lao2	tuberculosis
+4862	褡	205	99.9076246572	da1	cummerbund
+4863	耦	205	99.9077305981	ou3	pair/mate/ploughshare
+4864	覃	205	99.9078365391	tan2	(surname)/deep
+4865	馔	204	99.9080479042	zhuan4	food/delicacies
+4866	篾	204	99.9081533284	mie4	bamboo splints for baskets
+4867	兖	203	99.9082582358	yan3	place name
+4868	阋	203	99.9083631431	xi4	
+4869	遨	203	99.9084680505	ao2	make excursion/ramble/travel
+4870	爰	203	99.9085729579	yuan2	therefore/to lead on to
+4871	痂	203	99.9086778653	jia1	scab
+4872	艄	203	99.9087827727	shao1	stern of boat
+4873	耨	203	99.90888768	nou4	hoe
+4874	沤	202	99.9089920706	ou1/ou4	bubble/froth, steep
+4875	邋	202	99.9090964612	la1	
+4876	焓	202	99.9092008518	han2	
+4877	秣	202	99.9093052424	mo4	feed a horse with grain/horse feed
+4878	昶	202	99.909409633	chang3	bright/long day
+4879	窣	200	99.9097217713	su1	
+4880	绦	200	99.9098251283	tao1	braid/cord/sash
+4881	俎	200	99.9099284853	zu3	a stand for food at sacrifice
+4882	榫	199	99.9100313256	sun3	tenon and mortise
+4883	蟪	199	99.9101341658	hui4	(cicada)/Platypleura kaempferi
+4884	稗	198	99.9102364892	bai4	millet/Panicum crus
+4885	謇	198	99.9103388127	jian3	speak out boldly
+4886	氩	198	99.9104411362	ya4	argonium
+4887	锴	198	99.9106457831	kai3	high quality iron
+4888	龉	198	99.9107481065	yu3	irregular teeth
+4889	烃	198	99.91085043	ting1	hydrocarbon
+4890	俣	197	99.9109522367	yu3	big
+4891	嬷	197	99.9110540433	ma1/mo2	ma/mamma
+4892	肱	197	99.91115585	gong1	brachium/humerus
+4893	鸢	197	99.9112576567	yuan1	kite
+4894	笫	197	99.9113594633	zi3	planks of bed/sleeping-mat
+4895	痤	197	99.91146127	cuo2	acne
+4896	菏	196	99.9116643666	he2	
+4897	莆	196	99.9117656565	pu2	place name
+4898	芨	196	99.9118669463	ji2/ji1	Bletilla hyacinthina (mucilaginous)/Acronym for the Chinese Elder tree ?草
+4899	阕	196	99.9119682362	que4	section of a song/shut
+4900	砣	196	99.9120695261	tuo2	steelyard weight
+4901	碜	196	99.912170816	chen3	
+4902	鼹	196	99.9122721059	yan3	mole
+4903	猷	195	99.9124741689	you2	consult with/to scheme
+4904	竽	195	99.912574942	yu2	(mus. instr.)
+4905	舸	195	99.9126757151	ge3	barge
+4906	诓	194	99.9127759714	kuang1	mislead/to swindle
+4907	錾	194	99.9128762277	zan4	engrave
+4908	淬	193	99.9129759672	cui4	dip into water/to temper
+4909	隗	193	99.9130757068	wei3	(surname)/eminent/lofty
+4910	悌	193	99.9131754463	ti4	do one's duty as a younger brother
+4911	姘	193	99.9132751858	pin1	be a mistress or lover
+4912	槭	193	99.9133749254	qi4	
+4913	邈	193	99.9134746649	miao3	profound/remote
+4914	婕	193	99.9135744044	jie2	handsome
+4915	歙	192	99.9136736272	she4/xi1	name of a district in Anhui
+4916	稹	192	99.9137728499	zhen3	accumulate/fine and close
+4917	蹴	192	99.9138720727	cu4	carefully/kick/tread on/stamp
+4918	砒	191	99.9139707786	pi1	arsenic
+4919	痈	191	99.9140694846	yong1	carbuncle
+4920	镏	191	99.9141681906	liu2	lutecium
+4921	羯	191	99.9142668965	jie2	castrate a ram/deer's skin
+4922	豕	191	99.9143656025	shi3	hog/swine
+4923	鲂	191	99.9144643084	fang2	bream/Zeus japanicus
+4924	蓖	190	99.9145624976	bi4	the castor-oil plant
+4925	匦	190	99.9146606868	gui3	small box
+4926	笤	190	99.914758876	tiao2	broom
+4927	峥	189	99.9148565484	zheng1	excel/lofty
+4928	徭	189	99.9149542207	yao2	compulsory service
+4929	浃	189	99.9150518931	jia1	
+4930	烊	189	99.9151495655	yang2	molten/smelt
+4931	窸	188	99.9153443935	xi1	
+4932	酆	188	99.9154415491	feng1	(surname)/name of an ancient city
+4933	缢	188	99.9155387047	yi4	hang/strangle oneself
+4934	褓	188	99.9156358603	bao3	cloth for carrying baby on back
+4935	蚨	188	99.9157330159	fu2	(water-beetle)/money
+4936	翳	188	99.9158301715	yi4	feather screen/to screen/to shade
+4937	趔	188	99.9159273272	lie4	stumble
+4938	炔	187	99.916023966	que1/gui4	alkyne
+4939	誊	187	99.9161206048	teng2	make a (clean) copy
+4940	赜	187	99.9162172436	ze2	mysterious
+4941	仃	187	99.9163138824	ding1	alone
+4942	勖	187	99.9164105213	xu4	exhort/stimulate
+4943	葺	187	99.9165071601	qi4	to repair
+4944	蚴	187	99.9166037989	you4	larva
+4945	泷	187	99.9167004377	long2/shuang1	torrential (rain), name of a river in Guangdong
+4946	蛴	187	99.9167970765	qi2	larva/maggot
+4947	媸	186	99.9169898374	chi1	ugly woman
+4948	俳	185	99.9170854426	pai2	irresolute/not serious/variety show
+4949	诖	185	99.9171810479	gua4	deceive/disturb
+4950	茑	185	99.9172766531	niao3	grossulariaceae
+4951	逡	185	99.9173722584	qun1	shrink from
+4952	孱	185	99.9174678636	can4/chan2	dodger, coward/weak
+4953	砦	185	99.9175634689	zhai4	stronghold/stockade
+4954	跸	185	99.9176590741	bi4	to clear streets when emperor tours
+4955	祜	185	99.9177546794	hu4	celestial blessing
+4956	伉	184	99.9178497679	kang4	husband/wife
+4957	溴	184	99.9179448563	xiu4	bromine
+4958	屐	184	99.9180399448	ji1	clogs
+4959	飚	184	99.9181350332	biao1	
+4960	蛞	184	99.9182301217	kuo4	
+4961	掮	183	99.9184197819	qian2	carry on shoulders
+4962	崆	183	99.9185143535	kong1	name of a mountain
+4963	庾	183	99.9186089252	yu3	(surname)/name of a mountain
+4964	橛	183	99.9187034969	jue2	a peg/low post
+4965	矸	183	99.9187980686	gan1	
+4966	鸨	183	99.9188926403	bao3	Chinese bustard/procuress
+4967	圻	183	99.9189872119	qi2	boundary/a border
+4968	缂	183	99.9190817836	ke4	to woof
+4969	蒯	183	99.9191763553	kuai3	a rush/scirpus cyperinus
+4970	诹	182	99.9192704102	zou1	choose/consult
+4971	啭	182	99.9193644651	zhuan4	sing, chirp, warble, twitter
+4972	饧	182	99.91945852	xing2/tang2	malt-sugar/molasses
+4973	镉	182	99.9195525749	ge2	cadmium
+4974	鸪	182	99.9196466298	gu1	partridge/Francolinus chinensis
+4975	蛩	182	99.9197406847	qiong2	anxious/grasshopper/a cricket
+4976	蠖	182	99.9198347396	huo4	looper caterpillar
+4977	劭	181	99.9200223326	shao4	(surname)/stimulate to effort
+4978	哐	181	99.9201158707	kuang1	
+4979	崧	181	99.9202094088	song1	lofty/name of a mountain in Henan
+4980	杼	181	99.9203029469	zhu4	shuttle of a loom
+4981	棂	181	99.920396485	ling2	lattice, the lattice of a window a sill, a lintel
+4982	螫	181	99.9204900231	shi4/zhe1	to sting, to sting
+4983	龃	181	99.9205835612	ju3	irregular/uneven teeth
+4984	饔	181	99.9206770993	yong1	dressed food/first meal of the day
+4985	遑	181	99.9207706374	huang2	leisure
+4986	颢	181	99.9208641755	hao4	bright/white
+4987	腱	180	99.9209571969	jian4	gristle
+4988	襁	180	99.9210502182	qiang3	cloth for carrying baby on back
+4989	忾	179	99.9211427227	kai4	anger
+4990	濠	179	99.9212352273	hao2	trench
+4991	牝	179	99.9213277318	pin4	female
+4992	蛄	179	99.9214202363	gu1	mole-cricket
+4993	鲆	179	99.9215127409	ping2	
+4994	嗄	178	99.9216047286	a2/sha4	ah (exclamatory part.), hoarse
+4995	灏	178	99.9216967164	hao4	vast (of water)
+4996	疥	177	99.9217881874	jie4	scabies
+4997	苜	177	99.9218796583	mu4	clover
+4998	荞	177	99.9219711293	qiao2	buckwheat
+4999	嘣	177	99.9220626003	beng1	
+5000	夤	177	99.9221540712	yin2	late at night
+5001	砝	177	99.9222455422	fa3	
+5002	颞	177	99.9223370132	nie4	temporal bones
+5003	忤	176	99.9225194383	wu3	disobedient/unfilial
+5004	遢	176	99.9226103925	ta4/ta1	careless, negligent, slipshod
+5005	旎	176	99.9227013467	ni3	fluttering of flags
+5006	瘛	176	99.9227923009	chi4	
+5007	魉	176	99.9228832551	liang3	sprite/fairy
+5008	辇	176	99.9229742092	nian3	emperor's carriage
+5009	瓤	175	99.9231556008	rang2	pulp of fruit
+5010	荥	175	99.9232460382	xing2/ying2	place name
+5011	涫	175	99.9233364756	guan4	
+5012	娌	175	99.923426913	li3	husband's brother's wife
+5013	氚	175	99.9235173504	chuan1	tritium
+5014	臁	175	99.9236077878	lian2	
+5015	毂	175	99.9236982252	gu1/gu3	wheel, hub of wheel
+5016	碇	175	99.9237886626	ding4	anchor
+5017	毖	174	99.9238785832	bi4	careful/prevent
+5018	壅	174	99.9239685038	yong1	obstruct/stop up
+5019	吡	174	99.9240584245	bi3	
+5020	缛	174	99.9241483451	ru4	adorned/beautiful
+5021	玮	174	99.9242382657	wei3	(reddish jade)/precious/rare
+5022	羟	174	99.9243281863	qiang3	hydroxyl (radical)
+5023	珈	173	99.9245075107	jia1	gamma/jewelry
+5024	颀	173	99.9245969146	qi2	tall
+5025	虼	173	99.9246863184	ge4	flea
+5026	佝	172	99.9248640925	gou1	
+5027	翕	172	99.9249529795	xi4/xi1	agree
+5028	遴	172	99.9250418666	lin2	(surname)/select for appointment
+5029	珏	172	99.9251307536	jue2	gems mounted together
+5030	郛	172	99.9252196407	fu2	suburbs
+5031	玖	171	99.925485785	jiu3	(black stone)/nine (fraud-proof)
+5032	蹇	171	99.9255741553	jian3	(surname)/difficulty/lame
+5033	逋	171	99.9256625255	bu1	flee/abscond/owe
+5034	氅	171	99.9257508958	chang3	overcoat
+5035	粽	171	99.925839266	zong4	rice dumplings wrapped in leaves
+5036	诂	171	99.9259276363	gu3	comment/explain
+5037	岢	170	99.9260154898	ke3	name of a mountain
+5038	聒	170	99.9261033432	guo1	
+5039	髁	170	99.9261911967	ke1	condyles
+5040	黍	169	99.9262785334	shu3	broomcorn millet/glutinous millet
+5041	芾	169	99.9263658701	fei4/fu2	small, luxuriance of vegetation
+5042	淝	169	99.9264532068	fei2	name of a river
+5043	鲎	169	99.9265405435	hou4	king crab
+5044	鞣	169	99.9266278802	rou2	suede/chamois/tannin/to tan
+5045	髋	169	99.9267152168	kuan1	pelvis/pelvic
+5046	闳	169	99.9268025535	hong2	(surname)/big/gate
+5047	潆	169	99.9268898902	ying2	eddy/small river
+5048	汨	168	99.9269767101	mi4	name of a river
+5049	胍	168	99.92706353	gua1	guanidine
+5050	阏	167	99.9271498331	e4/yan1	shut/stop, first wives of xiong-nu chiefs
+5051	钤	167	99.9272361363	qian2	latch of door/seal
+5052	鹜	167	99.9273224394	wu4	
+5053	鬈	167	99.9274087425	quan2	to curl/curled
+5054	铵	167	99.9274950456	an3	ammonium
+5055	戬	167	99.9275813487	jian3	carry to the utmost/to cut
+5056	崮	166	99.9277534382	gu4	(element in mountain names)
+5057	枰	166	99.9278392245	ping2	chess-like game
+5058	樯	166	99.9279250108	qiang2	boom/mast
+5059	脍	166	99.9280107972	kuai4	chopped meat or fish
+5060	畲	166	99.9280965835	yu2/she1	cultivated field
+5061	衾	166	99.9281823698	qin1	coverlet/quilt
+5062	蹼	166	99.9282681562	pu3	web (of feet of ducks, frogs, etc.)
+5063	劬	165	99.928439212	qu2	labor
+5064	咭	165	99.9285244816	ji1	
+5065	囫	165	99.9286097511	hu2	whole/in one lump
+5066	洱	165	99.9286950207	er3	name of a river
+5067	刎	164	99.9287797735	wen3	cut across (throat)
+5068	芏	164	99.9288645262	du4	
+5069	琊	164	99.928949279	ya2	
+5070	碚	164	99.9290340317	bei4	place name in Chongqing
+5071	鳕	164	99.9291187845	xue3	codfish/Gadus macrocephalus
+5072	谪	163	99.9292030205	zhe2	disgrace (an official)/find fault
+5073	芎	163	99.9292872565	xiong1	
+5074	恂	163	99.9293714924	xun2	sincere
+5075	槿	163	99.9294557284	jin3	Hibiscus syriacus/transient
+5076	鲢	163	99.9295399644	lian2	Hypophthalmichthys moritrix
+5077	鲧	163	99.9296242004	gun3	father of great yeu
+5078	嘧	163	99.9297084363	mi4	(phonetic) as in pyrimidine
+5079	绀	163	99.9297926723	gan4	violet or purple
+5080	郦	162	99.9298763915	li4	(surname)/ancient place name
+5081	噱	162	99.9299601107	jue2	loud laughter
+5082	浠	162	99.9300438299	xi1	name of a river in Hubei
+5083	潸	162	99.9301275491	shan1	tearfully
+5084	跏	162	99.9302112683	jia1	sit cross-legged
+5085	鲶	162	99.9302949875	nian2	sheat
+5086	矍	161	99.9303781899	jue2	(surname)/glance fearfully
+5087	苌	161	99.9304613923	chang2	carambola
+5088	抻	161	99.9305445947	chen1	
+5089	琰	161	99.9306277971	yan3	gem/glitter of gems
+5090	鹚	161	99.9307109995	ci2	
+5091	龆	161	99.9307942019	tiao2	shed the milk teeth/young
+5092	臬	161	99.9308774043	nie4	provincial judge
+5093	芄	160	99.9309600899	wan2	Metaplexis stauntoni
+5094	呔	160	99.9310427756	tai3	
+5095	雒	160	99.9311254612	luo4	black horse with white mane/fearful
+5096	觞	160	99.9312081468	shang1	feast/goblet
+5097	钒	159	99.9312903156	fan2	vanadium
+5098	饫	159	99.9313724845	yu4	full (as of eating)
+5099	阒	159	99.9314546533	qu4	live alone/quiet
+5100	槎	159	99.9315368221	cha2	a raft made of bamboo or wood/to fell trees/to hew
+5101	鸩	159	99.931618991	zhen4	poisonous/to poison
+5102	舂	159	99.9317011598	chong1	to pound (grain)/beat
+5103	谠	158	99.9317828119	dang3	advice/counsels
+5104	阡	158	99.9318644639	qian1	road leading north and south
+5105	莒	158	99.931946116	ju3	(fibrous plant)
+5106	萸	158	99.932027768	yu2	cornelian cherry
+5107	妗	158	99.9321094201	jin4	wife of mother's brother
+5108	稔	158	99.9321910721	ren3	ripe grain
+5109	穰	158	99.9322727242	rang2	(surname)/abundant/stalk of grain
+5110	蚧	158	99.9323543762	jie4	horned toad
+5111	餍	158	99.9324360283	yan4	eat to the full
+5112	谯	157	99.9325171635	qiao2/qiao4	(surname)/drum tower, ridicule/to blame
+5113	芗	157	99.9325982988	xiang1	(Fujian drama)
+5114	菸	157	99.9326794341	yan1	cigarette/tobacco
+5115	葩	157	99.9327605693	pa1	corolla of flower
+5116	踔	157	99.9328417046	chuo1	
+5117	厣	156	99.9329223231	yan3	operculum
+5118	佻	156	99.9330029416	tiao1	frivolous/unsteady/delay
+5119	嘌	156	99.9330835601	piao4	
+5120	饩	156	99.9331641785	xi4	grain ration/sacrificial victim
+5121	钏	156	99.933244797	chuan4	an armlet/bracelet
+5122	蠓	156	99.9333254155	meng3	grasshopper/midge/sandfly
+5123	黩	156	99.933406034	du2	blacken/constantly/to insult
+5124	倨	156	99.9334866525	ju4	stubborn
+5125	缬	155	99.9336473726	xie2	knot/tie a knot
+5126	殚	155	99.9337274743	dan1	entirely/to exhaust
+5127	钿	155	99.933807576	dian4/tian2	gold inlaid work, gold inlaid work
+5128	鎏	155	99.9338876777	liu2	bessemerizing of matte
+5129	恁	155	99.9339677794	ren4/nin2	that, like this, thus, so, such
+5130	藿	155	99.9340478811	huo4	Lophanthus rugosus/beans
+5131	囟	154	99.934127466	xin4	skull/top of head
+5132	鄣	154	99.9342070509	zhang1	place name
+5133	呋	154	99.9342866358	fu1	
+5134	婺	154	99.9343662208	wu4	beautiful
+5135	绱	154	99.9344458057	shang4	
+5136	瓯	154	99.9345253906	ou1	bowl/cup
+5137	旃	154	99.9346049755	zhan1	felt/silken banner
+5138	锶	154	99.9346845604	si1	strontium
+5139	酩	154	99.9347641453	ming3	
+5140	恹	153	99.9348432134	yan1	contented/peaceful
+5141	逶	153	99.9349222816	wei1	winding, curving/swagger
+5142	缦	153	99.9350013497	man4	plain thin silk/slow/unadorned
+5143	鸹	153	99.9350804178	gua1	the crow
+5144	螟	152	99.9351589692	ming2	Heliothus armigera
+5145	菟	152	99.9352375205	tu4/tu2	dodder/cuscuta
+5146	阗	152	99.9353160718	tian2	fill up/rumbling sound
+5147	濉	152	99.9353946232	sui1	name of a river
+5148	篑	152	99.9354731745	kui4	basket for carrying soil
+5149	醪	152	99.9355517259	lao2	wine or liquor with sediment
+5150	鲛	152	99.9356302772	jiao1	shark
+5151	讦	152	99.9357088285	jie2	accuse/pry
+5152	媪	152	99.9357873799	ao3	old woman
+5153	邬	152	99.9358659312	wu1	(surname)/ancient place name
+5154	殇	152	99.9359444826	shang1	die prematurely
+5155	鄯	151	99.9360225171	shan4	name of a district in Xinjiang
+5156	芡	151	99.9361005517	qian4	Euryale ferox
+5157	嫠	151	99.9361785862	li2	widow
+5158	肼	151	99.9362566208	jing3	
+5159	峤	151	99.9363346553	jiao4/qiao2	highest peak
+5160	矽	150	99.9364121731	xi1	
+5161	讧	150	99.9364896909	hong4	
+5162	掼	150	99.9365672086	guan4	fling/smash
+5163	焖	150	99.9366447264	men4	cook in a covered vessel
+5164	愆	150	99.9367222442	qian1	fault/transgression
+5165	聩	150	99.936799762	kui4	born deaf/deaf
+5166	岘	150	99.9368772797	xian4	steep hill
+5167	靛	149	99.9369542807	dian4	indigo pigment
+5168	菖	149	99.9370312817	chang1	calamus
+5169	卟	149	99.9371082827	bu3	
+5170	姒	149	99.9371852837	si4	(surname)/wife of older brother
+5171	杷	149	99.9372622847	pa2	loquat
+5172	砉	149	99.9373392856	hua1	
+5173	袢	149	99.9374162866	pan4	
+5174	蚋	149	99.9374932876	rui4	(mosquito)/Simulia lugubris/blackfly
+5175	笳	149	99.9375702886	jia1	whistle made of reed
+5176	挈	149	99.9376472896	qie4	pull out/take family along
+5177	踽	148	99.9378007748	ju3	hunchbacked/walk alone
+5178	黾	148	99.937877259	min3/mian3	toad
+5179	侩	147	99.9380297106	kuai4	broker
+5180	凫	147	99.938105678	fu2	mallard/Anas platyrhyncha
+5181	诔	147	99.9381816454	lei3	eulogize the dead/eulogy
+5182	郯	147	99.9382576128	tan2	(surname)/name of an ancient city
+5183	韪	147	99.9383335802	wei3	correct/right
+5184	挲	147	99.9384095477	suo1	feel/to fondle
+5185	笪	147	99.9384855151	da2	(surname)/rough bamboo mat
+5186	鼋	147	99.9385614825	yuan2	sea turtle
+5187	莜	147	99.9386374499	you2	
+5188	菅	146	99.9387888679	jian1	(grass)/Themeda forsbali
+5189	嵊	146	99.9388643186	sheng4	name of a district in Zhejiang
+5190	裢	146	99.9389397692	lian2	pouch hung from belt
+5191	趿	146	99.9390152198	ta1	
+5192	箸	146	99.9390906705	zhu4	chopsticks
+5193	莴	145	99.9391656043	wo1	(lettuce)/Lactuca sativa
+5194	莠	145	99.9392405381	you3	Setaria viridis/vicious
+5195	阌	145	99.939315472	wen2	wen xiang, Henan province
+5196	旯	145	99.9393904058	la2	
+5197	圜	145	99.9394653397	huan2/yuan2	circle/encircle, circle/round
+5198	涪	145	99.9395402735	fu2	name of a river
+5199	赍	145	99.9396152074	ji1	
+5200	柞	144	99.9396896244	zuo4/zha4	oak/Quercus serrata
+5201	嗍	144	99.9397640415	suo1	
+5202	囵	144	99.9398384585	lun2	complete
+5203	榧	144	99.9399128756	fei3	Torreya nucifera
+5204	裰	144	99.9399872927	duo1	
+5205	笾	144	99.9400617097	bian1	basket for fruits
+5206	簟	144	99.9401361268	dian4	fine woven grass mat
+5207	跎	144	99.9402105438	tuo2	stumble
+5208	巽	144	99.9402849609	xun4	a sign in the trigram/obey
+5209	曷	144	99.940359378	he2	why/how/when/what/where
+5210	逖	143	99.9404332782	ti4	far
+5211	骓	143	99.9405071785	zhui1	(surname)/piebald
+5212	绔	143	99.9405810788	ku4	
+5213	枋	143	99.9406549791	fang1	Santalum album
+5214	镒	143	99.9407288793	yi4	abrasion/gold-20 taels in weight
+5215	魃	143	99.9408027796	ba2	drought demon
+5216	餮	143	99.9408766799	tie4	gluttonous
+5217	讵	143	99.9409505802	ju4	how (interj. of surprise)
+5218	乜	142	99.9410239636	mie1/nie4	squint
+5219	鄢	142	99.9410973471	yan1	(surname)/name of a feudal state
+5220	瑭	142	99.9411707306	tang2	(jade)
+5221	踅	142	99.9412441141	chi4/xue2	walk with one leg, to walk around/turn back midway
+5222	馓	141	99.9413169808	san3	
+5223	蟛	141	99.9413898475	peng2	(land-crab)/grapsus sp.
+5224	鳟	141	99.9414627142	zun1	
+5225	荛	141	99.9415355809	rao2	fuel/grass
+5226	菬	141	99.9416084476	qiao2	
+5227	忪	140	99.9416807976	zhong1/song1	restless/agitated
+5228	阍	140	99.9417531475	hun1	door-keeper
+5229	姹	140	99.9418254974	cha4	
+5230	纰	140	99.9418978473	pi1	error/carelessness/spoiled silk
+5231	桉	140	99.9419701972	an1	eucalyptus globulus
+5232	氪	140	99.9420425471	ke4	krypton
+5233	氘	140	99.9421148971	dao1	deuterium
+5234	垅	139	99.9421867302	long3	
+5235	郃	139	99.9422585633	xia2	
+5236	汊	139	99.9423303965	cha4	branching stream
+5237	娉	139	99.9424022296	ping1	graceful
+5238	纡	139	99.9424740627	yu1	(surname)/cord/twist
+5239	缟	139	99.9425458959	gao3	plain white silk
+5240	旮	139	99.942617729	ga1	
+5241	镢	139	99.9426895621	jue2	
+5242	傈	139	99.9427613953	li4	
+5243	堋	138	99.9428327116	peng2	target in archery
+5244	蔺	138	99.942904028	lin4	juncus effusus
+5245	庥	138	99.9429753443	xiu1	protection/shade
+5246	枥	138	99.9430466607	li4	stable
+5247	腭	138	99.943117977	e4	
+5248	鹕	138	99.9431892934	hu2	pelican
+5249	笮	138	99.9432606097	ze2	board under tiles on roof/narrow
+5250	髂	138	99.9433319261	qia4	
+5251	魍	138	99.9434032424	wang3	elf/sprite
+5252	缁	138	99.9434745588	zi1	Buddhists/black silk/dark
+5253	槊	138	99.9435458751	shuo4	long lance
+5254	跞	138	99.9436171915	li4	move/walk
+5255	醚	137	99.943687991	mi2	ether
+5256	吒	137	99.9437587906	zha4	upbraid
+5257	枳	137	99.9438295901	zhi3	(orange)/hedge thorn
+5258	搿	137	99.9439003897	ge2	to hug
+5259	鹧	137	99.9439711893	zhe4	partridge/Francolinus chinensis
+5260	蜍	137	99.9440419888	chu2	Bufo vulgaris/toad
+5261	舻	137	99.9441127884	lu2	bow of ship
+5262	鏊	137	99.944183588	ao4	
+5263	禳	137	99.9442543875	rang2	sacrifice for avoiding calamity
+5264	蒺	136	99.9443246703	ji2	Tribulus terrestris
+5265	钹	136	99.9443949531	bo2	cymbals
+5266	蜢	136	99.9444652359	meng3	grasshopper
+5267	鬻	136	99.9445355186	yu4	vend
+5268	珩	136	99.9446058014	heng2	top gem of pendant from girdle
+5269	卮	135	99.9446755674	zhi1	goblet
+5270	垭	135	99.9447453334	ya4/ya1	character used in place names
+5271	苄	135	99.9448150994	bian4	
+5272	苕	135	99.9448848654	tiao2	Teocoma grandiflora
+5273	菀	135	99.9449546314	wan3	luxuriance of growth
+5274	骠	135	99.9450243974	piao4/biao1	white horse
+5275	袷	135	99.9450941634	jia2	lined
+5276	跹	135	99.9451639294	xian1	manner of dancing/walk around
+5277	瘘	135	99.9452336954	lou4	
+5278	騔	135	99.9453034613	ge2	
+5279	磬	134	99.9454424765	qing4	musical stone
+5280	缶	134	99.9455117258	fou3	pottery
+5281	笸	134	99.945580975	po3	flat basket-tray
+5282	鸷	134	99.9456502242	zhi4	birds of prey
+5283	芰	133	99.9457882058	ji4	Trapa natans/water caltrop
+5284	蕲	133	99.9458569382	qi2	(herb)/implore/pray/place name
+5285	阆	133	99.9459256706	lang2	
+5286	纨	133	99.9459944031	wan2	white/white silk
+5287	琮	133	99.9460631355	cong2	(surname)/octagonal jade badge
+5288	牦	133	99.9461318679	mao2	
+5289	砩	133	99.9462006003	fei4/fu2	dam up water with rocks, name of a stone
+5290	蠲	133	99.9462693328	juan1	bright/glow-worm/remit taxes
+5291	锒	133	99.9463380652	lang2	chain/ornament
+5292	锕	133	99.9464067976	a1	
+5293	郓	133	99.94647553	yun4	place name
+5294	妯	132	99.9465437457	zhou2	wives of brothers
+5295	驷	132	99.9466119613	si4	team of 4 horses
+5296	鹩	132	99.9466801769	liao2	eastern wren
+5297	舢	132	99.9467483926	shan1	sampan
+5298	趸	132	99.9468166082	dun3	wholesale
+5299	芫	131	99.9470207383	yuan2	daphne genkwa
+5300	嗉	131	99.9470884372	su4	crop (of bird), crop of a bird/fat
+5301	蠊	131	99.9471561361	lian2	cockroach
+5302	笊	131	99.9472238349	zhao4	loosely woven bamboo ladle
+5303	莸	130	99.947291017	you2	Caryopteris divaricata
+5304	饴	130	99.947358199	yi2	syrup
+5305	阃	130	99.9474253811	kun3	door to women's room/threshold
+5306	浯	130	99.9474925632	wu2	
+5307	枇	130	99.9475597452	pi2	loquat
+5308	焱	130	99.9476269273	yan4	flames
+5309	铆	129	99.9476935926	mao3	riveting
+5310	擤	129	99.9477602579	xing3	blow nose
+5311	柢	129	99.9478269232	di3	foundation/root
+5312	醢	129	99.9478935884	hai3	minced meat/pickled meat
+5313	呲	128	99.9479597369	ci1	
+5314	崾	128	99.9480258854	yao3	
+5315	溆	128	99.9480920339	xu4	name of a river
+5316	潴	128	99.9481581824	zhu1	pool/pond
+5317	牖	128	99.9482243309	you3	enlighten/lattice window
+5318	硪	128	99.9482904794	wo4	
+5319	碓	128	99.9483566279	dui4	pestle/pound with a pestle
+5320	鹆	128	99.9484227764	yu4	mynah
+5321	鬣	128	99.9484889249	lie4	bristles/mane
+5322	堀	128	99.9485550734	ku1	cave/hole
+5323	帙	128	99.9486212219	zhi4	(surname)/book cover
+5324	雱	128	99.9486873704	pang1	
+5325	诎	127	99.9488852991	qu1	
+5326	獐	127	99.9489509308	zhang1	river deer/roebuck
+5327	桁	127	99.9490165625	heng2	pole plate/purlin/ridge-pole
+5328	蛱	127	99.9490821943	jia2	butterfly
+5329	鳏	127	99.949147826	guan1	widower
+5330	郴	127	99.9492134577	chen1	name of a district in Hunan
+5331	幂	127	99.9492790894	mi4	power (math.term)
+5332	箝	127	99.9493447211	qian2	pliers/pincers/to clamp
+5333	僳	127	99.9494103528	su4	Lisu (ethnic group)
+5334	疝	127	99.9494759845	shan4	hernia
+5335	茴	126	99.9495410995	hui2	fennel
+5336	揶	126	99.9496062144	ye2	gesticulate/play antics
+5337	呦	126	99.9496713293	you1	bleating of the deer
+5338	嗌	126	99.9497364442	ai4	
+5339	囹	126	99.9498015592	ling2	prison
+5340	螈	126	99.9498666741	yuan2	salamander/newt/Diemyelilus pyrogaster
+5341	脲	126	99.949931789	niao4	
+5342	镊	125	99.9499963872	nie4	forceps/to nip
+5343	锑	125	99.9500609853	ti1	antimony
+5344	胨	125	99.9501255834	dong4	
+5345	膈	125	99.9501901816	ge2	diaphragm
+5346	痼	125	99.9502547797	gu4	obstinate disease
+5347	鳊	125	99.9503193779	bian1	
+5348	赅	125	99.950383976	gai1	(surname)/include in/prepare
+5349	贽	125	99.9504485741	zhi4	gifts to superiors
+5350	苤	124	99.9505772536	pie3	Brassica campestris subsp. rapa
+5351	峄	124	99.950641335	yi4	name of hills in Shandong
+5352	桡	124	99.9507054164	rao2	
+5353	雎	124	99.9507694977	ju1	(fish hawk)/osprey
+5354	鲋	124	99.9508335791	fu4	silver carp
+5355	鞫	124	99.9508976604	ju1	
+5356	鼬	124	99.9509617418	you4	weasel, mustela itatis
+5357	獯	123	99.9510253064	xun1	name of a tribe
+5358	昀	123	99.9510888709	yun2	sun light/used in personal name
+5359	痍	123	99.9511524355	yi2	bruise/sores
+5360	蟊	123	99.9512160001	mao2	Spanish fly/grain-eating grub
+5361	鞴	123	99.9512795646	bei4	
+5362	疖	123	99.9513431292	jie2/jie1	pimple, sore, boil
+5363	熘	123	99.9514066938	liu1	
+5364	乇	122	99.9514697416	tuo1	
+5365	羸	122	99.9515327894	lei2	entangled/lean
+5366	嵴	122	99.9515958371	ji2	
+5367	栀	122	99.9516588849	zhi1	gardenia
+5368	槲	122	99.9517219327	hu2	oak/Quercus dentata
+5369	炝	122	99.9517849805	qiang4	
+5370	炷	122	99.9518480283	zhu4	candlewick/incense stick
+5371	硐	122	99.9519110761	dong4	
+5372	锸	122	99.9519741239	cha1	
+5373	鹂	122	99.9520371717	li2	Chinese oriole
+5374	裾	122	99.9521002194	ju1	garment
+5375	侪	122	99.9521632672	chai2	a class/a company/companion
+5376	珐	121	99.9523518938	fa4	enamel ware/cloisonne ware
+5377	縯	121	99.9524144248	yin3	
+5378	哔	121	99.9524769558	bi4	beiges/serge
+5379	屙	121	99.9525394868	e1	defecate
+5380	旆	121	99.9526020178	pei4	pennant/streamer
+5381	佰	121	99.9526645488	bai3	(complicated form of) hundred (used to avoid fraud)
+5382	僦	121	99.9527270798	jiu4	hire/to rent
+5383	牯	121	99.9527896108	gu3	bullock/cow
+5384	钪	121	99.9528521418	kang4	scandium
+5385	掾	121	99.9529146728	yuan4	official
+5386	仟	120	99.953039218	qian1	thousand
+5387	圮	120	99.9531012322	pi3	destroyed/injure
+5388	芟	120	99.9531632465	shan1	cut down/mow/scythe
+5389	崃	120	99.9532252607	lai2	name of a mountain in Sichuan
+5390	廪	120	99.9532872749	lin3	government granary
+5391	擘	120	99.9533492891	bo4	thumb/break/tear/pierce/split/to analyze
+5392	笱	120	99.9534113033	gou3	basket for trapping fish
+5393	跗	120	99.9534733175	fu1	instep/tarsus
+5394	鲅	120	99.9535353318	ba4	
+5395	硷	119	99.9535968292	jian3	base (chem.)/soda/alkali
+5396	苎	119	99.9536583266	zhu4	Boehmeria nivea
+5397	匏	119	99.9537198241	pao2	bottle gourd/Lagenaria vulgaris
+5398	嗾	119	99.9537813215	sou3	to urge on/incite
+5399	圄	119	99.9538428189	yu3	imprison
+5400	彀	119	99.9539043163	gou4	enough
+5401	粳	118	99.953965297	jing1	
+5402	卣	118	99.9540262776	you3	wine container
+5403	勐	118	99.9540872583	meng3	
+5404	掴	118	99.9541482389	guo2	to slap
+5405	涑	118	99.9542092196	su4	name of a river
+5406	浞	118	99.9542702002	zhuo2	
+5407	玳	118	99.9543311809	dai4	tortoise shell/turtle
+5408	愍	118	99.9543921615	min3	pity/sympathize
+5409	畛	118	99.9544531422	zhen3	border/boundary/field-path
+5410	赧	118	99.9545141228	nan3	blush
+5411	貉	117	99.9545745867	hao2/he2/mo4	badger-like animal, badger-like animal, name of a wild tribe/silent
+5412	擀	117	99.9546350505	gan3	
+5413	湫	117	99.9546955144	jiao3/qiu1	marsh
+5414	逦	117	99.9547559782	li3	winding
+5415	椴	117	99.9548164421	duan4	Hibiscus syriacus
+5416	铄	117	99.954876906	shuo4	bright/melt/fuse (metal)
+5417	箧	117	99.9549373698	qie4	portfolio/trunk
+5418	刖	117	99.9549978337	yue4	cut off the feet as punishment
+5419	鲮	117	99.9550582975	ling2	pangolin/Manis pentadactylata
+5420	訇	116	99.9551182446	hong1	(surname)/sound of a crash
+5421	茱	116	99.9551781917	zhu1	cornelian cherry
+5422	啖	116	99.9552381388	dan4	eat/taste/entice (with a bait)
+5423	悭	116	99.9552980859	qian1	stingy
+5424	愀	116	99.9553580329	qiao3	change countenance/worry
+5425	朐	116	99.95541798	qu2	(surname)
+5426	畈	116	99.9554779271	fan4	field/farm
+5427	鹨	116	99.9555378742	liu4	
+5428	蛘	116	99.9555978212	yang2	
+5429	佶	115	99.9556572515	ji2	difficult to pronounce
+5430	缃	115	99.9557166818	xiang1	light yellow color
+5431	晟	115	99.9557761121	sheng4	brightness of sun/splendor
+5432	鲱	115	99.9558355424	fei1	
+5433	凼	115	99.9558949727	dang4	
+5434	苴	115	99.955954403	ju1	(hemp)/(surname)/sack cloth
+5435	颛	115	99.9560138333	zhuan1	(surname)/good/simple
+5436	厍	114	99.9560727468	she4	(surname)
+5437	匚	114	99.9561316603	fang1/qu1	box/basket
+5438	徉	114	99.9561905738	yang2	walk back and forth
+5439	洙	114	99.9562494873	zhu1	(surname)/name of a river
+5440	氡	114	99.9563084008	dong1	radon
+5441	胗	114	99.9563673143	zhen1	gizzard
+5442	癯	114	99.9564262278	qu2	
+5443	鞒	114	99.9564851413	qiao2	
+5444	锆	114	99.9565440548	gao4	zirconium
+5445	佤	114	99.9566029683	wa3	Kawa
+5446	勰	113	99.9568381056	xie2	harmonious
+5447	钺	113	99.9568965023	yue4	battle-axe
+5448	繇	113	99.956954899	yao2/you2/zhou4	folk-song/forced labor, cause/means, interpretations of the trigrams
+5449	螭	113	99.9570132957	chi1	hornless dragon
+5450	嵬	112	99.9570711756	wei2	rocky
+5451	轸	112	99.9571290556	zhen3	d (11th)/strongly (as of emotion)
+5452	肟	112	99.9571869355	wo4	
+5453	肫	112	99.9572448155	zhun1	gizzard
+5454	邨	112	99.9573026954	cun1	
+5455	瘿	112	99.9573605753	ying3	goiter/knob on tree
+5456	仞	111	99.9574179385	ren4	(measure)
+5457	奁	111	99.9574753016	lian2	bridal trousseau
+5458	宄	111	99.9575326648	gui3	traitor
+5459	轳	111	99.9575900279	lu2	windlass
+5460	熳	111	99.9576473911	man4	to spread
+5461	睇	111	99.9577047542	di4	look down upon
+5462	钼	111	99.9577621174	mu4	molybdenum
+5463	蝼	111	99.9578194805	lou2	mole-cricket/Gryllotalpa africona
+5464	跆	111	99.9578768437	tai2	trample
+5465	樗	111	99.9579342068	chu1	simarubaceae
+5466	鲰	111	99.95799157	zou1	(surname)/minnows/small fish
+5467	诶	110	99.9581057795	ei1	
+5468	薜	110	99.9581626259	bi4	Ficus pumila
+5469	铧	110	99.9582194722	hua2	ploughshare/spade
+5470	裥	110	99.9582763186	jian3	
+5471	榇	110	99.9583331649	chen4	Sterculia plantanifolia/coffin
+5472	馃	110	99.9583900113	guo3	
+5473	蹚	109	99.9585031873	tang1	
+5474	怄	109	99.9585595168	ou4	annoyed
+5475	寤	109	99.9586158464	wu4	awake from sleep
+5476	缗	109	99.958672176	min2	cord/fishing-line/string of coins
+5477	硗	109	99.9587285056	qiao1	stony soil
+5478	碡	109	99.9587848352	du2/zhou2	stone roller
+5479	矬	109	99.9588411647	cuo2	short/dwarfish
+5480	鸱	109	99.9588974943	chi1	scops owl
+5481	虺	109	99.9589538239	hui1/hui3	sick/with no ambition, poisonous snakes
+5482	糅	109	99.9590101535	rou2	mix
+5483	雠	109	99.9590664831	chou2	enmity/feud
+5484	帑	109	99.9591228126	tang3	treasury
+5485	镧	109	99.9591791422	lan2	lanthanum
+5486	埙	108	99.959234955	xun1	ancient porcelain wind-instrument
+5487	啁	108	99.9592907678	zhou1	twittering of birds
+5488	悒	108	99.9593465806	yi4	anxiety/worry
+5489	犍	108	99.9594023934	jian1	bullock
+5490	硌	108	99.9594582062	ge4	
+5491	锩	108	99.959514019	juan4/juan3	to bend iron
+5492	虿	108	99.9595698318	chai4	(scorpion)/an insect
+5493	蛑	108	99.9596256446	mou2	marine crab
+5494	艉	108	99.9596814574	wei3	
+5495	钅	108	99.9597372702	jin1	
+5496	咴	107	99.9597925662	hui1	
+5497	筮	107	99.9598478622	shi4	divine by stalk
+5498	艏	107	99.9599031582	shou3	
+5499	糁	107	99.9599584542	san3/shen1	to mix (of powders)
+5500	鼍	107	99.9600137502	tuo2	large water lizard
+5501	肄	107	99.9600690462	yi4	descendants/distress/practice
+5502	籴	106	99.9601238254	di2	buy up (grain)
+5503	骜	106	99.9601786047	ao4	a noble steed/untamed
+5504	砻	106	99.9602333839	long2	grind/mill
+5505	蜮	106	99.9602881631	yu4	mythical creature/toad/worm
+5506	龀	106	99.9603429423	chen4	replace the milk teeth
+5507	黢	106	99.9603977216	qu1	
+5508	劢	106	99.9604525008	mai4	put forth effort
+5509	耪	105	99.9605610257	pang3	to weed
+5510	鬯	105	99.9606152881	chang4	sacrificial spirit
+5511	畚	105	99.9606695505	ben3	a basket or pan used for earth/manure etc
+5512	觳	105	99.960723813	hu2	(measure)/frightened
+5513	稞	105	99.9607780754	ke1	(wheat)
+5514	鹁	105	99.9608323379	bo2	woodpidgeon
+5515	鲲	105	99.9608866003	kun1	sea-monster/young of fishes
+5516	捌	104	99.9609946084	ba1	complicated form of the numeral eight/split
+5517	菔	104	99.961048354	fu2	turnip
+5518	獬	104	99.9611020997	xie4	(mythical animal)
+5519	柘	104	99.9611558454	zhe4	Cudrania triloba
+5520	娆	104	99.961209591	rao2/rao3	graceful, disturbance
+5521	篪	104	99.9612633367	chi2	bamboo flute with 8 holes
+5522	鲀	104	99.9613170823	tun2	
+5523	谰	103	99.9613703112	lan2	make a false charge
+5524	孬	103	99.9614235401	nao1	
+5525	伥	103	99.9614767689	chang1	groping/rash/reckless
+5526	谇	103	99.9615299978	sui4	abuse
+5527	鄄	103	99.9615832267	juan4	name of a district in Shandong
+5528	狎	103	99.9616364555	xia2	be intimate with
+5529	闫	103	99.9616896844	yan2	(surname)
+5530	滟	103	99.9617429133	yan4	tossing of billows
+5531	齑	103	99.9617961421	ji1	fragment/spices
+5532	遒	103	99.961849371	qiu2	consolidate/end/strong
+5533	磔	103	99.9619025999	zhe2	tearing off limbs as punishment
+5534	聃	103	99.9619558287	dan1	ears without rim
+5535	綦	103	99.9620090576	qi2	dark gray/superlative/variegated
+5536	鲡	103	99.9620622865	li2	
+5537	蔻	102	99.9621149986	kou4	
+5538	泠	102	99.9621677106	ling2	(surname)/sound of water flowing
+5539	砗	102	99.9622204227	che1	Tridacna gigas
+5540	钕	102	99.9622731348	nu:3/nv3	neodymium
+5541	镫	102	99.9623258469	deng4	stirrup
+5542	菹	101	99.9623780422	zu1	
+5543	胂	101	99.9624302375	shen4	arsine
+5544	煅	101	99.9624824328	duan4	
+5545	煸	101	99.9625346281	bian1	
+5546	螯	101	99.9625868234	ao2	nippers/claw (of crab)/chela/pincers/Astacus fluviatilis
+5547	躅	101	99.9626390187	zhu2	
+5548	鲠	101	99.962691214	geng3	blunt/fish bones/unyielding
+5549	佥	101	99.9627434093	qian1	all
+5550	罘	101	99.9627956046	fu2	place name
+5551	嶝	101	99.9628477999	deng4	path leading up a mountain
+5552	坨	100	99.9629516737	tuo2	lump/spherical substance
+5553	菽	100	99.9630033522	shu1	
+5554	哞	100	99.9630550307	mou1	moo (sound made by cow)
+5555	徜	100	99.9631067092	chang2	sit cross-legged/walk back and forth
+5556	慊	100	99.9631583877	qian4/qie4	dissatisfied, contented
+5557	洳	100	99.9632100663	ru4	
+5558	渑	100	99.9632617448	sheng2/mian3	name of a river in Shandong
+5559	灞	100	99.9633134233	ba4	name of a river
+5560	盍	100	99.9633651018	he2	why not
+5561	钋	100	99.9634167803	po1	polonium
+5562	鸫	100	99.9634684588	dong1	thrush/Tardus fuscatus
+5563	踯	100	99.9635201373	zhi2	hesitating/to stop
+5564	縻	100	99.9635718159	mi2	tie up
+5565	萘	100	99.9636234944	nai4	
+5566	褫	100	99.9636751729	chi3	strip/deprive of/to discharge/dismiss/undress
+5567	羰	100	99.9637268514	tang1	carbonyl (radical)
+5568	俅	99	99.9638296916	qiu2	ornamental cap
+5569	芤	99	99.9638808534	kou1	hollow/scallion stalk
+5570	隳	99	99.9639320151	hui1	destroy/overthrow
+5571	洮	99	99.9639831768	tao2	cleanse/name of a river
+5572	胼	99	99.9640343386	pian2	callous on hand or foot
+5573	罴	99	99.9640855003	pi2	(bear)
+5574	镛	99	99.964136662	yong1	large bell
+5575	怛	99	99.9641878237	da2	distressed/alarmed/shocked/grieved
+5576	芊	98	99.9642384687	qian1	green/luxuriant growth
+5577	啉	98	99.9642891136	lin2	
+5578	噌	98	99.9643397586	ceng1/cheng1	to scold/whoosh!, sound of bells, etc
+5579	嫱	98	99.9643904035	qiang2	female court officials
+5580	绲	98	99.9644410485	gun3	cord/embroidered sash/sew
+5581	膻	98	99.9644916934	shan1	rank odor (of sheep or goats)
+5582	焐	98	99.9645423383	wu4	
+5583	葎	97	99.9646431114	lv4	
+5584	亓	97	99.9646932396	qi2	(surname)/his/her/its/their
+5585	倮	97	99.9647433678	luo3	
+5586	莼	97	99.9647934959	chun2	
+5587	蘅	97	99.9648436241	heng2	Asarum blumei
+5588	嘞	97	99.9648937522	lei	
+5589	缒	97	99.9649438804	zhui4	let down with a rope
+5590	镆	97	99.9649940085	mo4	sword
+5591	伧	96	99.9650937481	cang1	low fellow/rustic/rude/rough
+5592	荏	96	99.9651433595	ren3	Perilla ocimoides/soft
+5593	唳	96	99.9651929708	li4	cry of a crane or wild goose
+5594	檩	96	99.9652425822	lin3	cross-beam/ridge-pole
+5595	鸶	96	99.9652921936	si1	heron
+5596	蚬	96	99.9653418049	xian3	Cyclina orientalis
+5597	骱	96	99.9653914163	xie4/jie4	joint of bones
+5598	蘖	96	99.9654410277	nie4	
+5599	澍	96	99.9654906391	shu4	moisture/timely rain
+5600	韫	96	99.9655402504	yun4	contain
+5601	颎	96	99.9655898618	jiong3	
+5602	嘏	95	99.9656389564	gu3/jia3	good fortune/longevity, far/grand
+5603	垡	95	99.965688051	fa2	
+5604	腚	95	99.9657371456	ding4	
+5605	焯	95	99.9657862402	chao1	
+5606	繻	95	99.9658353347	xu1	
+5607	怙	95	99.9658844293	hu4	presume
+5608	羧	95	99.9659335239	suo1	(chem.) carboxyl (radical)
+5609	鼙	95	99.9659826185	pi2	drum carried on horseback
+5610	倥	94	99.9660311963	kong1/kong3	ignorant/blank-minded, urgent/pressed
+5611	亳	94	99.9660797741	bo2	name of district in Anhui/capital of Yin
+5612	艽	94	99.9661283519	jiao1	
+5613	荠	94	99.9661769297	ji4/qi2	Capsella bursa pastoris, water chestnut
+5614	昴	94	99.9662255075	mao3	the Pleiades
+5615	舨	94	99.9662740853	ban3	sampan
+5616	魈	94	99.9663226631	xiao1	elf
+5617	醣	94	99.9663712409	tang2	carbohydrate
+5618	枵	94	99.9664198187	xiao1	empty/hollow of a tree
+5619	粜	94	99.9664683965	tiao4	
+5620	甙	93	99.9665164576	dai4	
+5621	珲	93	99.9665645186	hun2/hui1	(fine jade)
+5622	杓	93	99.9666125796	biao1/shao2	(star), ladle
+5623	楸	93	99.9666606406	qiu1	Catalpa/Mallotus japonicus
+5624	楦	93	99.9667087016	xuan4	block (hat)/stretch (shoe)
+5625	疃	93	99.9667567626	tuan3	
+5626	蛏	93	99.9668048237	cheng1	mussel/razor clam/Solecurtus constricta
+5627	蠛	93	99.9668528847	mie4	minute flies
+5628	髌	93	99.9669009457	bin4	kneecap
+5629	茔	93	99.9669490067	ying2	a grave
+5630	诼	92	99.967044612	zhuo2	complain
+5631	嬖	92	99.9670921562	bi4	(treat as a) favorite
+5632	耒	92	99.9671397004	lei3	plough
+5633	蜣	92	99.9671872447	qiang1	dung beetle
+5634	笄	92	99.9672347889	ji1	15 years old/hairpin for bun
+5635	跣	92	99.9672823331	xian3	barefooted
+5636	钣	92	99.9673298774	ban3	metal plate/sheet of metal
+5637	戆	91	99.9673769048	zhuang4/gang4	simple/stupid
+5638	蜉	91	99.9674239323	fu2	(dragon fly)/(large ant)/(wasp)
+5639	喾	91	99.9674709597	ku4	name of an emperor
+5640	铍	91	99.9675179871	pi2	beryllium
+5641	陉	90	99.9675644978	xing2	border the stove/defile/pass
+5642	薹	90	99.9676110085	tai2	Carex dispalatha
+5643	肷	90	99.9676575191	qian3	
+5644	岵	90	99.9677040298	hu4	wooded hill
+5645	瓴	90	99.9677505405	ling2	concave channels of tiling
+5646	荽	89	99.9677965343	sui1	coriander
+5647	怫	89	99.9678425282	fei4/fu2	anger, anxious
+5648	钭	89	99.9678885221	tou3	a wine flagon
+5649	窀	89	99.967934516	zhun1	grave
+5650	缯	89	99.9679805098	zeng1/zeng4	(surname)/silk fabrics, to tie/to bind
+5651	倬	88	99.9680259869	zhuo1	noticeable, large/clear, distin
+5652	摭	88	99.968071464	zhi2	pick up/to select
+5653	帔	88	99.9681169411	pei4	cape
+5654	楝	88	99.9681624182	lian4	Melia japonica
+5655	痱	88	99.9682078953	fei4	prickly heat
+5656	蚶	88	99.9682533724	han1	small clam/arca inflata
+5657	螬	88	99.9682988495	cao2	larva of Mimela lucidula
+5658	髑	88	99.9683443266	du2	skull
+5659	鼗	87	99.968434764	tao2	
+5660	狷	87	99.9684797243	juan4	timid/cautious
+5661	殛	87	99.9685246846	ji2	put to death
+5662	裉	87	99.9685696449	ken4	s seam in a garment
+5663	粝	87	99.9686146052	li4	
+5664	萋	87	99.9686595655	qi1	Celosia argentea/luxuriant
+5665	葭	87	99.9687045258	jia1	reed/Phragmites communis
+5666	衽	87	99.9687494861	ren4	overlapping part of Chinese gown
+5667	鳢	87	99.9687944464	li3	snakefish
+5668	傧	86	99.96883889	bin1	best man/entertain
+5669	喁	86	99.9688833335	yong2	breathing (of fish)
+5670	嫘	86	99.968927777	lei2	(surname)
+5671	罟	86	99.9689722205	gu3	implicate/net for birds or fish
+5672	钌	86	99.969016664	liao3	ruthenium
+5673	裼	86	99.9690611076	ti4	
+5674	愦	86	99.9691055511	kui4	confused/troubled
+5675	蝽	86	99.9691499946	chun1	
+5676	锗	85	99.9692383649	zhe3	germanium
+5677	衿	85	99.9692822916	jin1	overlapping part of Chinese gown
+5678	粢	85	99.9693262183	zi1	common millet
+5679	醵	85	99.9693701451	ju4	contribute to a feast
+5680	跫	85	99.9694140718	qiong2	sound of trampling
+5681	鐾	85	99.9694579985	bei4	
+5682	廛	85	99.9695019253	chan2	market place
+5683	墉	85	99.969545852	yong1	fortified wall
+5684	哌	85	99.9695897788	pai4	
+5685	扦	84	99.9696771154	qian1	graft (tree)/stick in
+5686	堇	84	99.9697205254	jin3	yellow loam/clay/season/few
+5687	婧	84	99.9697639353	jing4	modest/supple
+5688	暌	84	99.9698073453	kui2	in opposition to/separated from
+5689	罱	84	99.9698507552	lan3	
+5690	镞	84	99.9698941652	zu2	arrowhead/sharp
+5691	蹰	84	99.9699375751	chu2	irresolute/undecided
+5692	陟	84	99.9699809851	zhi4	advance/ascend
+5693	鳔	84	99.970024395	biao4	air bladder of fish
+5694	脘	84	99.970067805	wan3	
+5695	岿	83	99.9701541081	kui1	high and mighty (of mountain)/hilly
+5696	侔	83	99.9701970013	mou2	similar/comparable/equal
+5697	郾	83	99.9702398945	yan3	place name
+5698	唿	83	99.9702827876	hu1	
+5699	砹	83	99.9703256808	ai4	
+5700	疴	83	99.9703685739	ke1	
+5701	麸	83	99.9704114671	fu1	bran
+5702	薨	83	99.9704543603	hong1	death of a prince/swarming
+5703	綝	83	99.9704972534	chen1	
+5704	滁	82	99.9705396298	chu2	name of a river
+5705	偾	82	99.9705820062	fen4	instigate/ruin/destroy
+5706	拊	82	99.9706243826	fu3	pat
+5707	撺	82	99.970666759	cuan1	rush/stir up/throw/fling/hurry/rage
+5708	呒	82	99.9707091354	fu3/mu2	unclear/an expletive
+5709	狯	82	99.9707515117	kuai4	crafty/cunning
+5710	猢	82	99.9707938881	hu2	(monkey)
+5711	椁	82	99.9708362645	guo3	outer coffin
+5712	榱	82	99.9708786409	cui1	small rafter
+5713	罾	82	99.9709210173	zeng1	large square net
+5714	铳	82	99.9709633936	chong4	a gun/a pistol
+5715	裎	82	99.97100577	cheng2	take off clothes
+5716	鳚	82	99.9710481464	wei4	
+5717	眦	82	99.9710905228	zi4	
+5718	璎	82	99.9711328992	ying1	necklace
+5719	崞	81	99.9712171351	guo1	name of a mountain
+5720	缇	81	99.9712589947	ti2	orange red silk
+5721	蝣	81	99.9713008543	you2	Ephemera strigata
+5722	萑	80	99.9713421971	huan2	(reeds)
+5723	狲	80	99.97138354	sun1	(monkey)
+5724	缱	80	99.9714248828	qian3	attached to/loving
+5725	晷	80	99.9714662256	gui3	sundial
+5726	冼	80	99.9715075684	xian3	(surname)
+5727	痧	80	99.9715489112	sha1	cholera
+5728	蕖	79	99.97163108	qu2	lotus
+5729	狍	79	99.9716719061	pao2	
+5730	憷	79	99.9717127321	chu4	
+5731	锛	79	99.9717535581	ben1	adz/adze
+5732	窨	79	99.9717943841	xun1/yin4	to scent tea with flowers, cellar
+5733	袼	79	99.9718352102	ge1	
+5734	帏	79	99.9718760362	wei2	curtain/women's apartment/tent
+5735	儋	79	99.9719168622	dan1	carry
+5736	绨	79	99.9719576882	ti2	coarse greenish black pongee
+5737	疠	79	99.9719985143	li4	sore caused by varnish poisoning
+5738	蘩	78	99.9720388235	fan2	Artemisia stellariana
+5739	嵝	78	99.9720791327	lou3	mountain peak
+5740	庀	78	99.972119442	pi3	prepare
+5741	汜	78	99.9721597512	si4	stream which returns after branching
+5742	炅	78	99.9722000605	gui4	(surname)
+5743	煳	78	99.9722403697	hu2	
+5744	泶	78	99.9722806789	xue2	
+5745	瓠	78	99.9723209882	hu4	gourd
+5746	窳	78	99.9723612974	yu3	bad/useless/weak
+5747	虮	78	99.9724016067	ji3	nymph of louse
+5748	蚰	78	99.9724419159	you2	house centipede
+5749	邰	78	99.9724822251	tai2	(surname)/name of a feudal state
+5750	苊	77	99.9725220176	e4	
+5751	砀	77	99.9725618101	dang4	stone with color veins
+5752	捩	77	99.9726016025	lie4	tear/twist
+5753	蹉	77	99.972641395	cuo1	error/slip/miss/err
+5754	莪	77	99.9726811874	e2	zedoary
+5755	螽	77	99.9727209799	zhong1	(grasshopper)/Gompsocleis mikado
+5756	蘼	76	99.972800048	mi2	millet
+5757	槔	76	99.9728393237	gao1	water pulley
+5758	曛	76	99.9728785993	xun1	twilight/sunset
+5759	蛲	76	99.972917875	nao2	
+5760	鹾	76	99.9729571507	cuo2	brine/salt
+5761	隹	76	99.9729964264	zhui1	short-tailed bird
+5762	犸	76	99.973035702	ma3	mammoth
+5763	衄	76	99.9730749777	nu:4/nv4	bleed at the nose/check in battle
+5764	銎	75	99.9731922879	qiong1/qiong2	eye of an axe
+5765	泫	75	99.9732310468	xuan4	weep
+5766	玢	75	99.9732698057	fen1/bin1	porphyrites
+5767	辊	75	99.9733085646	gun3	revolve/stone roller
+5768	瞋	75	99.9733473235	tian2	
+5769	墀	75	99.9733860823	chi2	courtyard
+5770	酐	75	99.9734248412	gan1	anhydride
+5771	堞	74	99.9735018422	die2	battlements
+5772	尥	74	99.9735400843	liao4	
+5773	嚯	74	99.9735783264	huo4	
+5774	猗	74	99.9736165685	yi1	(interj.)
+5775	逑	74	99.9736548106	qiu2	collect/to match
+5776	逯	74	99.9736930527	lu4	(surname)/go carefully
+5777	硖	74	99.9737312948	xia2	place name
+5778	噻	74	99.9737695369	sai1	
+5779	嵛	74	99.973807779	yu2	county in shandong province
+5780	畀	74	99.9738460211	bi4	confer on/give to
+5781	鲃	74	99.9739225053	ba1	
+5782	偬	73	99.9739602306	zong3	busy/hurried/despondent
+5783	鄞	73	99.9739979559	yin2	name of a district in Zhejiang
+5784	呖	73	99.9740356813	li4	sound of splitting/cracking
+5785	溧	73	99.9740734066	li4	name of a river
+5786	嬲	73	99.9741111319	niao3	tease/disturb
+5787	肭	73	99.9741488572	na4	castor
+5788	鹈	73	99.9741865825	ti2	pelican
+5789	鹱	73	99.9742243078	hu4	
+5790	窭	73	99.9742620332	ju4	poor/rustic
+5791	黧	73	99.9742997585	li2	dark/sallow color
+5792	谵	73	99.9743374838	zhan1	incoherent talk/talkative
+5793	沆	73	99.9743752091	hang4	
+5794	嫒	73	99.9744129344	ai4	your daughter (hon.)
+5795	塬	73	99.9744506597	yuan2	
+5796	缣	73	99.974488385	jian1	thick waterproof silk
+5797	篯	73	99.9745261104	jian1	
+5798	酃	72	99.9745633189	ling2	name of a district in Hunan
+5799	喱	72	99.9746005274	li2	grain weight
+5800	泔	72	99.9746377359	gan1	slop from rinsing rice
+5801	溘	72	99.9746749445	ke4	suddenly
+5802	迕	72	99.974712153	wu3	
+5803	肀	72	99.9747493615	yu4	
+5804	秫	72	99.9747865701	shu2	Panicum italicum
+5805	裣	72	99.9748237786	lian3	
+5806	铋	72	99.9748609871	bi4	bismuth
+5807	蒌	72	99.9748981957	lou2	Arthemisia vulgaris/piper betle
+5808	曩	72	99.9749354042	nang3	in former times
+5809	赀	72	99.9749726127	zi1	fine instead of punishment/property
+5810	箪	72	99.9750098212	dan1	round basket for cooked rice
+5811	朊	72	99.9750470298	ruan3	protein
+5812	鳙	72	99.9750842383	yong1	
+5813	仫	72	99.9751214468	mu4	
+5814	钎	71	99.9751581386	qian1	
+5815	芑	71	99.9751948303	qi3	Panicum miliaceum
+5816	胙	71	99.9752315221	zuo4	confer upon/sacrificial flesh
+5817	盱	71	99.9752682138	xu1	(surname)/anxious/stare
+5818	糇	71	99.9753049056	hou2	
+5819	挹	71	99.9753415973	yi4	give up/ladle out/pour out
+5820	捭	71	99.975378289	bai3/bai4	spread out/to open, weed
+5821	悱	71	99.9754149808	fei3	want but cannot speak
+5822	鬟	71	99.9754516725	huan2	a knot of hair on top of head
+5823	崤	70	99.975561231	yao2/xiao2	mountain in Henan
+5824	澶	70	99.9755974059	chan2	still (as of water)/still water
+5825	甾	70	99.9756335809	zai1	steroid nucleus
+5826	欹	70	99.9756697559	yi1	interjection
+5827	瞽	70	99.9757059308	gu3	blind
+5828	钇	70	99.9757421058	yi3	yttrium
+5829	鹪	70	99.9757782807	jiao1	eastern wren
+5830	鞔	70	99.9758144557	man2	
+5831	缡	70	99.9758506307	li2	bridal veil or kerchief
+5832	铯	70	99.9758868056	se4	cesium
+5833	鲚	70	99.9759229806	ji4	Coilia nasus
+5834	嘬	69	99.9759948137	chuai4/zuo1	to gnaw/eat ravenously, suck
+5835	庹	69	99.9760304719	tuo3	length of 2 outstretched arms
+5836	渖	69	99.9760661301	shen3	place name/pour
+5837	湔	69	99.9761017882	jian1	cleanse/name of a river
+5838	玎	69	99.9761374464	ding1	jingling/tinkling
+5839	锜	69	99.9761731046	yi3	
+5840	锊	69	99.9762087628	lue4	(ancient unit of weight)
+5841	舾	69	99.9762444209	xi1	
+5842	籼	69	99.9762800791	xian1	
+5843	阊	69	99.9763157373	chang1	gate of heaven/gate of palace
+5844	祕	69	99.9763513955	bi4	
+5845	猊	69	99.9763870536	ni2	(mythical animal)/lion
+5846	燹	69	99.9764227118	xian3	conflagration
+5847	葑	68	99.9764578532	feng1	turnip
+5848	蓼	68	99.9764929946	liao3/lu4	polygonum/smartweed, luxuriant growth
+5849	幛	68	99.976528136	zhang4	hanging scroll
+5850	岣	68	99.9765632774	gou3	name of a hill in Hunan
+5851	浼	68	99.9765984187	mei3	ask a favor of
+5852	瑷	68	99.9766687015	ai4	jasper/precious stone
+5853	敫	68	99.9767038429	jiao3	
+5854	钔	68	99.9767389843	men2	mendelevium
+5855	钫	68	99.9767741257	fang1	francium
+5856	锼	68	99.9768092671	sou1	to engrave (metal of wood)
+5857	锿	68	99.9768444085	ai1	
+5858	癔	68	99.9768795499	yi4	
+5859	穸	68	99.9769146912	xi1	
+5860	褊	68	99.9769498326	bian3	narrow/urgent
+5861	蚍	68	99.976984974	pi2	
+5862	篦	68	99.9770201154	bi4	fine-toothed comb/to comb
+5863	麇	68	99.9770552568	jun1	hornless deer
+5864	樘	68	99.9770903982	tang2	
+5865	钯	68	99.9771255396	ba3	palladium
+5866	禇	68	99.977160681	chu3	
+5867	铒	68	99.9771958224	er3	erbium
+5868	莩	67	99.9772655884	fu2/piao3	pellicle of culms, die of starvation
+5869	嵯	67	99.977300213	cuo2	lofty (as of mountain)
+5870	逭	67	99.9773348376	huan4	escape from
+5871	遄	67	99.9773694622	chuan2	hurry/go to and fro
+5872	戗	67	99.9774040868	qiang1	
+5873	睃	67	99.9774387114	suo1	
+5874	鮈	67	99.977473336	ju1	
+5875	瀣	67	99.9775079606	xie4	mist/vapor
+5876	皴	67	99.9775425852	cun1	chapped/cracked
+5877	泮	67	99.9775772098	pan4	melt
+5878	轫	67	99.9776118344	ren4	brake
+5879	褰	66	99.9776459422	qian1	lift up the skirts/lower garments
+5880	炱	66	99.97768005	tai2	soot
+5881	醍	66	99.9777141579	ti2	
+5882	锱	66	99.9777482657	zi1	ancient weight/one-eighth of a tael
+5883	篁	66	99.9777823735	huang2	(bamboo)/bamboo grove
+5884	葚	66	99.9778164813	ren4/shen4	fruit of mulberry, fruit of mulberry
+5885	驽	65	99.9779177712	nu2	worn out old horses
+5886	辚	65	99.9779513622	lin2	rumbling of wheels
+5887	睥	65	99.9779849533	bi4/pi4	look askance
+5888	鸺	65	99.9780185443	xiu1	owl
+5889	筇	65	99.9780521353	qiong2	species of bamboo
+5890	戥	65	99.9780857264	deng3	small steelyard for weighing money
+5891	髀	65	99.9781193174	bi4	buttocks/thigh
+5892	驺	65	99.9781529084	zou1	go/mythical animal
+5893	哙	64	99.9782195737	kuai4	(surname)/throat/to swallow
+5894	濞	64	99.978252648	bi4	
+5895	逄	64	99.9782857222	pang2	(surname)
+5896	桤	64	99.9783187965	qi1	alder
+5897	攵	64	99.9783518707	fan3	
+5898	炻	64	99.978384945	shi2	
+5899	磙	64	99.9784180192	gun3	
+5900	疳	64	99.9784510935	gan1	rickets
+5901	醭	64	99.9784841677	bu2	mold on liquids
+5902	鳇	64	99.978517242	huang2	sturgeon
+5903	鹮	64	99.9785503162	huan2	
+5904	迓	64	99.9785833904	ya4	receive (as a guest)
+5905	眇	64	99.9786164647	miao3	minute (small)/subtle
+5906	楮	64	99.9786495389	chu3	Broussonetia kasinoki
+5907	砜	64	99.9786826132	feng1	
+5908	菘	63	99.9788138766	song1	(cabbage)/Brassica chinensis
+5909	馇	63	99.9788464341	zha	
+5910	栌	63	99.9788789915	lu2	capital (of column)/smoke tree
+5911	醐	63	99.978911549	hu2	purest cream
+5912	唢	63	99.9789441065	suo3	
+5913	獍	63	99.9789766639	jing4	an animal which eats its mother
+5914	殳	63	99.9790092214	shu1	(surname)/spear
+5915	仡	63	99.9790417789	yi4	strong/brave
+5916	刿	62	99.979106377	gui4	cut/injure
+5917	葜	62	99.9791384177	qia1	
+5918	薅	62	99.9791704584	hao1	pull out (weed)
+5919	湓	62	99.979202499	pen2	flowing of water/name of a river
+5920	搴	62	99.9792345397	qian1	seize
+5921	尕	62	99.9792665804	ga3	(phonetic)
+5922	磴	62	99.9792986211	deng4	cliff-ledge/stone step
+5923	锝	62	99.9793306618	de2	
+5924	镅	62	99.9793627024	mei2	
+5925	艚	62	99.9793947431	cao2	sea-going junk
+5926	殄	62	99.9794267838	tian3	exterminate
+5927	暝	62	99.9794588245	ming2	dark
+5928	祢	62	99.9794908651	mi2	
+5929	豉	62	99.9795229058	chi3	salted fermented beans
+5930	垴	62	99.9795549465	nao3	
+5931	瓿	61	99.9796185111	bu4	
+5932	煺	61	99.979650035	tui4	
+5933	蟥	61	99.9796815589	huang2	horse-leech
+5934	蹀	61	99.9797130828	die2	tread on
+5935	黼	61	99.9797761305	fu3	(embroidery)
+5936	氙	61	99.9798076544	xian1	xenon
+5937	铑	61	99.9798391783	lao3	rhodium
+5938	蒡	60	99.9799332332	bang4	Arctium lappa/great burdock
+5939	杪	60	99.9799642403	miao3	the limit/tip of branch
+5940	肜	60	99.9799952474	rong2	(surname)
+5941	膂	60	99.9800262545	lu:3/lv3	backbone/strength
+5942	砬	60	99.9800572617	la2	
+5943	硭	60	99.9800882688	mang2	crude saltpeter
+5944	酽	60	99.9801192759	yan4	strong (of tea)
+5945	踟	60	99.980150283	chi2	hesitating/undecided/hesitant
+5946	鲷	60	99.9801812901	diao1	pagrus major
+5947	蒴	60	99.9802122972	shuo4	pod/capsule
+5948	藁	59	99.9802427875	gao3	
+5949	猡	59	99.9802732778	luo2	name of a tribe
+5950	旒	59	99.9803037682	liu2	tassel
+5951	硇	59	99.9803342585	nao2	
+5952	锍	59	99.9803647488	liu3	
+5953	鞲	59	99.9803952391	gou1	
+5954	哿	59	99.9804257295	ge3	excellent/happy/well-being
+5955	皤	59	99.9804562198	po2	white
+5956	哏	59	99.9804867101	gen2	
+5957	殍	59	99.9805172004	piao3	die of starvation
+5958	漯	59	99.9805476907	ta4/luo4	name of a river
+5959	谂	58	99.9806691353	shen3	consult
+5960	跶	58	99.9806991088	da2	
+5961	橥	58	99.9807290823	zhu1	Zelkova acuminata
+5962	镬	58	99.9807590559	huo4	boiler or caldron
+5963	鸲	58	99.9807890294	qu2	(mynah)
+5964	姝	58	99.9808190029	shu1	pretty woman
+5965	茭	58	99.9808489765	jiao1	Zizania aquatica
+5966	窆	58	99.98087895	bian3	put a coffin in grave
+5967	髟	58	99.9809089236	biao1	hair/shaggy
+5968	畋	58	99.9809388971	tian2	cultivate (land)/to hunt
+5969	溏	58	99.9809688706	tang2	noncoagulative/pond
+5970	鲔	58	99.9809988442	wei3	little tuna/Euthnnus allecteratus
+5971	喹	58	99.9810587912	kui2	
+5972	吣	57	99.9811182215	qin4	
+5973	羼	57	99.9811476783	chan4	confusion/sheep crowding
+5974	缧	57	99.981177135	lei2	bind/bond
+5975	窬	57	99.9812065918	yu2	hole in a wall
+5976	骘	57	99.9812360485	zhi4	determine/promote/stallion
+5977	赉	57	99.9812655053	lai4	bestow/confer
+5978	镓	57	99.9812949621	jia1	gallium
+5979	邳	56	99.981323902	pi1	
+5980	璩	56	99.981352842	qu2	(jade ring)/(surname)
+5981	鸸	56	99.981381782	er2	emu
+5982	涠	56	99.9814107219	wei2	still water
+5983	溲	56	99.9814396619	sou1	urinate
+5984	孥	56	99.9814686019	nu2	child/offspring
+5985	敉	56	99.9814975418	mi3	peaceful
+5986	筌	56	99.9815264818	quan2	bamboo fish trap
+5987		56	99.9815554218		
+5988	蹓	55	99.9816706648	liu1	
+5989	垓	55	99.981699088	gai1	boundary
+5990	苒	55	99.9817275112	ran3	luxuriant growth/passing (of time)
+5991	荸	55	99.9817559344	bi2	water chestnut
+5992	甓	55	99.9817843576	pi4	glazed tile
+5993	锪	55	99.9818127808	huo1	
+5994	镄	55	99.9818412039	fei4	
+5995	脔	55	99.9818696271	luan2	skinny/sliced meat
+5996	艟	55	99.9818980503	chong1	
+5997	眬	54	99.9819828031	long2	
+5998	彘	54	99.9820107095	zhi4	swine
+5999	檠	54	99.9820386159	qing2	instrument for straightening bows
+6000	胩	54	99.9820665223	ka3	
+6001	旄	54	99.9820944287	mao2/mao4	banner decorated with animal's tail, aged
+6002	祆	54	99.9821223351	xian1	
+6003	伛	54	99.9821502414	yu3	hunchbacked
+6004	鲥	54	99.9821781478	shi2	shad/Ilisha elongata
+6005	荦	54	99.9822060542	luo4	brindled ox/clear/eminent
+6006	暾	54	99.9822339606	tun1	sun above the horizon
+6007	缌	53	99.982317163	si1	fine linen
+6008	飏	53	99.9823445527	yang2	
+6009	锞	53	99.9823719423	ke4	grease-pot for cart/ingot
+6010	趵	53	99.9823993319	bao4/bo1	jump/leap
+6011	跖	53	99.9824267215	zhi2	sole of foot
+6012	跬	53	99.9824541111	kui3	brief/short step
+6013	僬	53	99.9824815007	jiao1	clever/pigmies
+6014	皲	53	99.9825088903	jun1	to chap
+6015	翥	53	99.9825362799	zhu4	soar
+6016	祎	53	99.9825636696	yi1	
+6017	芴	52	99.9826727112	wu4	fluorine
+6018	菰	52	99.982699584	gu1	Zizania latifolia/mushroom
+6019	眙	52	99.9827264569	yi2	place name
+6020	锓	52	99.9827533297	qin3	
+6021	訾	52	99.9827802025	zi1/zi3	(surname)/backbite/wealth, backbite/dislike
+6022	莳	52	99.9828070754	shi2/shi4	Peuceclanum gravelens/to plant
+6023	菪	52	99.9828339482	dang4	henbane
+6024	槠	52	99.982860821	zhu1	Quercus glanca
+6025	榍	52	99.9828876938	xie4	
+6026	俜	52	99.9829145667	ping1	forlorn
+6027	觚	52	99.9829414395	gu1	goblet/rule/law
+6028	撄	52	99.9829683123	ying1	oppose/to attack
+6029	嵫	51	99.9829946684	zi1	name of a mountain in Gansu
+6030	桴	51	99.9830210244	fu2	beam/rafter
+6031	晡	51	99.9830473804	bu1	3-5 p.m.
+6032	爨	51	99.9830737365	cuan4	(surname)/cooking-stove/to cook
+6033	悫	51	99.9831000925	que4	honest
+6034	锇	51	99.9831264486	e2	osmium
+6035	锖	51	99.9831528046	qiang1	the color of a mineral
+6036	锘	51	99.9831791607	nuo4	
+6037	蝾	51	99.9832055167	rong2	salamander
+6038	糌	51	99.9832318727	zan1	
+6039	柙	51	99.9832582288	xia2	cage/pen/scabbard
+6040	滹	51	99.9832845848	hu1	(surname)/name of a river
+6041	睚	51	99.9833109409	ya2	
+6042	莨	50	99.9833631362	lang4	Scopalia japonica maxin
+6043	尻	50	99.9833889754	kao1	end of spine
+6044	罨	50	99.9834148147	yan3	foment/valve
+6045	锔	50	99.9834406539	ju1/ju2	mend chinaware with staples, curium
+6046	筲	50	99.9834664932	shao1	basket/bucket
+6047	妣	50	99.9834923324	bi3	deceased mother
+6048	砘	50	99.9835181717	dun4	
+6049	谳	50	99.983544011	yan4	decide judicially
+6050	钽	50	99.9835698502	tan3	
+6051	鈤	50	99.9835956895	ri4	
+6052	鄹	49	99.9836726905	zou1	
+6053	菡	49	99.9836980129	han4	lotus blossom
+6054	崦	49	99.9837233354	yan1	name of a mountain in Gansu
+6055	狺	49	99.9837486579	yin2	snarling of dogs
+6056	杌	49	99.9837739803	wu4	low stool
+6057	秭	49	99.9837993028	zi3	billion
+6058	舯	49	99.9838246253	zhong1	
+6059	豇	49	99.9838499478	jiang1	cowpeas/black-eyed beans
+6060	鲵	49	99.9838752702	ni2	Cryptobranchus japonicus/salamander
+6061	蘧	49	99.9839005927	qu2	(surname)/Dianthus superbus
+6062	阚	49	99.9839259152	kan4	(surname)/peep
+6063	悝	49	99.9839512376	kui1/li3	laugh at, sad
+6064	铌	49	99.9839765601	ni2	niobium
+6065	缑	48	99.9840266883	gou1	(surname)
+6066	瑗	48	99.984051494	yuan4	large jade ring
+6067	椹	48	99.9840762996	shen4/zhen1	fruit of mulberry
+6068	旰	48	99.9841011053	gan4	sunset/evening
+6069	魆	48	99.984125911	xu1	
+6070	蓍	48	99.9841507167	shi1	Achillea sibirica
+6071	蕹	47	99.9841750056	weng4	
+6072	岜	47	99.9841992945	ba1	
+6073	钐	47	99.9842235834	shan1	samarium
+6074	锬	47	99.9842478723	tan2	long spear
+6075	镪	47	99.9842721612	qiang1/qiang3	sulfuric acid, money/string of coins
+6076	绡	47	99.9842964501	xiao1	raw silk
+6077	檎	47	99.984320739	qin2	(fruit)
+6078	茕	47	99.9843693168	qiong2	alone/desolate
+6079	荈	47	99.9844664724	chuan3	
+6080	侉	46	99.9844902445	kua3	
+6081	渫	46	99.9845140167	xie4	(surname)/get rid of/scatter
+6082	辂	46	99.9845377888	lu4	chariot
+6083	欷	46	99.9845615609	xi1	to sob
+6084	轾	46	99.984585333	zhi4	back and lower of chariot/short/low
+6085	麴	46	99.9846091051	qu1	
+6086	戢	46	99.9846328772	ji2	collect oneself/put away
+6087	趼	46	99.9846566494	jian3	callous
+6088	芈	45	99.9847036768	mi3	(surname)
+6089	苈	45	99.9847269321	li4	Drabanemerosa hebecarpa
+6090	缍	45	99.9847501875	duo3	
+6091	歃	45	99.9847734428	sha4	drink
+6092	燠	45	99.9847966981	yu4	warm
+6093	耜	45	99.9848199535	si4	plough/ploughshare
+6094	顸	45	99.9848432088	han1	dawdling
+6095	蚵	45	99.9848664641	e2/ke1	oyster
+6096	哓	45	99.9848897194	xiao1	a cry of alarm/querulous
+6097	澌	45	99.9849129748	si1	drain dry/to exhaust
+6098	郜	45	99.9849362301	gao4	(surname)/name of a feudal state
+6099	徼	45	99.9849594854	jiao3/jiao4	by mere luck, boundary/go around
+6100	籀	45	99.9849827408	zhou4	(surname)/(writing)/develop
+6101	陬	44	99.9850054793	zou1	corner/foot of mountain
+6102	蕤	44	99.9850282179	rui2	fringe/overladen with flowers
+6103	叻	44	99.9850509564	le4	place names
+6104	猞	44	99.985073695	she1	
+6105	洇	44	99.9850964335	yin1	
+6106	锎	44	99.985119172	kai1	
+6107	舳	44	99.9851419106	zhu2	poopdeck/stern of boat
+6108	缋	44	99.9851646491	hui4	multi-color/to draw
+6109	镗	44	99.9851873877	tang1/tang2	noise of drums
+6110	褙	44	99.9852101262	bei4	paper or cloth pasted together
+6111	耋	44	99.9852328648	die4/die2	aged/in one's eighties
+6112	聬	44	99.9852556033	weng3	
+6113	鳡	44	99.9852783419	gan3	
+6114	鲌	44	99.9853010804	ba4	
+6115	鰽	44	99.985323819	qiu2	
+6116	袴	43	99.9854597335	ku4	
+6117	巯	43	99.9854819552	qiu2	
+6118	吖	43	99.985504177	a1	
+6119	猁	43	99.9855263987	li4	a kind of monkey
+6120	桷	43	99.9855486205	jue2	rafter/malus toringo
+6121	砼	43	99.9855708423	tong2	
+6122	锾	43	99.985593064	huan2	(ancient measure)/money
+6123	颟	43	99.9856152858	man1	dawdling
+6124	跽	43	99.9856375075	ji4	kneel
+6125	悛	43	99.9856597293	quan1	to reform
+6126	桕	43	99.9856819511	jiu4	
+6127	艨	43	99.9857041728	meng2	war-boat
+6128	颡	43	99.9857263946	sang3	forehead/kowtow
+6129	髹	43	99.9857486163	xiu1	red lacquer/to lacquer
+6130	桫	43	99.9857708381	suo1	Stewartia pseudocamellia
+6131	葸	42	99.9859036519	xi3	feel insecure/unhappy
+6132	屣	42	99.9859253569	xi3	slippers
+6133	獒	42	99.9859470618	ao2	mastiff
+6134	瘌	42	99.9859687668	la4	scabies/scald-head
+6135	佴	42	99.9859904718	er4	assistant
+6136	锫	42	99.9860121768	pei2	
+6137	隰	42	99.9860338817	xi2	(surname)/low/marshy land
+6138	醌	42	99.9860555867	kun1	
+6139	鰕	42	99.9861207016	xia1	
+6140	岽	41	99.9861418898	dong1	
+6141	昃	41	99.986163078	ze4	afternoon/decline
+6142	螓	41	99.9861842662	qin2	small cicada with a square head
+6143	垧	41	99.9862054544	shang3	
+6144	廨	41	99.9862266426	xie4	office
+6145	骺	41	99.9862478308	hou2	
+6146	黥	41	99.986269019	qing2	(surname)/tattoo criminals on face
+6147	豳	41	99.9862902072	bin1	name of an ancient city
+6148	荑	40	99.9864168195	ti2/yi2	(grass), to weed
+6149	莶	40	99.9864374909	xian1	
+6150	蓊	40	99.9864581623	weng3	a plant in bloom/thick
+6151	揎	40	99.9864788337	xuan1	pull up sleeves/strike with fists
+6152	娈	40	99.9864995051	luan2	beautiful
+6153	嫜	40	99.9865201765	zhang1	husband's parent/lady in the moon
+6154	毽	40	99.986540848	jian4	shuttlecock
+6155	砑	40	99.9865615194	ya4	to calender
+6156	碶	40	99.9865821908	qi4	
+6157	剀	40	99.9866028622	kai3	carefully/moderately
+6158	薷	40	99.9866235336	ru2	Elshotria paltrini
+6159	怃	40	99.986644205	wu3	disappointed/startled
+6160	怿	40	99.9866648764	yi4	pleased/rejoice
+6161	骐	40	99.9866855478	qi2	piebald horse
+6162	腧	40	99.9867062192	shu4	
+6163	霈	40	99.9867268906	pei4	torrent of rain
+6164	蝻	40	99.986747562	nan3	immature locusts
+6165	墼	39	99.9868090594	ji1	
+6166	坩	39	99.9868292141	gan1	crucible
+6167	甏	39	99.9868493687	beng4	
+6168	鹇	39	99.9868695233	xian2	silver pheasant badge worn by civil officials of the 5th grade
+6169	鹣	39	99.9868896779	jian1	mythical bird with 1 eye and 1 wing
+6170	舴	39	99.9869098325	ze2	small boat
+6171	鲭	39	99.9869299872	qing1	mackerel/mullet
+6172	傺	39	99.9869501418	chi4	detain/hinder
+6173	枘	39	99.9869702964	rui4	tenon/tool handle
+6174	秕	39	99.986990451	bi3	grain not fully grown/husks/withered grain/unripe grain
+6175	糨	39	99.9870106056	jiang4	
+6176	忉	39	99.9870307603	dao1	grieved
+6177	磲	39	99.9870509149	qu2	Tridacna gigas
+6178	侑	38	99.9871310166	you4	urge to eat
+6179	萁	38	99.9871506544	qi2	stalks of pulse
+6180	葳	38	99.9871702922	wei1	luxuriant
+6181	呙	38	99.9871899301	guo1	
+6182	鹋	38	99.9872095679	miao2	
+6183	貘	38	99.9872292058	mo4	tapir
+6184	葶	38	99.9872488436	ting2	Draba nemerosa bebe carpa
+6185	枨	38	99.9872684814	cheng2	door post
+6186	棹	38	99.9872881193	zhuo1/zhao4	table
+6187	纛	38	99.9873077571	dao4	big banner/feather banner or fan
+6188	嶷	37	99.9873857916	yi2	name of a mountain in Hunan
+6189	妁	37	99.9874049127	shuo4	(surname)/matchmaker
+6190	杩	37	99.9874240337	ma4	
+6191	鹛	37	99.9874431548	mei2	
+6192	羝	37	99.9874622758	di1	billy goat/ram
+6193	骖	37	99.9874813969	can1	outside horses of a team of 4
+6194	祧	37	99.9875005179	tiao1	ancestral hall
+6195	淠	37	99.98753876	pi4	luxuriant (of water plants)
+6196	畎	37	99.9875578811	quan3	field drains
+6197	箨	37	99.9875770021	tuo4	sheath around joints of bamboo
+6198	鳐	37	99.9875961232	yao2	ray (fish)
+6199	剡	36	99.9876715738	shan4/yan3	river in Zhejiang, sharp
+6200	吲	36	99.9876901781	yin3	
+6201	嫫	36	99.9877087824	mo2	ugly woman
+6202	戽	36	99.9877273866	hu4	water bucket for irrigation
+6203	糗	36	99.9877459909	qiu3	(surname)/dry provisions
+6204	鸮	36	99.9877645952	xiao1	
+6205	蕰	36	99.9877831994	wen1	
+6206	坼	36	99.9878018037	che4	to crack/split/break/to chap
+6207	璺	36	99.9878204079	wen4	a crack, as in porcelain
+6208	栊	36	99.9878390122	long2	bar/cage/gratings
+6209	镝	36	99.9878576165	di1/di2	dysprosium
+6210	疔	36	99.9878762207	ding1	boil/carbuncle
+6211	瘰	36	99.987894825	luo3	scrofula/tuberculosis of glands
+6212	谮	36	99.9879134293	zen4	slander
+6213	辋	36	99.9879320335	wang3	tire/wheel band
+6214	碥	36	99.9879506378	bian3	
+6215	豂	36	99.9879692421	liao2	
+6216	黒	36	99.9880250549	hei1	
+6217	劂	35	99.9880431423	jue2	chisel/engrave
+6218	潋	35	99.9880612298	lian4	full of water/trough
+6219	孓	35	99.9880793173	jue2	larvae of mosquito
+6220	螋	35	99.9880974048	sou1	
+6221	鲳	35	99.9881154923	chang1	a type of fish
+6222	铙	35	99.9881335797	nao2	big cymbals
+6223	塄	35	99.9881516672	leng2	
+6224	萆	35	99.9881697547	bi4	castor seed
+6225	碲	35	99.9881878422	di4	tellurium
+6226	粋	35	99.9882059297	cui4	
+6227	纻	35	99.9882240171	zhu4	
+6228	沭	35	99.9882421046	shu4	river in Shandong
+6229	祏	35	99.9882601921	shi2	
+6230	鱲	35	99.9882963671	la4	
+6231	鄩	35	99.9883868045	xun2	
+6232	怍	34	99.9884405501	zuo4	ashamed
+6233	糍	34	99.9884581208	ci2	
+6234	鸻	34	99.9884756915	heng2	
+6235	仵	34	99.9884932622	wu3	opponent
+6236	柰	34	99.9885108329	nai4	crab-apple/how can one help
+6237	棼	34	99.9885284036	fen2	beams in roof/confused
+6238	氇	34	99.9885459743	lu	
+6239	氆	34	99.988563545	pu3	thick rough serge from Tibet
+6240	烀	34	99.9885811157	hu1	
+6241	镔	34	99.9885986864	bin1	fine steel
+6242	珉	34	99.9886162571	min2	
+6243	鞬	34	99.9886338277	jian1	
+6244	囝	33	99.9887211644	jian3	child
+6245	犴	33	99.9887382183	an4	jail
+6246	镠	33	99.9887552723	liao2	
+6247	觇	33	99.9887723262	zhan1/chan1	keep at/to spy
+6248	钆	33	99.9887893801	ga2	gadolinium
+6249	蚺	33	99.988806434	ran2	
+6250	蝓	33	99.9888234879	yu2	snail
+6251	趑	33	99.9888405418	zi1	
+6252	貔	33	99.9888575957	pi2	(leopard)
+6253	躞	33	99.9888746496	xie4	to walk
+6254	氽	33	99.9888917035	cuan1/tun3	boil for a short time
+6255	绂	33	99.9889087574	fu2	ribbon for a seal/sash
+6256	栲	33	99.9889258113	kao3	mangrove
+6257	鹎	33	99.9889428653	bei1	bird
+6258	襻	33	99.9889599192	pan4	a loop/a belt or band
+6259	蓚	33	99.9889769731	tiao2	
+6260	祓	33	99.9890110809	fu2	cleanse/remove evil
+6261	郿	32	99.9890617258	mei2	
+6262	骝	32	99.989078263	liu2	bay horse with black mane
+6263	檫	32	99.9890948001	cha2	
+6264	砟	32	99.9891113372	zha3	fragments
+6265	蝰	32	99.9891278743	kui2	
+6266	猱	32	99.9891444115	nao2	(monkey)/scratch
+6267	缵	32	99.9891609486	zuan3	carry on
+6268	沔	32	99.9891774857	mian3	inundation/name of a river
+6269	彖	32	99.9891940228	tuan4	running hog
+6270	黻	32	99.98921056	fu2	(embroidery)
+6271	眢	32	99.9892270971	yuan1	inflamed eyelids/parched
+6272	鮠	32	99.9893263198	wei2	
+6273	茛	31	99.9893423402	gen4	ranunculus
+6274	蕈	31	99.9893583605	xun4	mold/mushroom
+6275	骀	31	99.9893743808	tai2/dai4	tired/worn out horse
+6276	樨	31	99.9893904012	xi1	Osmanthus fragrans
+6277	昝	31	99.9894064215	zan3	
+6278	餂	31	99.9894224419	tian2	
+6279	镎	31	99.9894384622	na2	
+6280	酡	31	99.9894544825	tuo2	flushed (from drinking)
+6281	鳜	31	99.9894705029	gui4	helicolenus
+6282	觋	31	99.9894865232	xi2	wizard
+6283	礅	31	99.9895025436	dun1	stone block
+6284	垆	31	99.9895185639	lu2	clay/shop
+6285	坻	31	99.9895345842	chi2/di3	islet/rock in river, place name
+6286	荇	31	99.9895506046	xing4	Limnanthemui nymphoides
+6287	扃	31	99.9895666249	jiong1	shut
+6288	磻	31	99.9895826453	bo1	
+6289	郗	31	99.9895986656	chi1/xi1	(surname)/name of an ancient city
+6290	阇	31	99.9896146859	du1	
+6291	腈	31	99.9896307063	jing1	
+6292	铈	31	99.9896467266	shi4	cerium
+6293	顟	31	99.9897268283	lao2	
+6294	衖	30	99.9897423319	long4	
+6295	珙	30	99.9897578354	gong3	(gem)
+6296	襞	30	99.989773339	bi4	creases/folds or pleats in a garment
+6297	劁	30	99.9897888425	qiao1	
+6298	隈	30	99.9898043461	wei1	bay/cove
+6299	胬	30	99.9898198496	nu3	
+6300	纮	30	99.9898353532	hong2	
+6301	翙	30	99.9898508567	hui4	
+6302	茀	30	99.9898663603	bo2	
+6303	荜	30	99.9898818638	bi4	bean/pulse
+6304	溱	30	99.9898973674	zhen1/qin2	name of a river
+6305	酤	30	99.989912871	gu1	to deal in liquors
+6306	鱇	30	99.9899903887	kang1	
+6307	圯	29	99.9900053755	yi2	bridge, bank
+6308	柽	29	99.9900203623	cheng1	tamarisk
+6309	瞀	29	99.990035349	mao4	indistinct vision/dim
+6310	铖	29	99.9900503358	cheng2	person's name
+6311	粞	29	99.9900653226	xi1	ground rice/thresh rice
+6312	撙	29	99.9900803093	zun3	regulate/restrain
+6313	铊	29	99.9900952961	ta1	thallium
+6314	圹	29	99.9901102829	kuang4	tomb
+6315	菝	29	99.9901252696	ba2	smilax china
+6316	岙	29	99.9901552432	ao4	
+6317	漶	29	99.99017023	huan4	indecipherable
+6318	缏	29	99.9901852167	bian4	braid
+6319	貊	29	99.9902002035	mo4	name of a wild tribe/silent
+6320	粫	29	99.9902151903	er2	
+6321	徂	29	99.990230177	cu2	to go/to reach
+6322	洎	29	99.9902451638	ji4	to reach/when
+6323	礌	29	99.9902601506	lei3	
+6324	邠	28	99.9903495544	bin1	
+6325	邽	28	99.9903640244	gui1	
+6326	溽	28	99.9903784944	ru4	damp/muggy
+6327	棰	28	99.9903929643	chui2	flog/whip
+6328	舭	28	99.9904074343	bi3	
+6329	艋	28	99.9904219043	meng3	small boat
+6330	聱	28	99.9904508443	ao2	difficult to pronounce
+6331	尢	28	99.9904653143	wang1/you2	lame
+6332	藚	28	99.9904797842	xu4	
+6333	佾	28	99.9904942542	yi4	row of dancers at sacrifices
+6334	蕻	28	99.9905087242	hong4/hong2	budding/flourishing
+6335	狁	28	99.9905231942	yun3	name of a tribe
+6336	绁	28	99.9905376642	xie4	leash/rein
+6337	牾	28	99.9905521342	wu3	
+6338	慝	28	99.9905666042	te4	evil thought
+6339	蜱	28	99.9905810741	pi2	(insect)/egg of mantis
+6340	鬘	28	99.9905955441	man2	
+6341	埚	27	99.9906673773	guo1	crucible
+6342	堙	27	99.9906813305	yin1	bury/mound/to dam/close
+6343	菥	27	99.9906952837	xi1	
+6344	萏	27	99.9907092368	dan4	lotus
+6345	玟	27	99.99072319	min2/wen2	jade-like stone, veins in jade
+6346	椟	27	99.9907371432	du2	cabinet/case/casket
+6347	铗	27	99.9907510964	jia2	pincers for use at a fire/sword
+6348	颙	27	99.9907650496	yu2	
+6349	踬	27	99.9907790028	zhi4	stumble
+6350	筚	27	99.990792956	bi4	wicker
+6351	矻	27	99.9908069092	ku1	
+6352	搠	27	99.9908208624	shuo4	daub/thrust
+6353	圉	27	99.9908348156	yu3	stable, corral, enclosure/front
+6354	浍	27	99.9908487688	kuai4/hui4	drain/stream
+6355	蛸	27	99.9908766752	shao1/xiao1	long-legged spider, Octopus octopodia/mantis egg nest
+6356	鮊	27	99.990932488	ba4	
+6357	芘	26	99.9909459244	pi2	Malva sylvestris
+6358	萜	26	99.9909593609	tie1	
+6359	鄗	26	99.9909727973	hao4	
+6360	惝	26	99.9909862337	chang3/tang3	disappointed, disappointed
+6361	毵	26	99.9909996701	san1	long-haired/shaggy
+6362	鲽	26	99.9910131065	die2	
+6363	酞	26	99.9910265429	tai4	phthalein (chemical)
+6364	哚	26	99.9910534157	duo3	
+6365	溷	26	99.9910668522	hun4	disordered/privy
+6366	缞	26	99.9910802886	shuai1	
+6367	踰	26	99.991093725	yao2	
+6368	搦	26	99.9911071614	nuo4	take hold
+6369	帻	26	99.9911205978	ze2	conical cap
+6370	铦	26	99.9911340342	tian3	
+6371	鲴	26	99.9911474706	gu4	
+6372	髫	26	99.9911609071	tiao2	tufts of hair on children
+6373	醡	26	99.991254962	zha4	
+6374	儇	25	99.9912678816	xuan1	ingenious/frivolous
+6375	狴	25	99.9912808012	bi4	(tapir)
+6376	迮	25	99.9912937208	ze2	haste/to press
+6377	趱	25	99.9913195601	zan3	hasten/urge
+6378	椠	25	99.9913324797	qian4	wooden tablet/edition
+6379	赟	25	99.9913453993	yun1	
+6380	陔	25	99.991358319	gai1	step/terrace
+6381	坌	25	99.9913712386	ben4	bring together/dust
+6382	悃	25	99.9913841582	kun3	sincere
+6383	塍	25	99.9913970779	cheng2	raised path between fields
+6384	疬	25	99.9914099975	li4	
+6385	麈	25	99.9914229171	zhu3	leader of herd/stag
+6386	絜	25	99.9914358367	jie2	
+6387	脩	25	99.9914487564	you3	
+6388	赒	25	99.991461676	zhou1	
+6389	埒	25	99.9914745956	lei4/lie4	enclosure, dike, embankment
+6390	镡	25	99.9914875153	tan2	(surname)/knob on a sword-handle
+6391	镨	25	99.9915004349	pu3	praseodymium
+6392	骎	25	99.9915133545	qin1	
+6393	骙	25	99.9915262741	kui2	
+6394	鼩	25	99.9915521134	qu2	
+6395	雰	25	99.991565033	fen1	
+6396	藴	25	99.9915908723	wen1	
+6397	鳑	25	99.9916296312	pang2	
+6398	豨	24	99.991642034	xi1	
+6399	琚	24	99.9916544369	ju1	ornamental gems for belt
+6400	觫	24	99.9916668397	su4	tremble with fear
+6401	鲦	24	99.9916792425	tiao2	Chub leuciehthys
+6402	刳	24	99.9916916454	ku1	to cut open/rip up/scoop out
+6403	拶	24	99.9917040482	zan3/za1	punish by squeezing fingers
+6404	掊	24	99.9917164511	pou2/pou3	take up in both hands, break up/hit
+6405	泐	24	99.9917288539	le4	write
+6406	瘗	24	99.9917412568	yi4	bury/sacrifice
+6407	雩	24	99.9917536596	yu2	summer sacrifice for rain
+6408	麿	24	99.9917660624	mo3	
+6409	檗	24	99.9917784653	bo4	Phyllodendron amurense
+6410	鼂	24	99.9917908681	zhao1	
+6411	褔	24	99.9918280767	fu4	
+6412	铟	24	99.9918404795	yin1	indium
+6413	鲏	24	99.9918900909	pi1	
+6414	蒗	24	99.9919024937	lang4	(herb)/place name
+6415	魟	24	99.9919148966	gong1	
+6416	遹	23	99.9919267826	yu4	
+6417	攴	23	99.9919386687	po1	
+6418	蝥	23	99.9919505547	mao2/mou2	Spanish fly/grain-eating grub
+6419	茆	23	99.9919624408	mao2	
+6420	蓁	23	99.9919743269	zhen1	
+6421	嚆	23	99.9919862129	hao1	sound/noise
+6422	忮	23	99.991998099	zhi4	aggressive
+6423	篌	23	99.992009985	hou2	(mus. instr.)
+6424	菧	23	99.9920218711	di3	
+6425	卺	23	99.9920337571	jin3	nuptial wine cup
+6426	郫	23	99.9920456432	pi2	place name
+6427	篠	23	99.9920575293	xiao3	
+6428	犰	22	99.9921283288	qiu2	armadillo
+6429	狳	22	99.9921396981	yu2	armadillo
+6430	陠	22	99.9921510674	bu1	
+6431	蹁	22	99.9921624366	pian2	to limp
+6432	蓐	22	99.9921738059	ru4	mat/rushes
+6433	菃	22	99.9921965445	qu2	
+6434	埝	22	99.9922079137	nian4	
+6435	蕞	22	99.992219283	zui4	assemble/small
+6436	喈	22	99.9922306523	jie1	harmonious (of music)
+6437	戋	22	99.9922420216	jian1	narrow/small
+6438	赙	22	99.9922533908	fu4	contribute to funeral expenses
+6439	磉	22	99.9922647601	sang3	stone plinth
+6440	郤	22	99.9922761294	qie4	
+6441	聍	22	99.9922874987	ning2	
+6442	铷	22	99.9922988679	ru2	rubidium
+6443	硏	22	99.9923102372	yan2	
+6444	腘	22	99.9923216065	guo2	
+6445	鮟	22	99.9923898221	an1	
+6446	鳈	22	99.9924011914	quan2	
+6447	秾	21	99.9924120439	nong2	
+6448	邗	21	99.9924228964	han2	name of an ancient river
+6449	矧	21	99.9924446013	shen3	(interrog.)
+6450	舁	21	99.9924554538	yu2	to lift/raise
+6451	貅	21	99.9924663063	xiu1	(leopard)
+6452	骢	21	99.9924880113	cong1	buckskin horse
+6453	阼	21	99.9924988638	zuo4	steps leading to the eastern door
+6454	垸	21	99.9925097163	yuan4	
+6455	墁	21	99.9925205687	man4	to plaster
+6456	攮	21	99.9925314212	nang3	to fend off/to stab
+6457	柝	21	99.9925422737	tuo4	watchman's rattle
+6458	梃	21	99.9925531262	ting3	a club (weapon)
+6459	眚	21	99.9925639787	sheng3	cataract of the eye/error
+6460	箜	21	99.9925748312	kong1	ancient string music instrument
+6461	簏	21	99.9925856837	lu4	box/basket
+6462	綮	21	99.9925965362	qi3	embroidered banner
+6463	鲩	21	99.9926073886	huan4	
+6464	茇	21	99.9926290936	ba2	betel
+6465	摅	21	99.9926399461	shu1	set forth/to spread
+6466	顐	21	99.9926507986	wen4	
+6467	蜾	21	99.9926616511	guo3	Eumenes pomiformis
+6468	龂	21	99.9926725036	yan3	
+6469		21	99.9926833561		
+6470	讉	21	99.992726766	yi2	
+6471	鎯	20	99.9927371017	lang2	
+6472	脒	20	99.9927474374	mi3	
+6473	箬	20	99.9927577731	ruo4	(bamboo)/skin of bamboo
+6474	鲻	20	99.9927681088	zi1	Mugil cephalus/grey mullet
+6475	埸	20	99.9927784445	yi4	border
+6476	颃	20	99.9927887802	hang2	fly down
+6477	蒹	20	99.9927991159	jian1	reed
+6478	瞍	20	99.9928094516	sou3	blind
+6479	铫	20	99.9928197873	diao4/yao2	pan with a long handle, (surname)/weeding tool
+6480	蒐	20	99.992830123	sou1	
+6481	蹻	20	99.9928404587	jiao3	
+6482	幞	20	99.9928507944	fu2	
+6483	阯	20	99.9928611301	zhi3	
+6484	觏	20	99.9928714659	gou4	complete/meet unexpectedly/see
+6485	媵	20	99.9928818016	ying4	maid escorting bride to new home
+6486	钬	20	99.9928921373	huo3	holmium
+6487	襦	20	99.992902473	ru2	jacket/short coat
+6488	簋	20	99.9929128087	gui3	round basket of bamboo
+6489	翮	20	99.9929231444	he2	quill
+6490	蹯	20	99.9929334801	fan2	paws of animal
+6491	艖	20	99.9929438158	cha1	
+6492	鲿	20	99.9929954943	chang2	
+6493	蹠	19	99.9930151321	zhi2	
+6494	攉	19	99.993024951	huo1	
+6495	禊	19	99.99303477	xi4	purification ceremony
+6496	箐	19	99.9930445889	qing4	
+6497	镟	19	99.9930544078	xuan4	lathe/thread in screw
+6498	癍	19	99.9930642267	ban1	
+6499	霪	19	99.9930740456	yin2	heavy rain
+6500	袪	19	99.9930838645	qu1	
+6501	劓	19	99.9930936835	yi4	cut off the nose
+6502	殂	19	99.9931035024	cu2	die
+6503	脞	19	99.9931133213	cuo3	chopped meat/trifles
+6504	霨	19	99.9931231402	wei4	
+6505	饾	19	99.9931329591	dou4	
+6506	耵	19	99.993142778	ding1	
+6507	泺	19	99.993152597	luo4	name of a river
+6508	埤	19	99.9931624159	pi2	low wall
+6509	碁	19	99.9931722348	qi2	
+6510	鲐	19	99.9931820537	tai2	globefish
+6511	鷟	19	99.9931918726	zhuo2	
+6512	膬	19	99.9932016916	cui4	
+6513	粯	19	99.9932213294	xian4	
+6514	陴	18	99.9932600883	pi2	parapet
+6515	橼	18	99.9932693904	yuan2	Citrus medica
+6516	驩	18	99.9932786925	huan1	
+6517	唣	18	99.9932879947	zao4	
+6518	蜩	18	99.9932972968	tiao2	cicada
+6519	埯	18	99.9933065989	an3	
+6520	蓥	18	99.9933159011	ying2	
+6521	袝	18	99.9933252032	fu4	
+6522	谞	18	99.9933345053	xu1	
+6523	馘	18	99.9933438075	guo2	cut off the left ear of the slain
+6524	谫	18	99.9933531096	jian3	shallow/stupid
+6525	輶	18	99.9933624117	you2	
+6526	廑	18	99.9933717139	jin3	careful/hut
+6527	瘐	18	99.993381016	yu3	maltreat (as prisoners)
+6528	躐	18	99.9933903181	lie4	step across
+6529	黟	18	99.9933996203	yi1	black and shining ebony
+6530	膯	18	99.9934275267	teng1	
+6531	藭	18	99.9934461309	qiong	
+6532	禆	18	99.9934554331	bi4	
+6533	稓	18	99.9935112458	zuo2	
+6534	縠	17	99.9935200312	hu2	
+6535	揠	17	99.9935288165	ya4	eradicate/pull up
+6536	绐	17	99.9935376019	dai4	
+6537	鸰	17	99.9935463872	ling2	
+6538	搛	17	99.9935551726	jian1	
+6539	黹	17	99.9935639579	zhi3	embroidery
+6540	恧	17	99.9935727433	nu:4/nv4	ashamed
+6541	粎	17	99.9935815286	mi3	
+6542	柒	17	99.993590314	qi1	seven (fraud-proof)
+6543	裒	17	99.9935990993	pou2	collect
+6544	栳	17	99.9936078847	lao3	basket
+6545	钸	17	99.99361667	bu1	
+6546	饸	17	99.9936254554	he2	
+6547	譞	17	99.9936342407	xuan1	
+6548	铕	17	99.9936518114	you3	europium
+6549	絷	17	99.9936605968	zhi2	connect/tie up
+6550	蒨	17	99.9936693821	qian4	
+6551	蓣	17	99.9936781674	yu4	dioscoreaceae
+6552	迻	17	99.9936869528	yi2	
+6553	釆	17	99.9936957381	bian3	
+6554	鲕	17	99.9937045235	er2	caviar/fish roe
+6555	鍏	17	99.9937220942	wei2	
+6556	鷉	17	99.9937308795	si1	
+6557	郄	16	99.9937391481	qie4	
+6558	埘	16	99.9937474167	shi2	hen roost
+6559	薤	16	99.9937556852	xie4	Allium bakeri/shallot/scallion
+6560	鲞	16	99.9937639538	xiang3	wine-preserved pomfret
+6561	鼯	16	99.9937722223	wu2	Petaurista leucogenys
+6562	坭	16	99.9937804909	ni2	mud
+6563	蔌	16	99.9937887595	su4	(surname)/vegetables
+6564	缳	16	99.993797028	huan2	bind/tie/noose
+6565	筸	16	99.9938135652	gan1	
+6566	夼	16	99.9938301023	kuang3	
+6567	椐	16	99.9938383708	ju1	Zelkowa acuminata
+6568	轹	16	99.9938466394	li4	to bully/wheel-rut
+6569	脬	16	99.993854908	pao1	bladder
+6570	眍	16	99.9938631765	kou1	
+6571	饹	16	99.9938714451	le	
+6572	瘥	16	99.9938797137	chai4/cuo2	recover from disease, disease
+6573	瘵	16	99.9938879822	zhai4	foci of tubercular infection
+6574	邴	16	99.9939127879	bing3	(surname)/ancient city name/happy
+6575	鉁	16	99.9939210565	zhen1	
+6576	鞮	16	99.993929325	di1	
+6577	舄	16	99.9939375936	xi4	shoe/slipper
+6578	麄	16	99.9939458621	cu1	
+6579	翛	16	99.9939541307	xiao1	
+6580	覩	16	99.9939623993	du3	
+6581	纩	16	99.9939706678	kuang4	fine floss-silk or cotton
+6582	唛	16	99.993987205	ma4/mai4	mark
+6583	袓	16	99.9939954735	jie1	
+6584	祂	16	99.9940037421	ta1	
+6585	螵	16	99.994061622	piao1	nest of eggs of mantis
+6586	鸊	16	99.9940698906	bi4	
+6587	鮡	16	99.9940781591	zhao4	
+6588	禛	15	99.9940859109	zhen1	
+6589	袆	15	99.9940936627	yi1	
+6590	謴	15	99.9941014145	gun4	
+6591	邾	15	99.9941091662	zhu1	(surname)/name of a feudal state
+6592	鮣	15	99.994116918	yin	
+6593	酲	15	99.9941246698	cheng2	alcoholic
+6594	龁	15	99.9941324216	he2	
+6595	汔	15	99.9941401734	qi4	near
+6596	眄	15	99.9941479251	mian3	ogle
+6597	眊	15	99.9941556769	mei4	
+6598	鬲	15	99.9941634287	ge2	(surname)/earthen pot/iron caldron
+6599	阨	15	99.9941711805	e4	
+6600	靸	15	99.9941789322	sa3	
+6601	酺	15	99.9942021876	pu2	
+6602	狃	15	99.9942099394	niu3	accustomed to
+6603	轺	15	99.9942176911	yao2	light carriage
+6604	霅	15	99.9942254429	zha2	
+6605	鬂	15	99.9942331947	bin4	
+6606	鼷	15	99.9942409465	xi1	mouse
+6607	蠃	15	99.9942486982	luo3	solitary wasp
+6608	埴	15	99.99425645	zhi2	soil with large clay content
+6609	鴥	15	99.9942642018	yu4	
+6610	髆	15	99.9942797053	bo2	
+6611	膮	15	99.9942952089	xiao1	
+6612	铪	15	99.9943107125	ha1	hafnium
+6613	簳	15	99.994326216	gan3	
+6614	訉	15	99.9943572231	fan4	
+6615	鲉	15	99.9943727267	you2	
+6616	蕿	14	99.9943799617	xuan1	
+6617	袊	14	99.9943871967	ling2	
+6618	汆	14	99.9943944316	cuan1	
+6619	仝	14	99.9944089016	tong2	together/same
+6620	趽	14	99.9944161366	pang2	
+6621	堍	14	99.9944233716	tu4	side of bridge
+6622	揸	14	99.9944306066	zha1	
+6623	忭	14	99.9944378416	bian4	delighted/pleased
+6624	銧	14	99.9944450766	guang1	
+6625	妤	14	99.9944523116	yu2	handsome/fair
+6626	頫	14	99.9944595466	tiao4	
+6627	讟	14	99.9944740166	du2	
+6628	龠	14	99.9944812515	yue4	(ancient measure)/flute
+6629	垤	14	99.9944884865	die2	anthill/mound
+6630	擐	14	99.9944957215	huan4	pass through/to get into (armor)
+6631	噍	14	99.9945029565	jiao4	
+6632	洫	14	99.9945101915	xu4	
+6633	滏	14	99.9945174265	fu3	name of a river in Hebei
+6634	璁	14	99.9945246615	cong1	(gem)
+6635	癃	14	99.9945318965	long2	infirmity/retention of urine
+6636	邡	14	99.9945391315	fang1	name of a district in Sichuan
+6637	絁	14	99.9945463665	shi1	
+6638	蒽	14	99.9945680714	en1	
+6639	膫	14	99.9945825414	liao2	
+6640	臅	14	99.9945897764	chu4	
+6641	茖	14	99.9945970114	luo4	
+6642	詾	14	99.9946187164	xiong1	
+6643	贆	14	99.9946259514	biao1	
+6644	蹨	14	99.9946331864	nian3	
+6645	鰜	14	99.9946621263	jian1	
+6646	赕	14	99.9946765963	dan3	
+6647	鯮	14	99.9946910663	zong1	
+6648	蔯	13	99.9946977845	chen2	
+6649	貙	13	99.9947045027	chu1	
+6650	躜	13	99.9947179391	zuan1	
+6651	鳀	13	99.9947246573	ti2	
+6652	鹡	13	99.9947313756	ji2	
+6653		13	99.9947380938		
+6654	蠋	13	99.994744812	zhu2	
+6655	钲	13	99.9947515302	zheng1	gong used to halt troops
+6656	蜁	13	99.9947582484	xuan2	
+6657	兕	13	99.9947649666	si4	rhinoceros indicus
+6658	阽	13	99.9947716848	dian4/yan2	dangerous, dangerous
+6659	绋	13	99.9947851212	fu2	heavy rope/rope of a bier
+6660	铓	13	99.9947918394	mang2	
+6661	爝	13	99.9947985576	jue2	torch
+6662	磾	13	99.9948052758	di1	
+6663	螘	13	99.9948187122	yi3	
+6664	仂	13	99.9948254304	le4	surplus/tithe
+6665	顗	13	99.9948388669	yi3	
+6666	蟫	13	99.9948455851	yin2	
+6667	蕺	13	99.9948523033	ji2	Houttuynia cordata
+6668	骃	13	99.9948590215	yin1	
+6669	蔀	13	99.9948657397	bu4	
+6670	诪	13	99.9948724579	zhou1	
+6671	猹	13	99.9948791761	cha2	
+6672	鋬	13	99.9948858943	pan4	
+6673	齾	13	99.9948993307	e4	
+6674	埕	13	99.9949060489	cheng2	earthen jar
+6675	虡	13	99.9949262035	ju4	
+6676	紬	13	99.9949530764	chou1	
+6677	訢	13	99.9949597946	xi1	
+6678	蔎	13	99.9949665128	she4	
+6679	繸	12	99.9949727142	sui4	
+6680	绖	12	99.9949789156	die2	
+6681	埭	12	99.9949851171	dai4	dam
+6682	駮	12	99.9949913185	bo2	
+6683	鰡	12	99.9949975199	liu2	
+6684	鵳	12	99.9950037213	jian1	
+6685	柁	12	99.9950099227	tuo2	main beam of roof
+6686	筴	12	99.9950161242	jia1	
+6687	珧	12	99.9950223256	yao2	mother-of-pearl
+6688	贳	12	99.995028527	shi4	borrow/buy on credit/rent out
+6689	贶	12	99.9950347284	kuang4	bestow/confer
+6690	腩	12	99.9950409298	nan3	
+6691	臌	12	99.9950471313	gu3	dropsical/swollen
+6692	礓	12	99.9950533327	jiang1	
+6693	袛	12	99.9950595341	di1	
+6694	貐	12	99.9950657355	yu3	
+6695	蹐	12	99.995071937	ji2	
+6696	圬	12	99.9950781384	wu1	to plaster/whitewash
+6697	堠	12	99.9950843398	hou4	mounds for beacons
+6698	屦	12	99.9950905412	ju4	sandals
+6699	驵	12	99.9950967426	zang3	powerful horse
+6700	桄	12	99.9951091455	guang1/guang4	Arenga saccharifera, rung of ladder
+6701	憝	12	99.9951215483	dui4	dislike/hate
+6702	瘳	12	99.9951277498	chou1	convalesce/recover/heal
+6703	騃	12	99.9951339512	ai2	
+6704	茌	12	99.9951401526	chi2	name of a district in Shandong
+6705	辀	12	99.995146354	zhou1	
+6706	胠	12	99.9951525554	qu1	
+6707	埏	12	99.9951587569	shan1/yan2	to mix water with clay, boundary
+6708	腠	12	99.9951649583	cou4	the tissue between the skin and the flesh
+6709	靰	12	99.9951711597	wu4	
+6710	鞡	12	99.9951773611	la	
+6711	缻	12	99.9951835625	fou3	
+6712	铼	12	99.9952021668	lai2	rhenium
+6713	紤	12	99.9952083682	jiu3	
+6714	鐣	12	99.995264181	zhang3	
+6715	莤	12	99.9952765839	you2	
+6716	鱯	12	99.9952827853	hu4	
+6717	邲	11	99.9952941546	bi4	
+6718	唼	11	99.9952998392	sha4	
+6719	鐻	11	99.9953055238	ju4	
+6720	閟	11	99.9953112085	bi4	
+6721	駚	11	99.9953168931	yang3	
+6722	篥	11	99.9953225777	li4	bamboos good for poles/horn
+6723	茈	11	99.9953282624	ci2/zi3	water chestnut, Lithospermum officinale
+6724	肏	11	99.995333947	cao4	
+6725	萩	11	99.9953396317	jiao1	
+6726	跐	11	99.9953453163	ci1	
+6727	蹅	11	99.9953510009	zha1	
+6728	瞢	11	99.9953566856	meng2	
+6729	罽	11	99.9953623702	ji4	
+6730	聭	11	99.9953680548	kui4	
+6731	辻	11	99.9953737395	shi2	
+6732	铚	11	99.9953794241	zhi4	
+6733	箦	11	99.9953851087	ze2	
+6734	踣	11	99.9953907934	bo2	corpse/prostrate
+6735	菑	11	99.995396478	zi1	
+6736	捃	11	99.9954078473	jun4	gather/to sort
+6737	瘕	11	99.9954135319	jia3	obstruction in the intestine
+6738	閒	11	99.9954249012	jian1	
+6739	顩	11	99.9954362705	yan3	
+6740	鳓	11	99.9954419551	le4	(shad)/spermary of fish
+6741		11	99.995459009		
+6742	聛	11	99.9954931168	bi3	
+6743	脮	11	99.9954988015	tui3	
+6744	諹	11	99.99552154	yang2	
+6745	誖	11	99.9955272247	bei4	
+6746	蕅	11	99.9955329093	ou3	
+6747	睒	10	99.9955437618	shan3	
+6748	笰	10	99.9955489296	fei4	
+6749	籥	10	99.9955540975	yao4	
+6750	翧	10	99.9955592653	xuan1	
+6751	镩	10	99.9955644332	cuan1	
+6752	耧	10	99.995569601	lou2	drill for sowing grain
+6753	蜞	10	99.9955747689	qi2	grapsus
+6754	舡	10	99.9955799367	chuan2	
+6755	鹀	10	99.9955902724	wu2	
+6756		10	99.9955954403		
+6757	罣	10	99.9956006081	gua4	
+6758	觍	10	99.995605776	tian3	
+6759	絽	10	99.9956109439	lv3	
+6760	羶	10	99.9956161117	shan1	
+6761	臜	10	99.9956212796	za1	
+6762	觔	10	99.9956316153	jin1	
+6763	躼	10	99.9956367831	uu	
+6764	岈	10	99.995641951	ya2	
+6765	潲	10	99.9956471188	shao4	driving rain/to sprinkle
+6766	枧	10	99.9956522867	jian3	
+6767	觌	10	99.9956574545	di2	face to face
+6768	膦	10	99.9956626224	lin4	phosphine
+6769	礞	10	99.9956677902	meng2	(mineral)
+6770	蝤	10	99.9956729581	qiu2/you2	larva/grub
+6771	螗	10	99.9956781259	tang2	(cicada)
+6772	酹	10	99.9956832938	lei4	pour out libation/sprinkle
+6773	醅	10	99.9956884616	pei1	unstrained spirits
+6774	絅	10	99.9956936295	jiong1	
+6775	纁	10	99.9956987973	xun1	
+6776	葰	10	99.9957039652	jun4	
+6777	郇	10	99.995709133	xun2	name of a feudal state
+6778	躄	10	99.9957143009	bi4	
+6779	茼	10	99.9957194687	tong2	Chrysanthemum coronarium
+6780	洧	10	99.9957246366	wei3	name of a river
+6781	滠	10	99.9957298044	she4	name of a river
+6782	澉	10	99.9957349723	gan3	place name/wash
+6783	鎭	10	99.9957401401	zhen1	
+6784	铏	10	99.995745308	xing2	
+6785	赆	10	99.9957556437	jin4	farewell presents
+6786	赇	10	99.9957608115	qiu2	to bribe
+6787	顣	10	99.9957659794	cu4	
+6788	骕	10	99.9957711472	su4	
+6789	飑	10	99.9957763151	biao1	whirlwind
+6790	訄	10	99.9957814829	kao1	
+6791	輓	10	99.9957866508	wan3	
+6792	鋹	10	99.9957969865	chang3	
+6793	钘	10	99.9958021544	jian1	
+6794	陁	10	99.9958073222	tuo2	
+6795	耱	10	99.9958124901	mo4	
+6796	鋵	10	99.9958228258	tu1	
+6797	鱵	10	99.9958279936	zhen1	
+6798	榀	10	99.9958590007	pin3	
+6799	膶	10	99.9958693364	yen	
+6800	茐	10	99.9958745043	cong1	
+6801	螝	10	99.9958796721	gui1	
+6802	訙	10	99.99588484	xun4	
+6803	鄬	10	99.9959055114	wei2	
+6804	閮	10	99.9959210149	ting2	
+6805	鯆	10	99.9959416863	bu1	
+6806	逿	10	99.9959468542	dang4	
+6807	鮀	10	99.995952022	tuo2	
+6808	鯝	10	99.9959571899	gu4	
+6809	鰁	10	99.9959623577	quan2	
+6810	鱤	10	99.9959675256	gan3	
+6811	郕	9	99.9959721767	cheng2	
+6812	镴	9	99.9959768277	la4	
+6813	鮄	9	99.9959861299	fu2	
+6814	鲙	9	99.9959907809	kuai4	
+6815	鳁	9	99.995995432	wen1	
+6816	齁	9	99.9960000831	ku4	
+6817	膹	9	99.9960093852	fen4	
+6818	袣	9	99.9960140363	yi4	
+6819	謿	9	99.9960186873	zhao1	
+6820	陧	9	99.9960233384	nie4	dangerous
+6821	坜	9	99.9960279895	li4	
+6822	坫	9	99.9960326405	dian4	stand for goblets
+6823	甍	9	99.9960372916	meng2	rafters supporting tiles
+6824	绠	9	99.9960419427	geng3	rope/well-rope
+6825	恝	9	99.9960465937	jia2	indifferent
+6826	飗	9	99.9960512448	liu2	
+6827	镙	9	99.9960558959	luo2	
+6828	镱	9	99.9960605469	yi4	ytterbium
+6829	魋	9	99.9960698491	tui2	
+6830	硱	9	99.9960745001	kun3	
+6831	祫	9	99.9960791512	xia2	
+6832	箖	9	99.9960884533	lin2	
+6833	袧	9	99.9960931044	gou1	
+6834	迯	9	99.9960977554	tao2	
+6835	郙	9	99.9961024065	fu3	
+6836	酖	9	99.9961070576	dan1	
+6837	遘	9	99.9961117086	gou4	meet unexpectedly
+6838	阘	9	99.9961163597	ta4	
+6839	眭	9	99.9961210108	sui1	evil look of deep-set eyes
+6840	餗	9	99.9961256618	su4	
+6841	耖	9	99.9961303129	chao4	
+6842	鯒	9	99.996134964	yong3	
+6843	邶	9	99.996139615	bei4	name of a feudal state
+6844	絼	9	99.9961442661	zhen4	
+6845	颥	9	99.9961489172	ru2	
+6846	篚	9	99.9961535682	fei3	round covered basket
+6847	鳘	9	99.9961582193	min3	
+6848		9	99.9961628704		
+6849	虒	9	99.9961675214	ti2	
+6850	裈	9	99.9961721725	kun1	
+6851	遆	9	99.9961768236	ti2	
+6852	麑	9	99.9961814746	ni2	
+6853	粚	9	99.9961861257	li2	
+6854	鄚	9	99.9961954278	mao4	
+6855	粌	9	99.9962140321	yin2	
+6856	葌	9	99.9962372874	jian1	
+6857	貏	9	99.9962465896	bi3	
+6858	闅	9	99.9962605428	wen2	
+6859	鳉	9	99.9962884492	jiang1	
+6860	鴱	9	99.9962931002	ai4	
+6861	鶎	9	99.9962977513	zun1	
+6862	祼	9	99.9963070534	guan4	
+6863	鬛	9	99.9963117045	lie4	
+6864	镈	9	99.9963163556	bo2	
+6865	瞓	9	99.9963210066	fen3	
+6866	罶	8	99.9963251409	liu3	
+6867	羑	8	99.9963292752	you3	
+6868	黉	8	99.9963334095	hong2	
+6869	霚	8	99.9963375438	wu4	
+6870	笹	8	99.996341678	xiao3	
+6871	郐	8	99.9963458123	kuai4	(surname)/name of a feudal state
+6872	溻	8	99.9963499466	ta1	
+6873	袉	8	99.9963623494	tuo2	
+6874	訚	8	99.9963664837	yin2	
+6875	谉	8	99.996370618	shen3	
+6876	莛	8	99.9963747523	ting2	stalk of grass
+6877	哕	8	99.9963788866	yue3	
+6878	滗	8	99.9963830208	bi4	
+6879	瀹	8	99.9963871551	yue4	cleanse/to boil
+6880	稃	8	99.9963954237	fu1	
+6881	眰	8	99.996399558	die4	
+6882	眳	8	99.9964036922	ming2	
+6883	矞	8	99.9964078265	yu4	
+6884	硚	8	99.9964119608	qiao2	
+6885	禋	8	99.9964160951	yin1	
+6886	翀	8	99.9964202294	chong1	
+6887	苾	8	99.9964243637	bi4	
+6888	襕	8	99.9964284979	lan2	
+6889	趥	8	99.9964326322	qiu1	
+6890	茺	8	99.9964367665	chong1	
+6891	軿	8	99.9964409008	peng1	
+6892	逌	8	99.9964450351	you1	
+6893	唪	8	99.9964491693	feng3	recite/chant
+6894	庳	8	99.9964533036	bi4	low-built house
+6895	殪	8	99.9964574379	yi4	exterminate
+6896	隃	8	99.9964615722	yu2	
+6897	糈	8	99.9964657065	xu3	official pay/sacrificial rice
+6898	鲄	8	99.9964698407	ge3	
+6899	碕	8	99.9964781093	qi1	
+6900	鲣	8	99.9964822436	jian1	bonito
+6901	綎	8	99.9964863779	ting1	
+6902	栝	8	99.9964905122	gua1	Juniperus chinensis/measuring-frame
+6903	轵	8	99.9964946464	zhi3	end of axle outside of hub
+6904	雔	8	99.9964987807	chou2	
+6905	頠	8	99.996502915	wei3	
+6906	穈	8	99.9965070493	men2	
+6907	翃	8	99.9965111836	hong2	
+6908	膭	8	99.9965153178	gui1	
+6909	衒	8	99.9965194521	xuan4	
+6910	盇	8	99.9965235864	he2	
+6911	譢	8	99.996531855	sui4	
+6912	鳰	8	99.9965359892	ru4	
+6913	鴫	8	99.9965442578	tian2	
+6914	笟	8	99.9965483921	gu1	
+6915	莾	8	99.9965525264	mang3	
+6916	袑	8	99.9965649292	shao4	
+6917	訒	8	99.9965690635	ren4	
+6918	讝	8	99.9965773321	zhan2	
+6919	鈩	8	99.9965938692	lu2	
+6920	閷	8	99.9966021377	sha1	
+6921	頉	8	99.996606272	yi2	
+6922	髤	8	99.9966104063	xiu1	
+6923	龤	8	99.9966145406	xie2	
+6924	薿	8	99.9966186749	ni3	
+6925	鱥	8	99.9966228091	gui4	
+6926	觝	8	99.9966269434	zhi3	
+6927	鮻	8	99.9966310777	suo1	
+6928	鳤	8	99.996635212	guan3	
+6929	穉	7	99.9966388295	ti2	
+6930	觱	7	99.996642447	bi4	
+6931	轘	7	99.9966460645	huan2	
+6932	筘	7	99.9966532995	kou4	(a measure of width of cloth)
+6933	鲝	7	99.996656917	zha3	
+6934	蔸	7	99.996664152	dou1	
+6935	镚	7	99.9966677695	beng4	
+6936	痦	7	99.9966713869	wu4	(flat) mole
+6937	秵	7	99.9966750044	yin1	
+6938	臎	7	99.9966786219	cui4	
+6939	葴	7	99.9966822394	qian2	
+6940	泖	7	99.9966930919	mao3	still water
+6941	骟	7	99.9966967094	shan4	to geld
+6942	锽	7	99.9967003269	huang2	
+6943	犋	7	99.9967039444	ju4	
+6944	眵	7	99.9967075619	chi1	gritty secretion in eyes
+6945	耩	7	99.9967111794	jiang3	to plough/to sow
+6946	筢	7	99.9967147969	pa2	
+6947	躔	7	99.9967184144	chan2	course of stars/follow precedent
+6948	鬏	7	99.9967220319	jiu1	
+6949	黪	7	99.9967256494	can3	grey black
+6950		7	99.9967292669		
+6951	祔	7	99.9967328844	fu4	
+6952	箠	7	99.9967365019	chui2	
+6953	舲	7	99.9967401194	ling2	
+6954	蒷	7	99.9967437369	yun2	
+6955	蜺	7	99.9967473544	ni2	
+6956	襢	7	99.9967509719	tan3	
+6957	謺	7	99.9967545894	zhe2	
+6958	劐	7	99.9967582069	huo1	
+6959	搋	7	99.9967654418	chuai1	
+6960	醊	7	99.9967690593	zhui4	
+6961	廒	7	99.9967726768	ao2	granary
+6962	洚	7	99.9967762943	jiang4	flood
+6963	胲	7	99.9967799118	hai3	hydroxylamine
+6964	韥	7	99.9967835293	du2	
+6965	饘	7	99.9967871468	zhan1	
+6966	馂	7	99.9967907643	jun4	
+6967	筅	7	99.9967943818	xian3	bamboo brush for utensils
+6968	鳆	7	99.9967979993	fu4	Haliotis gigantea/sea ear
+6969	鲊	7	99.9968016168	zha3	
+6970	篸	7	99.9968088518	zan1	
+6971	腄	7	99.9968124693	hou2	
+6972	臑	7	99.9968160868	nao4	
+6973	诐	7	99.9968197043	bi4	
+6974	仳	7	99.9968233218	pi3	to part
+6975	趩	7	99.9968269393	chi4	
+6976	絪	7	99.9968377918	yin1	
+6977	绹	7	99.9968414093	tao2	
+6978	膵	7	99.9968450268	cui4	
+6979	蕗	7	99.9968486442	lu4	
+6980	蝘	7	99.9968522617	yan3	
+6981	袠	7	99.9968558792	zhi4	
+6982	賸	7	99.9968594967	sheng4	
+6983	葙	7	99.9968631142	xiang1	Celosia argentea
+6984	祪	7	99.9968775842	gui3	
+6985	禘	7	99.9968812017	di4	
+6986	菍	7	99.9968884367	nie4	
+6987	仉	7	99.9969065242	zhang3	mother/surname of Mencius
+6988	氕	7	99.9969101417	pie1	protium
+6989	矔	7	99.9969137592	guan4	
+6990	臒	7	99.9969246117	qu2	
+6991	苿	7	99.9969282292	wei4	
+6992	菢	7	99.9969318467	bao4	
+6993	蔂	7	99.9969354642	lei2	
+6994	藞	7	99.9969390816	la3	
+6995	袩	7	99.9969426991	zhe2	
+6996	跍	7	99.9969535516	ku1	
+6997	跓	7	99.9969571691	zhu4	
+6998	邿	7	99.9969680216	shi1	
+6999	醿	7	99.9969752566	mi2	
+7000	鈨	7	99.9969788741	yuan2	
+7001	駵	7	99.9969861091	liu2	
+7002	駸	7	99.9969897266	qin1	
+7003	鰪	7	99.9969933441	e2	
+7004	鱾	7	99.9969969616	ji3	
+7005		7	99.9970005791		
+7006	賨	7	99.9970041966	cong2	
+7007	艞	7	99.9970078141	yao4	
+7008	鹟	7	99.9970114316	weng1	
+7009	鞓	7	99.9970186666	ting1	
+7010	穊	6	99.9970284855	ji4	
+7011	蕡	6	99.9970315862	fei4	
+7012	鑨	6	99.9970346869	long2	
+7013	楱	6	99.9970377876	cou4	
+7014	靹	6	99.9970408883	na4	
+7015	鷃	6	99.997043989	yan4	
+7016	鼱	6	99.9970470897	jing1	
+7017	眫	6	99.9970501905	pan4	
+7018	艆	6	99.9970532912	lang2	
+7019	褯	6	99.9970563919	jie4	
+7020	剞	6	99.9970594926	ji1	curved wood graver
+7021	蔟	6	99.9970625933	cu4	collect/frame for silk worm/nest
+7022	靿	6	99.997065694	yao4	
+7023	瘼	6	99.9970718954	mo4	distress/sickness
+7024	酴	6	99.9970749961	tu2	yeast
+7025	鼢	6	99.9970780968	fen2	(mole)
+7026	睆	6	99.9970811976	huan3	
+7027	硁	6	99.9970842983	keng1	
+7028	秬	6	99.997087399	ju4	
+7029	穪	6	99.9970904997	bie2	
+7030	筦	6	99.9970936004	guan3	
+7031	粡	6	99.9970967011	tong2	
+7032	粣	6	99.9970998018	ce4	
+7033	綖	6	99.9971029025	yan2	
+7034	刭	6	99.997109104	jing3	cut the throat
+7035	跼	6	99.9971122047	qu2	
+7036	蒇	6	99.9971153054	chan3	complete/prepare
+7037	挢	6	99.9971184061	jiao3	correct
+7038	邆	6	99.9971215068	teng2	
+7039	彡	6	99.9971246075	san1	
+7040	猃	6	99.9971277082	xian3	long-snout dog
+7041	闉	6	99.9971308089	yin1	
+7042	阓	6	99.9971339096	hui4	
+7043	阛	6	99.9971370104	huan2	
+7044	靺	6	99.9971401111	wa4	
+7045	鞨	6	99.9971432118	he2	
+7046	铥	6	99.9971463125	diu1	thulium
+7047	瘅	6	99.9971494132	dan1/dan4	(disease), to hate
+7048	騻	6	99.9971556146	shuang1	
+7049	箅	6	99.9971587153	bi4	
+7050	箢	6	99.997161816	yuan1	
+7051	觖	6	99.9971649168	jue2	dissatisfied
+7052	麆	6	99.9971680175	zhu4	
+7053	齮	6	99.9971711182	yi3	
+7054	糀	6	99.9971742189	hua1	
+7055	瘊	6	99.9971804203	hou2	wart
+7056	聴	6	99.9971866217	ting1	
+7057	讬	6	99.9971928231	tuo1	
+7058	揲	6	99.9971959239	she2/die2	sort out divining stalks
+7059	镮	6	99.9971990246	huan2	
+7060	钷	6	99.9972021253	po3	
+7061	睪	6	99.997205226	yi4	
+7062	翫	6	99.9972145281	wan4	
+7063	荅	6	99.9972176288	da2	
+7064	菉	6	99.9972207295	lu4	
+7065	袚	6	99.9972238303	bo1	
+7066	褋	6	99.997226931	die2	
+7067	贠	6	99.9972300317	yuan2	
+7068	踦	6	99.9972362331	ji1	
+7069	遯	6	99.9972393338	dun4	
+7070	鎌	6	99.9972455352	lian2	
+7071	靉	6	99.9972486359	ai4	
+7072	韲	6	99.9972517367	ji1	
+7073	餖	6	99.9972548374	dou4	
+7074	麕	6	99.9972610388	jun1	
+7075	菵	6	99.9972672402	wang3	
+7076	蟭	6	99.9972703409	jiao1	
+7077	錏	6	99.9972734416	ya1	
+7078	稖	6	99.9973044487	bang4	
+7079	笇	6	99.9973137509	suan4	
+7080	篂	6	99.9973168516	xing1	
+7081	緛	6	99.9973199523	ruan3	
+7082	縿	6	99.9973261537	xian1	
+7083	蕚	6	99.9973354558	e4	
+7084	蝿	6	99.9973416573	ying2	
+7085	袃	6	99.997344758	chai4	
+7086	軅	6	99.997366463	yan4	
+7087	軓	6	99.9973695637	fan4	
+7088	鉄	6	99.9973757651	zhi2	
+7089	鯕	6	99.9973850672	qi2	
+7090	鶕	6	99.9973881679	an1	
+7091	麨	6	99.9973912686	chao3	
+7092		6	99.9973943694		
+7093		6	99.9973974701		
+7094	脭	6	99.9974005708	cheng2	
+7095	鲯	6	99.9974036715	qi2	
+7096	鐏	6	99.9974067722	zun1	
+7097	魾	6	99.9974098729	pi1	
+7098	眎	5	99.9974124568	shi4	
+7099	窋	5	99.9974176247	ku1	
+7100	縡	5	99.9974253765	zai4	
+7101	鉏	5	99.9974331282	chu2	
+7102	謦	5	99.9974357122	qing3	
+7103	麹	5	99.9974382961	qu1	
+7104	繐	5	99.9974434639	sui4	
+7105	粺	5	99.9974486318	bai4	
+7106	缊	5	99.9974512157	wen1	
+7107	艈	5	99.9974537996	uu	
+7108	蓇	5	99.9974563836	gu1	
+7109	蛣	5	99.9974589675	jie2	
+7110	蹾	5	99.9974615514	dun1	
+7111	掎	5	99.9974641353	ji3	drag
+7112	哜	5	99.9974667193	ji4	sip
+7113	鄦	5	99.9974693032	xu3	
+7114	韰	5	99.997474471	xie4	
+7115	飖	5	99.997477055	yao2	
+7116	镲	5	99.9974796389	cha3	
+7117	麃	5	99.9974822228	biao1	
+7118	筰	5	99.9974873907	zuo2	
+7119	聠	5	99.9974899746	ping2	
+7120	茷	5	99.9974925585	pei4	
+7121	螀	5	99.9974951425	jiang1	
+7122	褧	5	99.9975003103	jiong3	
+7123	賮	5	99.9975028942	jin4	
+7124	赗	5	99.9975054782	feng4	
+7125	踡	5	99.9975080621	juan3	
+7126	揞	5	99.997510646	an3	
+7127	遝	5	99.9975132299	ta4	
+7128	酂	5	99.9975158139	zan4	
+7129	酇	5	99.9975183978	zan4	
+7130	檑	5	99.9975235656	lei2	logs rolled down in defense of city
+7131	雮	5	99.9975261496	mu4	
+7132	氍	5	99.9975287335	qu2	woolen rug
+7133	腙	5	99.9975313174	zong1	
+7134	痖	5	99.9975364853	ya3	
+7135	髣	5	99.9975390692	fang3	
+7136	髳	5	99.9975416531	mao2	
+7137	酎	5	99.997544237	zhou4	strong wine
+7138	鲒	5	99.997546821	jie2	oyster
+7139	鲪	5	99.9975494049	jun1	
+7140	鹯	5	99.9975519888	zhan1	
+7141	麜	5	99.9975545727	li4	
+7142	齸	5	99.9975571567	yi4	
+7143	齻	5	99.9975597406	dian1	
+7144	粩	5	99.9975623245	lao1	
+7145	簰	5	99.9975700763	pai2	
+7146	蒾	5	99.9975726602	mi2	
+7147	蓏	5	99.9975752441	luo3	
+7148	薳	5	99.9975778281	wei3	
+7149	藛	5	99.997580412	xie3	
+7150	蚢	5	99.9975829959	hang2	
+7151	蓠	5	99.9975855799	li2	Gracilaria confervoides
+7152	蓰	5	99.9975881638	xi3	(grass)/increase five fold
+7153	遡	5	99.9975907477	su4	
+7154	郋	5	99.9975933316	xi2	
+7155	鄜	5	99.9975959156	fu1	
+7156	錞	5	99.9975984995	dui4	
+7157	靣	5	99.9976010834	mian4	
+7158	鸂	5	99.9976036673	xi1	
+7159	麐	5	99.9976062513	lin2	
+7160	麚	5	99.9976088352	jia1	
+7161	齧	5	99.9976114191	nie4	
+7162		5	99.997614003		
+7163	睊	5	99.997616587	juan4	
+7164	砢	5	99.9976191709	luo3	
+7165	碻	5	99.9976217548	qiao1	
+7166	絃	5	99.9976243387	xuan4	
+7167	茝	5	99.9976269227	zhi3	
+7168	菴	5	99.9976295066	yan3	
+7169	袥	5	99.9976320905	tuo1	
+7170	襍	5	99.9976346744	za2	
+7171	覗	5	99.9976372584	si4	
+7172	諥	5	99.9976424262	zhong4	
+7173	跂	5	99.9976450101	qi2	
+7174	辵	5	99.9976475941	chuo4	
+7175	邅	5	99.997650178	zhan1	
+7176	醨	5	99.9976527619	li2	
+7177	頍	5	99.9976553458	kui3	
+7178	疰	5	99.9976579298	zhu4	
+7179	觜	5	99.9976605137	zi1/zui3	(zodiacal sign), mouth
+7180	笭	5	99.9976656815	ling2	
+7181	糷	5	99.9976682655	lan4	
+7182	翉	5	99.9976734333	ben3	
+7183	胵	5	99.9976760172	zhi4	
+7184	芖	5	99.9976786012	zhi4	
+7185	蛚	5	99.997686353	lie4	
+7186	蛯	5	99.9976889369	lao3	
+7187	蜏	5	99.9976915208	you3	
+7188	賲	5	99.9976966887	bao3	
+7189	钃	5	99.9976992726	zhu2	
+7190	餈	5	99.9977018565	ci2	
+7191	馧	5	99.9977044404	wo4	
+7192	麤	5	99.9977070244	cu1	
+7193	鼶	5	99.9977096083	si1	
+7194	臓	5	99.9977147761	zang4	
+7195	螣	5	99.9977276958	te4	
+7196	铽	5	99.9977302797	te4	terbium
+7197	竝	5	99.9977328636	bing4	
+7198	粊	5	99.9977354475	bi3	
+7199	絺	5	99.9977431993	zhi3	
+7200	絿	5	99.9977457832	qiu2	
+7201	脦	5	99.9977509511	te4	
+7202	臇	5	99.997753535	juan3	
+7203	臋	5	99.9977561189	tun2	
+7204	葍	5	99.9977587029	fu2	
+7205	葞	5	99.9977612868	mi3	
+7206	葻	5	99.9977664546	lan2	
+7207	藙	5	99.9977690386	yi4	
+7208	蜔	5	99.9977716225	dian4	
+7209	螕	5	99.9977742064	bi1	
+7210	觼	5	99.9977819582	jue2	
+7211	觿	5	99.9977845421	wei2	
+7212	諝	5	99.99778971	xu1	
+7213	趧	5	99.9977974618	ti2	
+7214	跉	5	99.9978000457	ling2	
+7215	邉	5	99.9978103814	bian1	
+7216	酁	5	99.9978155492	chan2	
+7217	鍊	5	99.9978258849	lian4	
+7218	闀	5	99.9978284689	hong4	
+7219	闄	5	99.9978310528	yao3	
+7220	腽	5	99.9978336367	wa4	castor
+7221	髿	5	99.9978517242	suo1	
+7222	鶝	5	99.997856892	bi4	
+7223	鷣	5	99.997859476	yin2	
+7224	鋊	5	99.9978646438	yu4	
+7225	隤	5	99.9978672277	tui2	
+7226	譟	5	99.9978723956	zao4	
+7227	蒉	5	99.9978749795	kui4	(surname)/Amaranthus mangostanus
+7228	磜	5	99.9978775635	qi4	
+7229	綼	5	99.9978801474	bi4	
+7230	輋	5	99.9978827313	she1	
+7231	頨	5	99.9978853152	yu3	
+7232	閗	5	99.9978878992	dou4	
+7233	鲹	5	99.9978956509	shen1	
+7234	禣	4	99.9978977181	fu4	
+7235	粏	4	99.9978997852	tai4	
+7236	臐	4	99.9979039195	xun1	
+7237	迏	4	99.9979059866	da2	
+7238	鋾	4	99.9979080538	tao2	
+7239	鐇	4	99.9979101209	fan2	
+7240	铻	4	99.9979121881	wu2	
+7241	鮼	4	99.9979142552	qin1	
+7242	鼈	4	99.9979163223	bie1	
+7243	込	4	99.9979183895	ru4	
+7244	篰	4	99.9979204566	bu4	
+7245	痄	4	99.9979225238	zha4	mumps
+7246	睄	4	99.9979245909	qiao2	
+7247	磡	4	99.997926658	kan4	
+7248	窔	4	99.9979287252	yao4	
+7249	筊	4	99.9979307923	jiao3	
+7250	羺	4	99.9979328595	nou2	
+7251	腪	4	99.9979349266	yun4	
+7252	荄	4	99.9979390609	gai1	
+7253	蓡	4	99.997941128	shen1	
+7254	蝀	4	99.9979431952	dong1	
+7255	詥	4	99.9979452623	ge2	
+7256	豀	4	99.9979473294	xi1	
+7257	苠	4	99.9979493966	min2	multitude/skin of bamboo
+7258	郞	4	99.9979514637	lang2	
+7259	骒	4	99.9979535309	ke4	mother horse
+7260	戤	4	99.997955598	gai4	infringe upon a trade mark
+7261	铞	4	99.9979576651	diao4	
+7262	耢	4	99.9979597323	lao4	
+7263	麯	4	99.9979617994	qu1	
+7264	秱	4	99.9979638666	tong2	
+7265	筼	4	99.9979659337	yun2	
+7266	脧	4	99.9979721351	juan1	
+7267	茣	4	99.9979742023	wu2	
+7268	菒	4	99.9979762694	gao3	
+7269	蕝	4	99.9979804037	jue2	
+7270	詝	4	99.9979824708	zhu3	
+7271	謱	4	99.997984538	lou2	
+7272	冁	4	99.9979866051	chan3	smilingly
+7273	踧	4	99.9979886723	di2	
+7274	茚	4	99.9979907394	yin4	
+7275	辌	4	99.9979928065	liang2	
+7276	辒	4	99.9979948737	wen1	
+7277	郪	4	99.9979969408	qi1	
+7278	鄘	4	99.997999008	yong1	
+7279	鄠	4	99.9980010751	hu4	
+7280	帱	4	99.9980031422	chou2/dao4	canopy/curtain, canopy
+7281	鈇	4	99.9980052094	fu1	
+7282	缲	4	99.9980072765	qiao1	
+7283	雚	4	99.9980093437	guan4	
+7284	雟	4	99.9980114108	gui1	
+7285	韺	4	99.9980134779	ying1	
+7286	頵	4	99.9980155451	yun1	
+7287	顝	4	99.9980176122	kua3	
+7288	镘	4	99.9980196794	man4	side of coin without words/trowel
+7289	鬋	4	99.9980217465	jian3	
+7290	酾	4	99.9980238136	shai1	
+7291	鳣	4	99.9980258808	zhan1	
+7292	麀	4	99.9980300151	you1	
+7293	麉	4	99.9980320822	jian1	
+7294	麊	4	99.9980341493	mi2	
+7295	麣	4	99.9980362165	yan2	
+7296	藬	4	99.9980382836	tui1	
+7297	鞚	4	99.9980424179	kong4	
+7298	飔	4	99.9980444851	si1	
+7299	鴃	4	99.9980465522	gui1	
+7300	醲	4	99.9980548208	nong2	
+7301	毳	4	99.9980568879	cui4	crisp/brittle/fine animal hair
+7302	絫	4	99.9980610222	lei3	
+7303	脺	4	99.9980630893	cui4	
+7304	蚘	4	99.9980672236	you2	
+7305	蝺	4	99.9980692907	yu3	
+7306	裀	4	99.998073425	yin1	
+7307	詧	4	99.9980754922	qie4	
+7308	踘	4	99.9980796264	ju1	
+7309	蹷	4	99.9980816936	jue2	
+7310	蟓	4	99.9980837607	xiang4	
+7311	盦	4	99.9980858279	an1	
+7312	瞆	4	99.998087895	gui4	
+7313	矰	4	99.9980899621	zeng1	
+7314	磥	4	99.9980920293	lei2	
+7315	祮	4	99.9980940964	gao4	
+7316	稛	4	99.9980961636	kun3	
+7317	箾	4	99.9980982307	xiao1	
+7318	翂	4	99.9981002978	fen1	
+7319	胊	4	99.998102365	qu2	
+7320	蓺	4	99.9981044321	yi4	
+7321	薾	4	99.9981064993	er3	
+7322	襱	4	99.9981085664	long2	
+7323	覅	4	99.9981106335	fiao	
+7324	讏	4	99.9981127007	wei4	
+7325	跅	4	99.9981147678	tuo4	
+7326	踆	4	99.998116835	qun1	
+7327	蹔	4	99.9981189021	zan4	
+7328	軐	4	99.9981209693	xian4	
+7329	轪	4	99.9981230364	dai4	
+7330	鄤	4	99.9981251035	wan4	
+7331	醰	4	99.9981271707	tan2	
+7332	鑟	4	99.9981292378	du2	
+7333	铔	4	99.998131305	ya1	
+7334	閛	4	99.9981333721	peng1	
+7335	陙	4	99.9981354392	chun2	
+7336	霳	4	99.9981375064	long2	
+7337	顑	4	99.9981395735	yan4	
+7338	镤	4	99.9981416407	pu2	protoactinium
+7339	竚	4	99.9981457749	zhu4	
+7340	紩	4	99.9981478421	zhi4	
+7341	聦	4	99.9981499092	cong1	
+7342	鶄	4	99.9981540435	qing1	
+7343	簷	4	99.9981581778	yan2	
+7344	糵	4	99.9981602449	nie4	
+7345	紖	4	99.9981623121	zhen4	
+7346	趦	4	99.9981685135	zi1	
+7347	禠	4	99.9981726478	si1	
+7348	籓	4	99.9981747149	ban1	
+7349	镥	4	99.998176782	lu3	
+7350	矝	4	99.9981809163	qin2	
+7351	笖	4	99.9981829835	yi3	
+7352	笧	4	99.9981850506	shan4	
+7353	簢	4	99.9981871177	min3	
+7354	簻	4	99.9981891849	ke1	
+7355	粍	4	99.9981933192	zhe2	
+7356	綍	4	99.9981953863	fu2	
+7357	縕	4	99.9981974535	wen1	
+7358	罋	4	99.9981995206	weng4	
+7359	翜	4	99.9982036549	sha4	
+7360	膰	4	99.998205722	pan2	
+7361	膲	4	99.9982077892	jiao1	
+7362	菂	4	99.9982098563	di4	
+7363	薢	4	99.9982139906	xie4	
+7364	藷	4	99.9982160577	zhu1	
+7365	袀	4	99.9982222591	jun1	
+7366	袐	4	99.9982243263	bi4	
+7367	覍	4	99.9982263934	bian4	
+7368	賹	4	99.9982429305	ai4	
+7369	釛	4	99.9982470648	ba2	
+7370	鈱	4	99.9982511991	min2	
+7371	鈶	4	99.9982532662	ci2	
+7372	鍦	4	99.9982574005	shi1	
+7373	閯	4	99.9982615348	sha4	
+7374	閺	4	99.9982636019	wen2	
+7375	隂	4	99.9982677362	yin4	
+7376	顪	4	99.9982760048	hui4	
+7377	驌	4	99.9982842734	su4	
+7378	驘	4	99.9982863405	luo2	
+7379	鰠	4	99.9982884076	sao1	
+7380	鲗	4	99.9982925419	zei2	
+7381	鶒	4	99.9982946091	chi4	
+7382	鶗	4	99.9982966762	ti2	
+7383	硙	4	99.9983049448	wei4	
+7384	禜	4	99.9983070119	yong3	
+7385	糢	4	99.998309079	mo2	
+7386	藠	4	99.9983111462	jiao4	
+7387	镦	4	99.9983132133	dun1/dui4	upsetting (forged pieces)
+7388	蕂	4	99.9983152805	sheng4	
+7389	霮	4	99.9983173476	dan4	
+7390	沩	4	99.9983194147	wei2	
+7391	禬	4	99.998323549	gui4	
+7392	鴪	4	99.9983256162	yu4	
+7393	鮨	4	99.9983276833	yi4	
+7394	鱣	4	99.9983297504	shan4	
+7395	盝	3	99.9983313008	lu4	
+7396	眹	3	99.9983328512	zhen4	
+7397	睖	3	99.9983344015	leng4	
+7398	磫	3	99.9983359519	zong1	
+7399	禫	3	99.9983375022	dan4	
+7400	繨	3	99.9983390526	da2	
+7401	褱	3	99.9983421533	huai2	
+7402	鏏	3	99.9983437036	wei4	
+7403	鹓	3	99.9983468044	yuan1	
+7404	繟	3	99.9983483547	chan2	
+7405	繺	3	99.9983499051	sha1	
+7406	沲	3	99.9983514554	duo4	
+7407	餦	3	99.9983530058	zhang1	
+7408	踺	3	99.9983561065	jian4	
+7409	祦	3	99.9983576568	wu2	
+7410	篲	3	99.9983592072	hui4	
+7411	絙	3	99.9983623079	geng1	
+7412	纄	3	99.9983638583	peng2	
+7413	脝	3	99.9983654086	heng1	
+7414	茊	3	99.998366959	zi1	
+7415	菫	3	99.9983685093	jin3	
+7416	蓞	3	99.9983700597	uu	
+7417	酦	3	99.99837161	po1	
+7418	醾	3	99.9983731604	mi2	
+7419	锳	3	99.9983747108	ying1	
+7420	钶	3	99.9983762611	ke1	columbium
+7421	鲼	3	99.9983778115	fen4	
+7422	齄	3	99.9983793618	zha1	
+7423	鷧	3	99.9983824625	yi4	
+7424		3	99.9983840129		
+7425	祋	3	99.9983855632	dui4	
+7426	箯	3	99.9983871136	bian1	
+7427	粐	3	99.998388664	hu4	
+7428	粦	3	99.9983902143	lin2	
+7429	粭	3	99.9983917647	he2	
+7430	紃	3	99.998393315	xun2	
+7431	脰	3	99.9983948654	dou4	
+7432	芃	3	99.9983964157	peng2	
+7433	苽	3	99.9983979661	gu1	
+7434	莿	3	99.9983995164	ci4	
+7435	菆	3	99.9984010668	zou1	
+7436	藗	3	99.9984026171	su4	
+7437	藧	3	99.9984041675	huan4	
+7438	袵	3	99.9984057179	ren4	
+7439	裯	3	99.9984072682	dao1	
+7440	褵	3	99.9984088186	li2	
+7441	襆	3	99.9984103689	pu2	
+7442	詤	3	99.9984119193	huang3	
+7443	譓	3	99.9984134696	hui4	
+7444	跊	3	99.99841502	mei4	
+7445	軈	3	99.9984165703	ying1	
+7446	苘	3	99.9984181207	qing3	
+7447	迺	3	99.9984196711	nai3	
+7448	掭	3	99.9984212214	tian4	
+7449	邘	3	99.9984243221	yu2	
+7450	鄳	3	99.9984258725	meng2	
+7451	猸	3	99.9984274228	mei2	
+7452	艴	3	99.9984289732	fu2	angry
+7453	鑕	3	99.9984305235	zhi4	
+7454	柃	3	99.9984320739	ling2	Eurya japonica
+7455	闒	3	99.9984336243	ta4	
+7456	毹	3	99.9984351746	shu1	rug
+7457	脶	3	99.998436725	luo2	
+7458	颋	3	99.9984382753	ting3	
+7459	鵀	3	99.9984398257	ren2	
+7460	鶜	3	99.998441376	mao2	
+7461	鶟	3	99.9984429264	tu2	
+7462	鷱	3	99.9984444767	gao1	
+7463	鹍	3	99.9984475775	kun1	
+7464	麖	3	99.9984491278	jing1	
+7465		3	99.9984506782		
+7466	軎	3	99.9984522285	wei4	
+7467	稂	3	99.9984537789	lang2	grass/weeds
+7468	佧	3	99.9984599803	ka3	ancient name for a minority group in China
+7469	緌	3	99.998463081	rui2	
+7470	蠾	3	99.9984646314	zhu2	
+7471	裲	3	99.9984661817	liang3	
+7472	郈	3	99.9984677321	hou4	
+7473	鋐	3	99.9984692824	hong2	
+7474	瓞	3	99.9984723831	die2	young melon
+7475	驙	3	99.9984739335	zhan1	
+7476	鯙	3	99.9984754839	chun2	
+7477	眆	3	99.9984770342	fang3	
+7478	睠	3	99.9984785846	juan4	
+7479	瞫	3	99.9984801349	shen3	
+7480	矅	3	99.9984816853	yao4	
+7481	碃	3	99.9984832356	qing4	
+7482	禃	3	99.998484786	zhi2	
+7483	秔	3	99.9984863363	jing1	
+7484	穻	3	99.9984878867	yu1	
+7485	籐	3	99.9984909874	teng2	
+7486	絏	3	99.9984925378	yi4	
+7487	纕	3	99.9984940881	xiang1	
+7488	翐	3	99.9984956385	zhi4	
+7489	耈	3	99.9984971888	gou3	
+7490	耎	3	99.9984987392	nuo4	
+7491	脷	3	99.9985002895	li4	
+7492	艐	3	99.9985033903	ke4	
+7493	苙	3	99.998506491	li4	
+7494	葹	3	99.9985080413	shi1	
+7495	蓂	3	99.9985095917	mi4	
+7496	蔲	3	99.998511142	kou4	
+7497	薋	3	99.9985126924	zi1	
+7498	蛷	3	99.9985142427	qiu2	
+7499	蜑	3	99.9985157931	dan4	
+7500	衂	3	99.9985173434	nv4	
+7501	衋	3	99.9985188938	xi4	
+7502	袿	3	99.9985204442	gui1	
+7503	誳	3	99.9985266456	jue4	
+7504	諆	3	99.9985281959	qi1	
+7505	讱	3	99.9985297463	ren4	
+7506	軃	3	99.9985312966	tuo3	
+7507	轝	3	99.998532847	yu4	
+7508	郀	3	99.9985343974	ku1	
+7509	鉐	3	99.9985374981	shi2	
+7510	鍧	3	99.9985390484	hong1	
+7511	鍼	3	99.9985405988	qian2	
+7512	鏦	3	99.9985421491	cong1	
+7513	镵	3	99.9985436995	chan2	
+7514	陗	3	99.9985483506	qiao4	
+7515	陼	3	99.9985499009	du3	
+7516	韈	3	99.9985514513	wa4	
+7517	骫	3	99.9985530016	wei3	
+7518	骳	3	99.998554552	bei4	
+7519	骹	3	99.9985561023	jiao1	
+7520	髠	3	99.9985576527	kun1	
+7521	髥	3	99.998559203	ran2	
+7522	鳒	3	99.9985607534	jian1	
+7523	鶡	3	99.9985623038	he2	
+7524	龒	3	99.9985638541	mang2	
+7525	籂	3	99.9985654045	shi4	
+7526	翯	3	99.9985669548	he4	
+7527	莚	3	99.9985685052	yan2	
+7528	萗	3	99.9985700555	ce4	
+7529	転	3	99.9985716059	zhuan3	
+7530	鄷	3	99.9985731562	feng1	
+7531	靭	3	99.9985747066	ren4	
+7532	馉	3	99.998576257	gu3	
+7533	鼰	3	99.998580908	ju2	
+7534	臛	3	99.9985871094	huo4	
+7535	軡	3	99.9985933109	qian2	
+7536	瞐	3	99.9985995123	mo4	
+7537	銶	3	99.9986010626	qiu2	
+7538	钖	3	99.998602613	yang2	
+7539	矊	3	99.9986041634	mian2	
+7540	矘	3	99.9986057137	tang3	
+7541	矡	3	99.9986088144	jue2	
+7542	硽	3	99.9986103648	yan1	
+7543	磿	3	99.9986119151	li4	
+7544	礈	3	99.9986134655	zhui4	
+7545	礜	3	99.9986150158	yu4	
+7546	秲	3	99.9986165662	zhi4	
+7547	笗	3	99.9986212173	dong1	
+7548	箘	3	99.9986227676	jun4	
+7549	箽	3	99.998624318	dong3	
+7550	簜	3	99.9986274187	dang4	
+7551	粷	3	99.998628969	ju2	
+7552	緷	3	99.9986336201	yun4	
+7553	繉	3	99.9986367208	hun2	
+7554	繙	3	99.9986382712	fan2	
+7555	罁	3	99.9986398215	gang1	
+7556	羇	3	99.9986429222	ji1	
+7557	聣	3	99.9986444726	uu	
+7558	脙	3	99.9986475733	xiu1	
+7559	脻	3	99.998650674	jie1	
+7560	脼	3	99.9986522244	lang3	
+7561	腗	3	99.9986537747	pi2	
+7562	艜	3	99.9986553251	dai4	
+7563	葘	3	99.9986584258	zi1	
+7564	葢	3	99.9986599761	gai4	
+7565	藘	3	99.9986646272	lv2	
+7566	蛬	3	99.9986692783	qiong2	
+7567	螁	3	99.9986708286	ban1	
+7568	螚	3	99.998672379	nai2	
+7569	螤	3	99.9986739293	zhong1	
+7570	袇	3	99.9986754797	ran2	
+7571	袌	3	99.9986770301	bao4	
+7572	袔	3	99.9986785804	ke4	
+7573	袦	3	99.9986801308	na4	
+7574	袨	3	99.9986816811	xuan4	
+7575	覂	3	99.9986832315	ban3	
+7576	訋	3	99.9986863322	diao4	
+7577	詻	3	99.9986925336	e4	
+7578	譃	3	99.9986971847	xu1	
+7579	譄	3	99.998698735	zeng1	
+7580	賰	3	99.9987033861	chun3	
+7581	趮	3	99.9987049365	zao4	
+7582	蹱	3	99.9987064868	zhong1	
+7583	軙	3	99.9987080372	qi2	
+7584	軠	3	99.9987095875	kuang2	
+7585	鄫	3	99.9987173393	zeng1	
+7586	鄿	3	99.9987188897	ji1	
+7587	酀	3	99.99872044	yan3	
+7588	釡	3	99.9987219904	fu3	
+7589	釢	3	99.9987235407	nai3	
+7590	鉃	3	99.9987250911	shi4	
+7591	鍎	3	99.9987281918	tu2	
+7592	鞗	3	99.9987328428	tiao2	
+7593	韱	3	99.9987343932	xian1	
+7594	餁	3	99.9987405946	ren4	
+7595	騺	3	99.9987514471	zhi4	
+7596	鯚	3	99.9987529975	ji4	
+7597	鳛	3	99.9987576485	xi2	
+7598	鴮	3	99.9987607492	wu1	
+7599	鴲	3	99.9987622996	zhi1	
+7600	鴷	3	99.99876385	lie	
+7601	鷷	3	99.9987654003	zun1	
+7602	鸀	3	99.9987669507	zhu2	
+7603	麎	3	99.998768501	chen2	
+7604	麡	3	99.9987700514	qi2	
+7605	麧	3	99.9987716017	he2	
+7606	鼇	3	99.9987731521	ao2	
+7607	鼞	3	99.9987747024	tang1	
+7608	鼤	3	99.9987762528	wen2	
+7609	齺	3	99.9987778032	zou1	
+7610	齽	3	99.9987793535	jin4	
+7611	龑	3	99.9987809039	yan	
+7612	裏	3	99.9987824542		
+7613		3	99.9987840046		
+7614		3	99.9987855549		
+7615	砮	3	99.9987871053	nu2	
+7616	綟	3	99.9987886556	li4	
+7617	緜	3	99.998790206	mian2	
+7618	繑	3	99.9987917564	jue1	
+7619	纑	3	99.9987933067	lu2	
+7620	蠙	3	99.9987964074	bin1	
+7621	輴	3	99.9987979578	chun1	
+7622	酨	3	99.9987995081	zai4	
+7623	鏂	3	99.9988010585	ou1	
+7624	駹	3	99.9988026088	mang2	
+7625	瞕	3	99.9988057096	zhang4	
+7626	肻	3	99.9988088103	ken3	
+7627	鐰	3	99.998811911	qiao1	
+7628	綵	3	99.9988134613	cai3	
+7629	鮰	3	99.9988150117	hui2	
+7630	鳾	3	99.998816562	shi	
+7631	虰	3	99.9988181124	ding1	
+7632	驎	3	99.9988196628	lin2	
+7633	荬	3	99.9988212131	mai3	
+7634	鑛	3	99.9988227635	kuang4	
+7635	犏	3	99.9988243138	pian1	
+7636	鞧	3	99.9988258642	qiu1	
+7637	鮋	3	99.9988274145	you2	
+7638	盕	2	99.9988315488	fan4	
+7639	盩	2	99.9988325824	zhou1	
+7640	盻	2	99.998833616	pan3	
+7641	眖	2	99.9988346495	kuang4	
+7642	砛	2	99.9988356831	jin1	
+7643	硈	2	99.9988367167	qia4	
+7644	禢	2	99.9988377502	ta4	
+7645	禥	2	99.9988387838	qi2	
+7646	窼	2	99.9988398174	ke1	
+7647	竏	2	99.9988408509	qian1	
+7648	筈	2	99.9988418845	kuo4	
+7649	筽	2	99.9988429181	o	
+7650	篴	2	99.9988439517	di2	
+7651	籆	2	99.9988449852	yue4	
+7652	籇	2	99.9988460188	hao2	
+7653	紏	2	99.9988470524	tou3	
+7654	肣	2	99.9988480859	han2	
+7655	胑	2	99.9988491195	zhi1	
+7656	臮	2	99.9988501531	ji4	
+7657	苲	2	99.9988511866	zha3	
+7658	蒃	2	99.9988522202	zhuan4	
+7659	虗	2	99.9988532538	xu1	
+7660	蜌	2	99.9988542874	bi4	
+7661	跘	2	99.9988553209	ban4	
+7662	鷭	2	99.9988584216	fan2	
+7663	鸼	2	99.9988594552	diao3	
+7664	鹐	2	99.9988604888	qian1	
+7665	矄	2	99.9988615223	xun1	
+7666	魖	2	99.9988625559	xu1	
+7667	鴐	2	99.9988635895	ge1	
+7668	薀	2	99.9988646231	wen1	
+7669	謏	2	99.9988656566	xiao3	
+7670	脎	2	99.9988666902	sa4	
+7671	聧	2	99.9988687573	kui1	
+7672	脜	2	99.9988697909	you3	
+7673	荖	2	99.9988718581	lao3	
+7674	蕌	2	99.9988728916	lei3	
+7675	蠷	2	99.9988739252	qu2	
+7676	褏	2	99.9988749588	you4	
+7677	觽	2	99.9988759923	wei2	
+7678	踫	2	99.9988770259	pan2	
+7679	蹽	2	99.9988780595	liao1	
+7680	軉	2	99.998879093	yu4	
+7681	墚	2	99.9988811602	liang2	
+7682	搌	2	99.9988821938	zhan3	bind/wipe
+7683	擗	2	99.9988832273	pi3	
+7684	哳	2	99.9988842609	zha1	
+7685	楗	2	99.998886328	jian4	door lock
+7686	韂	2	99.9988873616	chan4	
+7687	饏	2	99.9988894287	dan4	
+7688	耥	2	99.9988904623	tang1	
+7689	髼	2	99.9988914959	peng2	
+7690	篼	2	99.9988925295	dou1	
+7691	鬑	2	99.998893563	lian2	
+7692	醑	2	99.9988945966	xu3	spiritus/strain spirits
+7693	鴧	2	99.9988956302	yu4	
+7694	眜	2	99.9988966637	mo4	
+7695	瞷	2	99.9988976973	jian4	
+7696	磦	2	99.9988987309	piao1	
+7697	礨	2	99.9988997644	lei3	
+7698	祃	2	99.998900798	ma4	
+7699	祲	2	99.9989018316	jin4	
+7700	祻	2	99.9989028652	gu4	
+7701	窊	2	99.9989038987	wa1	
+7702	簥	2	99.9989049323	jiao1	
+7703	縢	2	99.9989069994	teng2	
+7704	繌	2	99.998908033	sha3	
+7705	聜	2	99.9989101002	di3	
+7706	胔	2	99.9989111337	zi4	
+7707	胾	2	99.9989121673	zi4	
+7708	脨	2	99.9989132009	ji2	
+7709	膼	2	99.9989142344	zhua1	
+7710	艕	2	99.998915268	bang4	
+7711	苼	2	99.9989163016	sheng1	
+7712	莻	2	99.9989173351	neus	
+7713	蓨	2	99.9989183687	tiao2	
+7714	蓵	2	99.9989194023	jie2	
+7715	蓾	2	99.9989204359	lu3	
+7716	藦	2	99.9989214694	mo4	
+7717	虀	2	99.998922503	ji1	
+7718	蚈	2	99.9989235366	qian1	
+7719	蛡	2	99.9989245701	yi4	
+7720	蝝	2	99.9989266373	yuan1	
+7721	蝹	2	99.9989276708	ao3	
+7722	蟿	2	99.9989287044	ji4	
+7723	衼	2	99.998929738	zhi1	
+7724	褦	2	99.9989307716	nai4	
+7725	襶	2	99.9989318051	dai4	
+7726	覐	2	99.9989328387	jiao4	
+7727	詯	2	99.9989338723	hui4	
+7728	誴	2	99.9989349058	cong2	
+7729	諓	2	99.9989359394	jian4	
+7730	謧	2	99.998936973	li2	
+7731	謪	2	99.9989380065	shang1	
+7732	譁	2	99.9989390401	wa2	
+7733	貤	2	99.9989400737	yi2	
+7734	赪	2	99.9989411073	cheng1	
+7735	踖	2	99.9989421408	ji2	
+7736	軆	2	99.9989431744	ti1	
+7737	輈	2	99.998944208	zhou1	
+7738	鄛	2	99.9989452415	chao2	
+7739	鄡	2	99.9989462751	qiao1	
+7740	醖	2	99.9989473087	yun4	
+7741	屺	2	99.9989483423	qi3	hill without trees
+7742	鍑	2	99.9989493758	fu4	
+7743	鏉	2	99.9989504094	shou4	
+7744	雊	2	99.998951443	gou4	
+7745	飐	2	99.9989535101	zhan3	
+7746	稆	2	99.9989545437	lv3	
+7747	駳	2	99.9989555772	dan4	
+7748	騽	2	99.9989566108	xi2	
+7749	骍	2	99.9989576444	xing1	
+7750	筻	2	99.998958678	gang4	
+7751	魱	2	99.9989597115	hu2	
+7752	舣	2	99.9989607451	yi3	moor a boat to the bank
+7753	鮾	2	99.9989617787	nei3	
+7754	鯋	2	99.9989628122	sha1	
+7755	鯏	2	99.9989638458	li2	
+7756	鶃	2	99.9989648794	yi4	
+7757	鶫	2	99.9989659129	dong1	
+7758	齛	2	99.9989669465	xie4	
+7759	矙	2	99.9989679801	kan4	
+7760	絾	2	99.9989690137	cheng2	
+7761	袗	2	99.9989700472	zhen3	
+7762	襬	2	99.9989710808	bai3	
+7763	漤	2	99.9989721144	lan3	
+7764	鬐	2	99.9989741815	qi2	
+7765	鲾	2	99.9989752151	bi1	
+7766	鴾	2	99.9989762486	mou2	
+7767	稭	2	99.9989772822	jie1	
+7768	籄	2	99.9989783158	kui4	
+7769	聺	2	99.9989793494	qie2	
+7770	褹	2	99.9989803829	yi4	
+7771	鏕	2	99.9989824501	ao2	
+7772	齆	2	99.9989834836	weng4	
+7773	盫	2	99.9989845172	an1	
+7774	矎	2	99.9989855508	xuan1	
+7775	礋	2	99.9989865844	ze2	
+7776	窌	2	99.9989876179	pao4	
+7777	簼	2	99.9989886515	gou1	
+7778	纴	2	99.9989907186	ren4	
+7779	翚	2	99.9989927858	hui1	
+7780	耰	2	99.9989938193	you1	
+7781	艧	2	99.9989948529	wo4	
+7782	藇	2	99.9989958865	yu3	
+7783	虖	2	99.9989969201	hu1	
+7784	蚖	2	99.9989979536	wan2	
+7785	蜎	2	99.9989989872	yuan1	
+7786	蜨	2	99.9990000208	die2	
+7787	蠭	2	99.9990010543	pang2	
+7788	詟	2	99.9990020879	zhe2	
+7789	豭	2	99.9990051886	jia1	
+7790	趬	2	99.9990072558	qiao1	
+7791	阢	2	99.9990082893	wu4	
+7792	圊	2	99.9990093229	qing1	pigsty/rest-room
+7793	録	2	99.99901139	lu4	
+7794	鍮	2	99.9990124236	tou1	
+7795	鍸	2	99.9990134572	hu2	
+7796	闚	2	99.9990144907	kui1	
+7797	阤	2	99.9990155243	yi3	
+7798	霫	2	99.9990165579	xi2	
+7799	鞎	2	99.9990175915	hen2	
+7800	韗	2	99.999018625	yun4	
+7801	鬖	2	99.9990196586	san1	
+7802	鳠	2	99.9990206922	hu4	
+7803	鴼	2	99.9990217257	lu4	
+7804	鷇	2	99.9990227593	kou4	
+7805	黇	2	99.9990237929	tian1	
+7806	黡	2	99.9990248265	yan3	
+7807	齣	2	99.99902586	chu1	
+7808	眅	2	99.9990279272	pan1	
+7809	磈	2	99.9990289607	wei3	
+7810	磳	2	99.9990299943	zeng1	
+7811	窅	2	99.9990320614	yao3	
+7812	窾	2	99.999033095	kuan3	
+7813	筭	2	99.9990341286	suan4	
+7814	箣	2	99.9990351622	ce4	
+7815	簃	2	99.9990361957	yi2	
+7816	簺	2	99.9990372293	sai4	
+7817	粴	2	99.9990382629	li3	
+7818	糦	2	99.9990392964	xi1	
+7819	絟	2	99.99904033	quan2	
+7820	緺	2	99.9990413636	gua1	
+7821	縩	2	99.9990423971	cai4	
+7822	罍	2	99.9990434307	lei2	
+7823	翣	2	99.9990444643	sha4	
+7824	聟	2	99.9990454979	xu4	
+7825	肊	2	99.9990465314	yi3	
+7826	肙	2	99.999047565	yuan4	
+7827	肞	2	99.9990485986	cha1	
+7828	臞	2	99.9990496321	qu2	
+7829	苶	2	99.9990506657	nie4	
+7830	菭	2	99.9990516993	tai2	
+7831	葖	2	99.9990527328	tu1	
+7832	蕳	2	99.9990537664	jian1	
+7833	蚒	2	99.9990548	tong2	
+7834	蜪	2	99.9990558336	tao2	
+7835	蠜	2	99.9990579007	fan2	
+7836	袕	2	99.9990589343	xue2	
+7837	裋	2	99.9990599678	shu4	
+7838	裩	2	99.9990610014	kun1	
+7839	褎	2	99.9990630686	you4	
+7840	襫	2	99.9990641021	shi4	
+7841	觭	2	99.9990661693	ji1	
+7842	訆	2	99.9990672028	jiao4	
+7843	訏	2	99.9990682364	xu3	
+7844	訽	2	99.99906927	gou4	
+7845	詨	2	99.9990703035	xiao4	
+7846	譻	2	99.9990713371	ying1	
+7847	诇	2	99.9990723707	xiong4	
+7848	貑	2	99.9990734043	jia1	
+7849	跱	2	99.9990744378	zhi4	
+7850	坶	2	99.9990754714	mu3	
+7851	躘	2	99.999076505	long2	
+7852	輖	2	99.9990775385	zhou1	
+7853	轇	2	99.9990785721	jiao1	
+7854	轋	2	99.9990796057	hun2	
+7855	轕	2	99.9990806392	ge2	
+7856	迒	2	99.9990816728	hang2	
+7857	郘	2	99.9990827064	lv3	
+7858	醄	2	99.99908374	tao2	
+7859	醼	2	99.9990847735	yan4	
+7860	鋋	2	99.9990858071	chan2	
+7861	鏁	2	99.9990868407	suo3	
+7862	鏭	2	99.9990878742	xi1	
+7863	鐄	2	99.9990889078	huang2	
+7864	辁	2	99.9990920085	quan2	small/wheel without spokes
+7865	阸	2	99.9990930421	e4	
+7866	牿	2	99.9990940757	gu4	shed or pen for cattle
+7867	鞝	2	99.9990951092	zhang3	
+7868	頞	2	99.9990961428	e4	
+7869	瞵	2	99.9990971764	lin2	
+7870	饤	2	99.9990982099	ding4	
+7871	駃	2	99.9990992435	kuai4	
+7872	駉	2	99.9991002771	jiong1	
+7873	騠	2	99.9991013107	ti2	
+7874	驡	2	99.9991023442	long2	
+7875	髪	2	99.9991033778	fa1	
+7876	鬿	2	99.9991054449	qi2	
+7877	鱻	2	99.9991085456	xian1	
+7878	鷫	2	99.9991106128	su4	
+7879	鹖	2	99.9991116464	he2	
+7880	磩	2	99.9991126799	qi4	
+7881	磭	2	99.9991137135	chuo4	
+7882	稌	2	99.9991147471	tu2	
+7883	穃	2	99.9991157806	rong4	
+7884	綂	2	99.9991168142	tong3	
+7885	膥	2	99.9991178478	cen1	
+7886	膱	2	99.9991188813	zhi2	
+7887	臿	2	99.9991199149	cha1	
+7888	艎	2	99.9991209485	huang2	
+7889	苃	2	99.9991219821	you3	
+7890	茍	2	99.9991230156	ji4	
+7891	蒟	2	99.9991240492	ju3	
+7892	藣	2	99.9991250828	bei1	
+7893	虈	2	99.9991261163	xiao1	
+7894	蜐	2	99.9991271499	jie2	
+7895	訅	2	99.9991281835	qiu2	
+7896	讈	2	99.9991302506	li4	
+7897	趷	2	99.9991323178	ke1	
+7898	蹹	2	99.9991343849	ta2	
+7899	鋫	2	99.9991374856	li2	
+7900	騛	2	99.9991416199	fei1	
+7901	鰤	2	99.999143687	shi1	
+7902	鶢	2	99.9991467877	yuan2	
+7903	鶳	2	99.9991478213	shi1	
+7904	黋	2	99.9991488549	kuang4	
+7905	齢	2	99.9991498885	ling2	
+7906	聝	2	99.9991540227	guo2	
+7907	膴	2	99.9991550563	wu3	
+7908	芵	2	99.9991560899	jue2	
+7909	藫	2	99.9991571234	tan2	
+7910	跰	2	99.9991633249	beng4	
+7911	踥	2	99.9991643584	qie4	
+7912	迆	2	99.999165392	tuo2	
+7913	逤	2	99.9991674591	suo4	
+7914	麅	2	99.9991757277	pao2	
+7915	缷	2	99.9991788284	xie4	
+7916	虙	2	99.999179862	fu2	
+7917	齗	2	99.9991808956	yan3	
+7918	裓	2	99.9991819291	ge2	
+7919	铹	2	99.9991829627	lao2	lawrencium
+7920	睙	2	99.9991839963	lie4	
+7921	矟	2	99.9991850298	shuo4	
+7922	硣	2	99.9991860634	xiao1	
+7923	磹	2	99.999187097	dian4	
+7924	礀	2	99.9991881306	jian4	
+7925	秶	2	99.9991901977	zi1	
+7926	窇	2	99.9991912313	bao2	
+7927	竷	2	99.9991922648	kan3	
+7928	笣	2	99.9991932984	bao1	
+7929	篃	2	99.999194332	mei4	
+7930	簬	2	99.9991953655	lu4	
+7931	簯	2	99.9991963991	qi3	
+7932	粓	2	99.9991974327	gan1	
+7933	粶	2	99.9991984663	lu4	
+7934	縼	2	99.9992046677	xuan4	
+7935	绤	2	99.9992098355	xi4	
+7936	罆	2	99.9992108691	guan4	
+7937	翆	2	99.9992129362	cui4	
+7938	翑	2	99.9992139698	yu4	
+7939	脵	2	99.999216037	gu3	
+7940	臄	2	99.9992170705	ju1	
+7941	茽	2	99.9992181041	zhong4	
+7942	莵	2	99.9992212048	tu4	
+7943	菕	2	99.9992222384	lun2	
+7944	蓛	2	99.9992232719	ce4	
+7945	蓷	2	99.9992243055	tui1	
+7946	蓸	2	99.9992253391	cao2	
+7947	蔘	2	99.9992263727	shen1	
+7948	蕼	2	99.9992294734	si4	
+7949	藖	2	99.9992315405	qian1	
+7950	藢	2	99.9992325741	zhi3	
+7951	蛢	2	99.9992346412	ping2	
+7952	蠄	2	99.9992367084	qin2	
+7953	蠈	2	99.9992377419	zei2	
+7954	蠎	2	99.9992387755	mang3	
+7955	覙	2	99.9992418762	zhen3	
+7956	訑	2	99.9992429098	yi2	
+7957	詸	2	99.9992460105	mi2	
+7958	謥	2	99.9992522119	cong4	
+7959	貋	2	99.9992553126	an4	
+7960	貛	2	99.9992563462	huan1	
+7961	贁	2	99.9992604805	bai4	
+7962	贂	2	99.999261514	chen3	
+7963	贉	2	99.9992625476	dan4	
+7964	趤	2	99.9992635812	dang4	
+7965	趯	2	99.9992646148	yue4	
+7966	趶	2	99.9992656483	wu1	
+7967	跔	2	99.9992666819	ju1	
+7968	蹆	2	99.999268749	tui3	
+7969	塥	2	99.9992697826	ge2	dry clay lump
+7970	輰	2	99.9992718497	yang2	
+7971	邼	2	99.999275984	kuang1	
+7972	釟	2	99.9992770176	ba1	
+7973	釠	2	99.9992780512	luan4	
+7974	鉂	2	99.999283219	shi3	
+7975	銊	2	99.9992842526	hui4	
+7976	鋭	2	99.9992873533	dui4	
+7977	錃	2	99.9992883869	pi1	
+7978	漭	2	99.999290454	mang3	vast/expansive (of water)
+7979	鏆	2	99.9992935547	guan4	
+7980	鐖	2	99.9992945883	ji1	
+7981	鑱	2	99.999297689	chan2	
+7982	镃	2	99.9992997561	zi1	
+7983	陜	2	99.9993038904	xia2	
+7984	霠	2	99.9993059576	yin1	
+7985	鞖	2	99.9993080247	sui1	
+7986	韨	2	99.9993090583	fu2	
+7987	韼	2	99.9993100918	peng2	
+7988	韽	2	99.9993111254	an1	
+7989	飳	2	99.9993152597	tou3	
+7990	飸	2	99.9993162933	tao1	
+7991	餆	2	99.9993173268	yao2	
+7992	駡	2	99.9993214611	ma4	
+7993	駷	2	99.9993224947	song3	
+7994	騼	2	99.999326629	lu4	
+7995	魜	2	99.9993286961	ren2	
+7996	鰫	2	99.9993297297	yong2	
+7997	鱽	2	99.9993317968	dao1	
+7998	鲬	2	99.9993328304	yong3	
+7999	鶆	2	99.9993348975	lai2	
+8000	鶊	2	99.9993359311	geng1	
+8001	鷿	2	99.9993379982	pi4	
+8002	鸁	2	99.9993390318	luo2	
+8003	麞	2	99.9993400654	zhang1	
+8004	鼏	2	99.999341099	mi4	
+8005	鼜	2	99.9993421325	qi4	
+8006	鼫	2	99.9993431661	shi2	
+8007		2	99.9993452332		
+8008		2	99.9993462668		
+8009		2	99.9993473004		
+8010		2	99.9993483339		
+8011		2	99.9993493675		
+8012	盬	2	99.9993504011	gu3	
+8013	祅	2	99.9993514347	yao1	
+8014	禭	2	99.9993535018	sui4	
+8015	糱	2	99.9993545354	nie4	
+8016	縂	2	99.9993555689	zong3	
+8017	蠥	2	99.9993566025	nie4	
+8018	軷	2	99.9993576361	ba2	
+8019	鄮	2	99.9993586696	mao4	
+8020	釱	2	99.9993597032	di4	
+8021	錣	2	99.9993617704	zhui4	
+8022	鑢	2	99.9993628039	lv4	
+8023	钑	2	99.9993638375	xi4	
+8024	饟	2	99.9993648711	xiang3	
+8025	鯅	2	99.9993659046	shan1	
+8026	鼊	2	99.9993669382	bi4	
+8027		2	99.9993679718		
+8028	粛	2	99.9993700389	su4	
+8029	粻	2	99.9993710725	zhang1	
+8030	瞂	2	99.9993741732	fa2	
+8031	靮	2	99.9993762403	di2	
+8032	盨	2	99.9993772739	xu3	
+8033	県	2	99.9993783075	xian4	
+8034	箥	2	99.9993793411	bo3	
+8035	簕	2	99.9993803746	le4	
+8036	臖	2	99.9993814082	xing4	
+8037	盿	2	99.9993855425	min2	
+8038	蔊	2	99.9993876096	han3	
+8039	鶸	2	99.9993917439	ruo4	
+8040	窎	2	99.999393811	diao4	
+8041	鉔	2	99.9993958782	za1	
+8042	鏱	2	99.9993969117	zhang1	
+8043	隺	2	99.9993979453	he4	
+8044	荘	2	99.9994000125	zhuang1	
+8045	蒻	2	99.999401046	ruo4	
+8046	蔴	2	99.9994020796	ma2	
+8047	裛	2	99.9994031132	yi4	
+8048	鈙	2	99.9994041467	qin2	
+8049	鎋	2	99.9994051803	xia2	
+8050	鑀	2	99.9994062139	ai4	
+8051	髴	2	99.9994072475	fei4	
+8052	鴓	2	99.999408281	bi4	
+8053	鸴	2	99.9994093146	xue2	
+8054	秹	2	99.9994113817	ren3	
+8055	茢	2	99.9994124153	lie4	
+8056	蘁	2	99.9994134489	e4	
+8057	蚑	2	99.9994144824	qi2	
+8058	鏻	2	99.999415516	lin2	
+8059	霤	2	99.9994165496	liu4	
+8060	霩	2	99.9994175832	kuo4	
+8061	頺	2	99.9994186167	tui2	
+8062	餚	2	99.9994196503	yao2	
+8063	鯂	2	99.9994206839	su1	
+8064	籔	2	99.9994217174	shu3	
+8065	蘘	2	99.9994237846	xiang1	
+8066	雑	2	99.9994248181	za2	
+8067	鬶	2	99.9994258517	gui1	
+8068	鯵	2	99.9994268853	shen1	
+8069	鰧	2	99.9994279189	teng	
+8070	鱂	2	99.9994289524	jiang1	
+8071	鳂	2	99.999429986	wei1	
+8072	鵟	2	99.9994310196	kuang2	
+8073	盠	1	99.9994315364	li2	
+8074	盳	1	99.9994320531	wang4	
+8075	盽	1	99.9994325699	feng1	
+8076	眃	1	99.9994330867	yun2	
+8077	眏	1	99.9994336035	yang1	
+8078	睧	1	99.9994341203	hun1	
+8079	硄	1	99.9994346371	guang1	
+8080	碔	1	99.9994351538	wu3	
+8081	碦	1	99.9994356706	ke4	
+8082	碸	1	99.9994361874	feng1	
+8083	磃	1	99.9994367042	ti2	
+8084	礘	1	99.999437221	e4	
+8085	礮	1	99.9994377378	pao4	
+8086	祘	1	99.9994382546	suan4	
+8087	禤	1	99.9994387713	xuan1	
+8088	秌	1	99.9994392881	qiu1	
+8089	秙	1	99.9994398049	ku4	
+8090	秢	1	99.9994403217	ling2	
+8091	稧	1	99.9994408385	qie4	
+8092	稬	1	99.9994413553	nuo4	
+8093	稲	1	99.9994418721	dao4	
+8094	稸	1	99.9994423888	xu4	
+8095	穜	1	99.9994429056	tong2	
+8096	竒	1	99.9994434224	qi2	
+8097	筶	1	99.9994439392	gao3	
+8098	篬	1	99.999444456	qiang1	
+8099	籒	1	99.9994449728	zhou4	
+8100	籞	1	99.9994460063	yu4	
+8101	籶	1	99.9994465231	shen1	
+8102	糂	1	99.9994470399	san1	
+8103	糉	1	99.9994475567	zong4	
+8104	綡	1	99.9994480735	liang2	
+8105	綶	1	99.9994485903	guo3	
+8106	緼	1	99.9994501406	wen1	
+8107	縁	1	99.9994506574	yuan2	
+8108	繤	1	99.9994522078	zuan3	
+8109	繧	1	99.9994527245	yun2	
+8110	繬	1	99.9994532413	se4	
+8111	纃	1	99.9994537581	qi2	
+8112	纒	1	99.9994547917	chan2	
+8113	纗	1	99.9994553085	zui1	
+8114	罯	1	99.9994558253	an3	
+8115	羀	1	99.999456342	liu3	
+8116	耴	1	99.9994568588	yi4	
+8117	肍	1	99.9994573756	qiu2	
+8118	腨	1	99.9994578924	shuan4	
+8119	膗	1	99.9994584092	chuai2	
+8120	膟	1	99.999458926	lu4	
+8121	舦	1	99.9994594427	tai4	
+8122	艊	1	99.9994599595	bo2	
+8123	菄	1	99.9994604763	dong1	
+8124	葾	1	99.9994609931	yuan1	
+8125	蒕	1	99.9994615099	yun1	
+8126	蒘	1	99.9994620267	na2	
+8127	蒧	1	99.9994625435	dian3	
+8128	蓃	1	99.9994630602	sou1	
+8129	蓆	1	99.999463577	xi2	
+8130	蔱	1	99.9994640938	sha1	
+8131	蘔	1	99.9994646106	jiong3	
+8132	蟨	1	99.9994651274	jue2	
+8133	蠪	1	99.9994656442	long2	
+8134	謟	1	99.9994671945	tao1	
+8135	讙	1	99.9994677113	huan1	
+8136	谽	1	99.9994682281	han1	
+8137	踨	1	99.9994687449	zong1	
+8138	躱	1	99.9994697785	duo3	
+8139	輗	1	99.9994702952	yi4	
+8140	鋕	1	99.9994713288	zhi4	
+8141	鎚	1	99.9994718456	dui1	
+8142	鯶	1	99.9994728792	huan4	
+8143	鳋	1	99.9994733959	sao1	
+8144	鹒	1	99.9994739127	geng1	
+8145	篭	1	99.9994744295	long2	
+8146	縜	1	99.9994749463	yun2	
+8147	腣	1	99.9994754631	di4	
+8148	赲	1	99.9994759799	li4	
+8149	馻	1	99.9994764967	yun3	
+8150	磞	1	99.9994770134	peng1	
+8151	睕	1	99.9994775302	wan1	
+8152	瞜	1	99.999478047	lv2	
+8153	碠	1	99.9994785638	ding4	
+8154	簘	1	99.9994795974	xiao1	
+8155	腃	1	99.9994801142	quan1	
+8156	腵	1	99.9994806309	jia1	
+8157	蓳	1	99.9994811477	jin3	
+8158	覇	1	99.9994816645	ba4	
+8159	銝	1	99.9994826981	xiu1	
+8160	巛	1	99.9994832149	chuan1	
+8161	鐴	1	99.9994837317	bei4	
+8162	鑵	1	99.9994842484	guan4	
+8163	隩	1	99.9994847652	yu4	
+8164	飮	1	99.9994857988	yin3	
+8165	飰	1	99.9994863156	fan4	
+8166	餇	1	99.9994868324	tong2	
+8167	饐	1	99.9994873491	yi4	
+8168	痃	1	99.9994878659	xuan2	
+8169	駞	1	99.9994883827	tuo2	
+8170	鴜	1	99.9994888995	ci2	
+8171		1	99.9994894163		
+8172		1	99.9994899331		
+8173	睅	1	99.9994904499	han4	
+8174	睍	1	99.9994909666	xian4	
+8175	碽	1	99.9994920002	gong1	
+8176	磸	1	99.999492517	ding4	
+8177	礉	1	99.9994930338	he2	
+8178	礽	1	99.9994935506	reng2	
+8179	祾	1	99.9994940674	ling2	
+8180	禌	1	99.9994945841	zi1	
+8181	筥	1	99.9994951009	ju3	
+8182	簴	1	99.9994956177	ju4	
+8183	紣	1	99.9994961345	zu2	
+8184	絍	1	99.9994966513	ren4	
+8185	縆	1	99.9994971681	geng1	
+8186	繀	1	99.9994976848	cui3	
+8187	羕	1	99.9994987184	yang4	
+8188	羵	1	99.9994992352	fen2	
+8189	耇	1	99.999499752	gou3	
+8190	聫	1	99.9995002688	lian2	
+8191	脗	1	99.9995007856	wen3	
+8192	臯	1	99.9995013023	gao1	
+8193	艁	1	99.9995018191	zao4	
+8194	艂	1	99.9995023359	feng2	
+8195	茞	1	99.9995028527	chen2	
+8196	葨	1	99.9995033695	wei1	
+8197	蒄	1	99.9995038863	guan1	
+8198	蒭	1	99.9995044031	chu2	
+8199	薂	1	99.9995049198	xi2	
+8200	藯	1	99.9995054366	wei4	
+8201	螑	1	99.9995064702	xiu4	
+8202	蟼	1	99.999506987	jing3	
+8203	衟	1	99.9995075038	dao4	
+8204	褑	1	99.9995080206	yuan2	
+8205	褠	1	99.9995085373	gou1	
+8206	訔	1	99.9995095709	yin2	
+8207	詗	1	99.9995106045	xiong4	
+8208	詪	1	99.9995111213	hen3	
+8209	諈	1	99.999511638	zhui4	
+8210	讌	1	99.9995126716	yan4	
+8211	豗	1	99.9995131884	hui1	
+8212	豷	1	99.9995137052	yi4	
+8213	貗	1	99.999514222	yu2	
+8214	貣	1	99.9995147388	te4	
+8215	賯	1	99.9995152555	min2	
+8216	贋	1	99.9995157723	yan4	
+8217	冱	1	99.9995162891	hu4	congealed/frozen
+8218	輀	1	99.9995168059	er2	
+8219	蒈	1	99.9995173227	kai3	
+8220	轓	1	99.9995178395	fan1	
+8221	迋	1	99.9995183563	wang4	
+8222	逓	1	99.999518873	di4	
+8223	酳	1	99.9995199066	yin4	
+8224	鈪	1	99.9995204234	ngag	
+8225	尜	1	99.9995209402	ga2	
+8226	轷	1	99.9995219738	hu1	
+8227	霘	1	99.9995224905	dong4	
+8228	鞄	1	99.9995230073	pao2	
+8229	騧	1	99.9995235241	gua1	
+8230	髽	1	99.9995240409	zhua1	
+8231	魣	1	99.9995245577	yu2	
+8232	鰰	1	99.9995255912	shen2	
+8233	鴹	1	99.999526108	yang2	
+8234	鼪	1	99.9995266248	sheng1	
+8235	秊	1	99.9995276584		
+8236		1	99.9995281752		
+8237	眮	1	99.999528692	tong2	
+8238	笀	1	99.9995292087	mang2	
+8239	籣	1	99.9995297255	lan2	
+8240	藑	1	99.9995302423	qiong2	
+8241	垲	1	99.9995307591	kai3	dry terrain
+8242	鍳	1	99.9995312759	jian4	
+8243	禔	1	99.9995323095	zhi1	
+8244	穯	1	99.9995328262	se4	
+8245	茿	1	99.999533343	zhu2	
+8246	莂	1	99.9995338598	bie2	
+8247	薃	1	99.9995343766	hao4	
+8248	襛	1	99.9995348934	nong2	
+8249	谻	1	99.9995354102	ji2	
+8250	魳	1	99.9995364437	shi1	
+8251	鵄	1	99.9995369605	chi1	
+8252		1	99.9995374773		
+8253	穄	1	99.9995379941	ji4	
+8254	穵	1	99.9995385109	ya4	
+8255	篛	1	99.9995390277	na4	
+8256	簑	1	99.9995395444	sui1	
+8257	絭	1	99.9995400612	juan4	
+8258	緅	1	99.999540578	zou1	
+8259	緍	1	99.9995410948	min3	
+8260	罇	1	99.9995416116	zun1	
+8261	耑	1	99.9995421284	zhuan1	
+8262	艒	1	99.9995426452	mo4	
+8263	豠	1	99.9995431619	chu2	
+8264	蹎	1	99.9995436787	dian1	
+8265	辢	1	99.9995441955	la4	
+8266	醻	1	99.9995447123	shou4	
+8267	鐍	1	99.9995452291	yu4	
+8268	鑮	1	99.9995457459	bo2	
+8269	頳	1	99.9995467794	cheng1	
+8270	驈	1	99.9995472962	yu4	
+8271	髲	1	99.999547813	bi4	
+8272	鱮	1	99.9995483298	yu2	
+8273	麰	1	99.9995488466	mou2	
+8274	鼄	1	99.9995493634	zhu1	
+8275	鼅	1	99.9995498801	zhi1	
+8276	鼖	1	99.9995503969	fen2	
+8277		1	99.9995509137		
+8278	眣	1	99.9995514305	die2	
+8279	睎	1	99.9995519473	xi1	
+8280	瞣	1	99.9995524641	huan4	
+8281	矀	1	99.9995529809	mei2	
+8282	硊	1	99.9995534976	wei3	
+8283	碅	1	99.9995540144	jun1	
+8284	磪	1	99.9995545312	cui1	
+8285	礒	1	99.999555048	yi3	
+8286	禞	1	99.9995555648	gao4	
+8287	秠	1	99.9995560816	pi1	
+8288	穙	1	99.9995565984	pu2	
+8289	穱	1	99.9995571151	jue2	
+8290	竢	1	99.9995581487	si4	
+8291	笍	1	99.9995586655	zhui4	
+8292	筩	1	99.9995591823	yong3	
+8293	簠	1	99.9995602159	fu3	
+8294	粃	1	99.9995607326	bi3	
+8295	粖	1	99.9995612494	mo4	
+8296	糓	1	99.9995617662	gu3	
+8297	糺	1	99.999562283	jiu1	
+8298	紭	1	99.9995627998	hong2	
+8299	紾	1	99.9995633166	tian3	
+8300	絶	1	99.9995638333	jue2	
+8301	綅	1	99.9995643501	qin1	
+8302	繂	1	99.9995648669	lv4	
+8303	繋	1	99.9995653837	ji4	
+8304	繣	1	99.9995659005	hua4	
+8305	罙	1	99.9995664173	mi2	
+8306	罥	1	99.9995669341	juan4	
+8307	罼	1	99.9995674508	bi4	
+8308	羜	1	99.9995684844	zhu4	
+8309	翭	1	99.9995690012	hou2	
+8310	耮	1	99.999569518	lao4	
+8311	聸	1	99.9995700348	dan1	
+8312	肸	1	99.9995705516	bi4	
+8313	胹	1	99.9995710683	er2	
+8314	脣	1	99.9995715851	chun2	
+8315	腬	1	99.9995721019	rou2	
+8316	膄	1	99.9995726187	shou4	
+8317	膋	1	99.9995736523	liao2	
+8318	臕	1	99.999574169	biao1	
+8319	舃	1	99.9995746858	tuo1	
+8320	艭	1	99.9995757194	shuang1	
+8321	艶	1	99.9995762362	yan4	
+8322	艼	1	99.999576753	ding3	
+8323	荢	1	99.9995772698	yu2	
+8324	萚	1	99.9995783033	tuo4	
+8325	蓗	1	99.9995788201	zong3	
+8326	蓱	1	99.9995793369	ping2	
+8327	蕋	1	99.9995798537	juan3	
+8328	蕟	1	99.9995803705	fa4	
+8329	薐	1	99.9995808873	leng2	
+8330	薠	1	99.999581404	fan2	
+8331	蘓	1	99.9995824376	su1	
+8332	蘪	1	99.9995829544	mei2	
+8333	虵	1	99.9995834712	ye3	
+8334	蚾	1	99.999583988	bo3	
+8335	蛖	1	99.9995845048	bang4	
+8336	蛜	1	99.9995850215	yi1	
+8337	蝍	1	99.9995855383	ji2	
+8338	蟂	1	99.9995865719	xiao1	
+8339	蟜	1	99.9995870887	jiao3	
+8340	蠏	1	99.9995876055	xie4	
+8341	衘	1	99.999588639	yu4	
+8342	袟	1	99.9995891558	zhi4	
+8343	袬	1	99.9995896726	yu4	
+8344	譅	1	99.9995907062	se4	
+8345	譌	1	99.999591223	e2	
+8346	譸	1	99.9995917397	zhou1	
+8347	趝	1	99.9995927733	jian4	
+8348	趡	1	99.9995932901	wei3	
+8349	跾	1	99.9995938069	chou1	
+8350	踀	1	99.9995943237	chu4	
+8351	踸	1	99.9995948405	chen3	
+8352	蹡	1	99.9995953572	qiang1	
+8353	垌	1	99.999595874	dong4	
+8354	蹳	1	99.9995963908	bo1	
+8355	躛	1	99.9995969076	wei4	
+8356	躩	1	99.9995974244	jue2	
+8357	躶	1	99.9995979412	luo3	
+8358	軏	1	99.999598458	yue4	
+8359	軬	1	99.9995989747	fan4	
+8360	輵	1	99.9995994915	ya4	
+8361	轗	1	99.9996000083	kan3	
+8362	轥	1	99.9996005251	lin4	
+8363	逷	1	99.9996010419	ti4	
+8364	遈	1	99.9996015587	shi2	
+8365	邌	1	99.9996020754	li2	
+8366	鄟	1	99.9996025922	zhuan1	
+8367	醎	1	99.999603109	jian3	
+8368	釭	1	99.9996036258	gang1	
+8369	怊	1	99.9996046594	chao1	
+8370	銌	1	99.9996051762	zun4	
+8371	鋂	1	99.9996056929	mei2	
+8372	鋎	1	99.9996062097	han4	
+8373	鍐	1	99.9996067265	wan3	
+8374	鎴	1	99.9996072433	xi2	
+8375	鎸	1	99.9996077601	juan1	
+8376	鑘	1	99.9996082769	lei2	
+8377	膪	1	99.9996098272	chuai4	
+8378	霣	1	99.999610344	yun3	
+8379	靃	1	99.9996108608	huo4	
+8380	韍	1	99.9996113776	fu2	
+8381	颩	1	99.9996118944	diao1	
+8382	飦	1	99.9996124111	gan1	
+8383	駋	1	99.9996134447	zhao1	
+8384	騄	1	99.9996139615	lu4	
+8385	骩	1	99.9996144783	wei3	
+8386	骻	1	99.9996149951	kua4	
+8387	骾	1	99.9996155119	geng3	
+8388	鬙	1	99.9996160286	seng1	
+8389	鬽	1	99.9996165454	mei4	
+8390	魫	1	99.9996170622	shen3	
+8391	鯈	1	99.999617579	tiao2	
+8392	鯩	1	99.9996180958	lun2	
+8393	鯬	1	99.9996186126	li2	
+8394	鰌	1	99.9996191294	qiu1	
+8395	鲓	1	99.9996196461	kao4	
+8396	鴂	1	99.9996201629	gui1	
+8397	鶍	1	99.9996206797	yi4	
+8398	鶠	1	99.9996211965	yan3	
+8399	鷁	1	99.9996217133	yi4	
+8400	鷖	1	99.9996222301	yi1	
+8401	鸇	1	99.9996227469	zhan1	
+8402	鸘	1	99.9996232636	shuang1	
+8403	鸧	1	99.9996237804	qiang1	
+8404	鹙	1	99.9996242972	qiu1	
+8405	麏	1	99.999624814	jun1	
+8406	黮	1	99.9996253308	dan3	
+8407	齯	1	99.9996258476	ni2	
+8408	龓	1	99.9996263643	long2	
+8409	盓	1	99.9996268811	yu1	
+8410	眕	1	99.9996273979	zhen3	
+8411	睘	1	99.9996279147	qiong2	
+8412	睩	1	99.9996284315	lu4	
+8413	矂	1	99.9996289483	sao4	
+8414	矵	1	99.9996294651	diao1	
+8415	矺	1	99.9996299818	da1	
+8416	砪	1	99.9996304986	mu3	
+8417	硂	1	99.9996310154	quan2	
+8418	碒	1	99.9996315322	yin2	
+8419	祤	1	99.9996325658	yu3	
+8420	禩	1	99.9996330826	si4	
+8421	稑	1	99.9996335993	lu4	
+8422	穐	1	99.9996341161	qiu1	
+8423	穛	1	99.9996346329	bo2	
+8424	竂	1	99.9996351497	liao2	
+8425	笉	1	99.9996356665	qin3	
+8426	篟	1	99.9996361833	qian4	
+8427	篺	1	99.9996367001	pi2	
+8428	紻	1	99.9996377336	yang3	
+8429	緐	1	99.9996387672	fan2	
+8430	繖	1	99.9996398008	san3	
+8431	繴	1	99.9996408343	bi4	
+8432	纀	1	99.9996413511	pu2	
+8433	羉	1	99.9996418679	luan2	
+8434	翈	1	99.9996423847	xia2	
+8435	耡	1	99.9996429015	chu2	
+8436	腀	1	99.9996434183	lun2	
+8437	艩	1	99.999643935	qi2	
+8438	苅	1	99.9996444518	yi4	
+8439	莁	1	99.9996449686	wu2	
+8440	菞	1	99.9996454854	li2	
+8441	菳	1	99.9996460022	qin1	
+8442	萈	1	99.999646519	huan2	
+8443	蒁	1	99.9996470358	shu4	
+8444	蒑	1	99.9996475525	yin1	
+8445	蓔	1	99.9996480693	yao3	
+8446	蓕	1	99.9996485861	gui4	
+8447	蔙	1	99.9996491029	xuan4	
+8448	蔿	1	99.9996496197	wei3	
+8449	蕧	1	99.9996501365	fu4	
+8450	薆	1	99.9996506532	ai4	
+8451	薗	1	99.99965117	yuan2	
+8452	薝	1	99.9996516868	zhan1	
+8453	藀	1	99.9996522036	ying2	
+8454	蘌	1	99.9996527204	yu3	
+8455	虋	1	99.9996532372	men2	
+8456	蚿	1	99.999653754	xian2	
+8457	蜫	1	99.9996542707	kun1	
+8458	蜽	1	99.9996547875	liang3	
+8459	螥	1	99.9996553043	cang1	
+8460	蠚	1	99.9996558211	he1	
+8461	袽	1	99.9996563379	ru2	
+8462	裶	1	99.9996568547	fei1	
+8463	裺	1	99.9996573715	an1	
+8464	褣	1	99.9996578882	rong2	
+8465	詅	1	99.9996589218	ling2	
+8466	詇	1	99.9996594386	yang4	
+8467	誻	1	99.9996604722	ta4	
+8468	豧	1	99.9996620225	fu1	
+8469	貮	1	99.9996625393	er4	
+8470	賱	1	99.9996635729	yun4	
+8471	赑	1	99.9996640897	bi4	
+8472	赹	1	99.9996646064	qiong2	
+8473	赽	1	99.9996651232	gui4	
+8474	踃	1	99.99966564	qiao4	
+8475	蹞	1	99.9996661568	kui3	
+8476	蹧	1	99.9996666736	zao1	
+8477	躻	1	99.9996671904	kong1	
+8478	躿	1	99.9996677072	kang1	
+8479	鄑	1	99.9996692575	zi1	
+8480	酼	1	99.9996697743	hai3	
+8481	醁	1	99.9996702911	lu4	
+8482	醕	1	99.9996708079	chun2	
+8483	醥	1	99.9996713247	piao3	
+8484	釪	1	99.9996718414	yu2	
+8485	鈵	1	99.9996723582	bing3	
+8486	銒	1	99.999672875	jian1	
+8487	銙	1	99.9996733918	kua3	
+8488	鋺	1	99.9996739086	yuan1	
+8489	錗	1	99.9996744254	wei4	
+8490	錥	1	99.9996749422	yu4	
+8491	鍓	1	99.9996754589	ji2	
+8492	鍟	1	99.9996759757	sheng1	
+8493	鎍	1	99.9996764925	se4	
+8494	鏿	1	99.9996775261	cheng1	
+8495	鐎	1	99.9996780429	jiao1	
+8496	鐤	1	99.9996785596	ding3	
+8497	锧	1	99.99968011	zhi4	
+8498	閧	1	99.9996806268	hong4	
+8499	闛	1	99.9996811436	tang1	
+8500	隝	1	99.9996816604	dao3	
+8501	隥	1	99.9996821771	deng4	
+8502	隦	1	99.9996826939	pi2	
+8503	靱	1	99.9996837275	ren4	
+8504	鞪	1	99.9996842443	mou2	
+8505	鞺	1	99.9996847611	tang1	
+8506	鞿	1	99.9996852779	ji1	
+8507	韟	1	99.9996857946	gao1	
+8508	顀	1	99.9996863114	chui2	
+8509	飀	1	99.9996868282	liu2	
+8510	飥	1	99.999687345	tuo1	
+8511	饆	1	99.9996888953	bi4	
+8512	馿	1	99.9996894121	lv2	
+8513	癀	1	99.9996899289	huang2	
+8514	驦	1	99.9996904457	shuang1	
+8515	髉	1	99.9996909625	bo2	
+8516	鬉	1	99.9996914793	zong1	
+8517	鬸	1	99.9996919961	liu4	
+8518	魛	1	99.9996925128	dao1	
+8519	鳷	1	99.9996930296	zhi1	
+8520	鵋	1	99.9996935464	ji4	
+8521	鵏	1	99.9996940632	bu1	
+8522	鵨	1	99.99969458	shu1	
+8523	鵼	1	99.9996950968	kong1	
+8524	鷵	1	99.9996956136	tu2	
+8525	鷼	1	99.9996961303	xian2	
+8526	鸍	1	99.9996966471	mi2	
+8527	鸓	1	99.9996971639	lei3	
+8528	鸖	1	99.9996976807	he4	
+8529	鹠	1	99.9996981975	liu2	
+8530	黶	1	99.9996987143	yan3	
+8531	齰	1	99.9996997478	ze2	
+8532	碀	1	99.9997002646	cheng2	
+8533	礇	1	99.9997007814	yu4	
+8534	筣	1	99.999701815	li2	
+8535	綀	1	99.9997043989	shu1	
+8536	缾	1	99.9997054325	ping2	
+8537	羷	1	99.9997059493	lian3	
+8538	耊	1	99.999706466	die2	
+8539	艍	1	99.9997074996	ju1	
+8540	葏	1	99.9997080164	jian1	
+8541	誽	1	99.9997095668	na2	
+8542	輧	1	99.9997111171	peng1	
+8543	輽	1	99.9997116339	ben4	
+8544	鏍	1	99.9997131843	luo2	
+8545	鏽	1	99.999713701	xiu4	
+8546	饝	1	99.9997152514	mo2	
+8547	騇	1	99.9997157682	she4	
+8548	腂	1	99.9997168017	lei3	
+8549	臗	1	99.9997173185	kun1	
+8550	眀	1	99.9997178353	ming2	
+8551	砫	1	99.9997183521	zhu3	
+8552	祙	1	99.9997188689	mei4	
+8553	祳	1	99.9997193857	shen4	
+8554	粧	1	99.9997199025	zhuang1	
+8555	蕣	1	99.9997204192	shun4	
+8556	觓	1	99.999720936	qiu2	
+8557	趹	1	99.9997214528	gui4	
+8558	鄍	1	99.9997219696	ming2	
+8559	鈡	1	99.9997224864	zhong1	
+8560	羭	1	99.9997230032	yu2	
+8561	蝄	1	99.99972352	wang3	
+8562	衸	1	99.9997240367	jie4	
+8563	謡	1	99.9997245535	yao2	
+8564	眲	1	99.9997261039	ne4	
+8565	睋	1	99.9997266207	e2	
+8566	矃	1	99.9997271374	ning3	
+8567	矒	1	99.9997276542	meng2	
+8568	硟	1	99.999728171	chan4	
+8569	磄	1	99.9997292046	tang2	
+8570	礂	1	99.9997297214	xi1	
+8571	礊	1	99.9997302382	ke4	
+8572	祰	1	99.9997307549	gao4	
+8573	祹	1	99.9997312717	tao2	
+8574	禐	1	99.9997317885	yuan4	
+8575	秳	1	99.9997323053	kuo4	
+8576	秼	1	99.9997328221	zhu1	
+8577	稄	1	99.9997333389	xun4	
+8578	稇	1	99.9997338557	kun3	
+8579	稘	1	99.9997348892	ji1	
+8580	稙	1	99.999735406	zhi4	
+8581	竸	1	99.9997364396	jing4	
+8582	竾	1	99.9997369564	chi2	
+8583	笐	1	99.9997374732	hang2	
+8584	笜	1	99.9997379899	zhu2	
+8585	筂	1	99.9997385067	chi2	
+8586	箒	1	99.9997390235	zhou3	
+8587	箛	1	99.9997395403	gu1	
+8588	箞	1	99.9997400571	qian1	
+8589	箤	1	99.9997405739	zu2	
+8590	箷	1	99.9997410906	yi2	
+8591	箹	1	99.9997416074	yao4	
+8592	箿	1	99.9997421242	ji2	
+8593	篜	1	99.999742641	zheng1	
+8594	簤	1	99.9997436746	dai4	
+8595	簨	1	99.9997441914	zhuan4	
+8596	簹	1	99.9997447081	dang1	
+8597	粔	1	99.9997462585	ju4	
+8598	粸	1	99.9997467753	qi2	
+8599	綄	1	99.999749876	huan2	
+8600	綊	1	99.9997503928	xie2	
+8601	綒	1	99.9997514264	fu1	
+8602	綔	1	99.9997519431	hu4	
+8603	綗	1	99.9997524599	jiong3	
+8604	緰	1	99.9997550438	tou2	
+8605	繜	1	99.999757111	zun1	
+8606	繝	1	99.9997576278	jian4	
+8607	罃	1	99.9997591781	ying1	
+8608	罝	1	99.9997596949	ju1	
+8609	羴	1	99.9997607285	shan1	
+8610	翢	1	99.9997612453	dao4	
+8611	聡	1	99.9997617621	cong1	
+8612	聻	1	99.9997627956	ni3	
+8613	脕	1	99.9997638292	wan4	
+8614	脟	1	99.999764346	lie4	
+8615	脳	1	99.9997648628	nao3	
+8616	脽	1	99.9997653795	shui2	
+8617	脿	1	99.9997658963	biao1	
+8618	臈	1	99.9997664131	la4	
+8619	艑	1	99.9997669299	bian4	
+8620	艢	1	99.9997679635	qiang2	
+8621	茻	1	99.999768997	mang3	
+8622	菐	1	99.9997700306	pu2	
+8623	菓	1	99.9997705474	guo3	
+8624	菙	1	99.9997710642	chui2	
+8625	菚	1	99.999771581	zhan4	
+8626	菣	1	99.9997720978	qin4	
+8627	菦	1	99.9997726145	qin2	
+8628	菨	1	99.9997731313	jie1	
+8629	葔	1	99.9997736481	hou2	
+8630	葠	1	99.9997741649	shen1	
+8631	葮	1	99.9997746817	duan4	
+8632	葲	1	99.9997751985	quan2	
+8633	蓙	1	99.9997757153	zuo4	
+8634	蔁	1	99.999776232	zhang1	
+8635	蕛	1	99.9997767488	ti2	
+8636	蕜	1	99.9997772656	fei3	
+8637	蕦	1	99.9997777824	xu1	
+8638	蕵	1	99.9997782992	sun1	
+8639	薖	1	99.9997793327	ke1	
+8640	藨	1	99.9997798495	biao1	
+8641	藮	1	99.9997803663	qiao2	
+8642	藰	1	99.9997808831	liu2	
+8643	藳	1	99.9997813999	gao3	
+8644	藵	1	99.9997819167	bao3	
+8645	虃	1	99.9997824335	jian1	
+8646	虘	1	99.9997829502	cuo2	
+8647	虝	1	99.9997839838	hu3	
+8648	蛥	1	99.9997845006	she2	
+8649	蛶	1	99.9997850174	jie4	
+8650	蜠	1	99.9997855342	jun4	
+8651	螐	1	99.9997865677	wu1	
+8652	螖	1	99.9997870845	hua2	
+8653	螡	1	99.9997876013	wen2	
+8654	蟳	1	99.9997886349	xun2	
+8655	蠌	1	99.9997891517	ze2	
+8656	蠒	1	99.9997901852	jian3	
+8657	蠗	1	99.999790702	zhuo2	
+8658	蠝	1	99.9997912188	lei3	
+8659	袘	1	99.9997922524	yi2	
+8660	褜	1	99.9997927692	pao2	
+8661	褨	1	99.9997932859	cha2	
+8662	襾	1	99.9997938027	ya4	
+8663	覊	1	99.9997943195	ji1	
+8664	覚	1	99.9997948363	jiao4	
+8665	覛	1	99.9997953531	mi4	
+8666	覟	1	99.9997958699	zhi4	
+8667	覠	1	99.9997963867	jun1	
+8668	訜	1	99.9997974202	bin1	
+8669	訡	1	99.999797937	yin2	
+8670	訮	1	99.9997984538	yan2	
+8671	証	1	99.9997989706	zheng4	
+8672	詷	1	99.9997994874	dong4	
+8673	詺	1	99.9998000042	ming4	
+8674	諘	1	99.9998015545	biao3	
+8675	謩	1	99.9998041384	mo2	
+8676	謸	1	99.9998046552	ao4	
+8677	謽	1	99.999805172	jiang4	
+8678	讍	1	99.9998056888	e4	
+8679	讛	1	99.9998062056	yi4	
+8680	貦	1	99.9998067224	wan2	
+8681	賳	1	99.9998093063	zai1	
+8682	贀	1	99.9998103399	yi4	
+8683	贌	1	99.9998118902	pu2	
+8684	趪	1	99.999812407	guang1	
+8685	跁	1	99.9998129238	ba4	
+8686	跈	1	99.9998134406	nian3	
+8687	跒	1	99.9998139574	qia3	
+8688	蹖	1	99.9998144741	chong1	
+8689	軇	1	99.9998155077	dao4	
+8690	軘	1	99.9998165413	tun2	
+8691	軣	1	99.9998170581	hong1	
+8692	逇	1	99.9998201588	dun4	
+8693	邔	1	99.9998206756	qi3	
+8694	邥	1	99.9998211923	shen3	
+8695	邫	1	99.9998217091	bang1	
+8696	鄽	1	99.9998222259	chan2	
+8697	醆	1	99.9998227427	zhan3	
+8698	醽	1	99.9998237763	ling2	
+8699	釥	1	99.9998242931	jiao3	
+8700	鈂	1	99.9998248098	qin2	
+8701	鋷	1	99.9998294609	nie4	
+8702	鎲	1	99.9998310113	tang3	
+8703	鐑	1	99.9998325616	qie4	
+8704	鐬	1	99.9998330784	hui4	
+8705	鑴	1	99.999834112	xi1	
+8706	镻	1	99.9998351455	die2	
+8707	閰	1	99.9998361791	ju2	
+8708	閳	1	99.9998366959	chan3	
+8709	閴	1	99.9998372127	qu4	
+8710	陮	1	99.9998392798	dui4	
+8711	陻	1	99.9998397966	yin1	
+8712	霂	1	99.9998403134	mu4	
+8713	靵	1	99.9998408302	niu3	
+8714	鞊	1	99.999841347	ji2	
+8715	鞛	1	99.9998418637	beng3	
+8716	韴	1	99.9998428973	za2	
+8717	韷	1	99.9998434141	le4	
+8718	頋	1	99.9998444477	gu4	
+8719	顕	1	99.999845998	xian3	
+8720	顨	1	99.9998465148	xun4	
+8721	飷	1	99.9998475484	jie3	
+8722	飺	1	99.9998480652	ci2	
+8723	餀	1	99.9998490987	hai4	
+8724	饡	1	99.9998511659	zan4	
+8725	饳	1	99.9998516827	duo4	
+8726	饻	1	99.9998521995	xi1	
+8727	駜	1	99.999853233	bi4	
+8728	駣	1	99.9998537498	tao2	
+8729	駥	1	99.9998542666	rong2	
+8730	駨	1	99.9998547834	xuan4	
+8731	駶	1	99.9998553002	ju2	
+8732	騿	1	99.9998563337	zhang1	
+8733	驇	1	99.9998573673	zhi4	
+8734	驑	1	99.9998578841	liu2	
+8735	驖	1	99.9998589177	tie3	
+8736	髞	1	99.9998599512	sao4	
+8737	鬀	1	99.999860468	ti4	
+8738	鬄	1	99.9998609848	di2	
+8739	鬅	1	99.9998615016	peng2	
+8740	魰	1	99.9998630519	wen2	
+8741	魵	1	99.9998635687	fen2	
+8742	魸	1	99.9998640855	pian4	
+8743	魺	1	99.9998646023	ge3	
+8744	鯐	1	99.9998656359	zou3	
+8745	鯓	1	99.9998661527	shen1	
+8746	鰞	1	99.999867703	wu1	
+8747	鰬	1	99.9998682198	qian2	
+8748	鰵	1	99.9998687366	min3	
+8749	鰸	1	99.9998692534	qu1	
+8750	鱌	1	99.9998702869	xiang4	
+8751	鳪	1	99.9998718373	bu3	
+8752	鴭	1	99.9998728709	dui1	
+8753	鴳	1	99.9998733876	an1	
+8754	鴵	1	99.9998744212	xiao1	
+8755	鴺	1	99.999874938	yi2	
+8756	鴽	1	99.9998754548	ru2	
+8757	鵁	1	99.9998759716	xiao1	
+8758	鶈	1	99.9998770051	qi1	
+8759	鶐	1	99.9998775219	shu4	
+8760	鷩	1	99.9998795891	bi4	
+8761	鼑	1	99.999882173	ding3	
+8762	鼘	1	99.9998826898	yuan1	
+8763	鼮	1	99.9998832066	ting2	
+8764	齼	1	99.9998842401	chu3	
+8765	龝	1	99.9998847569	qiu1	
+8766		1	99.9998852737		
+8767		1	99.9998857905		
+8768		1	99.9998863073		
+8769	禖	1	99.9998868241	mei2	
+8770	禵	1	99.9998873408	zhi1	
+8771	秅	1	99.9998878576	na2	
+8772	竌	1	99.9998883744	chu4	
+8773	羠	1	99.9998904416	yi2	
+8774	翖	1	99.9998909583	xi1	
+8775	艣	1	99.9998914751	lu3	
+8776	蚡	1	99.9998919919	fen2	
+8777	訹	1	99.9998925087	xu4	
+8778	輂	1	99.9998935423	ju2	
+8779	輨	1	99.999894059	guan3	
+8780	遶	1	99.9998945758	rao3	
+8781	鈆	1	99.9998950926	qian1	
+8782	鈖	1	99.9998956094	fen1	
+8783	绗	1	99.9998976765	hang2	
+8784	鐷	1	99.9998981933	ye4	
+8785	闟	1	99.9998992269	xi4	
+8786	韮	1	99.9998997437	jiu3	
+8787	騣	1	99.9999002605	zong1	
+8788	髧	1	99.9999007773	dan4	
+8789	鴢	1	99.999901294	ao1	
+8790	鷘	1	99.9999018108	chi4	
+8791	黺	1	99.9999023276	fen3	
+8792	祶	1	99.9999028444	di4	
+8793	荮	1	99.9999033612	zhou4	
+8794	瞏	1	99.999903878	huan2	
+8795	稴	1	99.9999043948	lian4	
+8796	笲	1	99.9999049115	fan2	
+8797	笿	1	99.9999054283	luo4	
+8798	縪	1	99.9999059451	bi4	
+8799	翸	1	99.9999069787	pen3	
+8800	肧	1	99.9999074955	pei1	
+8801	臶	1	99.9999080122	jian4	
+8802	蜸	1	99.999908529	qian3	
+8803	豊	1	99.9999090458	feng1	
+8804	輐	1	99.9999100794	wan4	
+8805	輘	1	99.9999105962	leng2	
+8806	雘	1	99.9999116297	wo4	
+8807		1	99.9999126633		
+8808	眞	1	99.9999131801	zhen1	
+8809	睴	1	99.9999136969	gun4	
+8810	瞡	1	99.9999142137	gui1	
+8811	砏	1	99.9999147305	bin1	
+8812	粿	1	99.999915764	guo3	
+8813	紘	1	99.9999162808	hong2	
+8814	舋	1	99.9999167976	xin4	
+8815	葋	1	99.9999173144	qu2	
+8816	薭	1	99.9999178312	bai4	
+8817	虲	1	99.9999183479	uu	
+8818	蠩	1	99.9999188647	zhu1	
+8819	覵	1	99.9999193815	bian3	
+8820	詄	1	99.9999204151	die2	
+8821	譗	1	99.9999209319	zha2	
+8822	趰	1	99.9999214487	er3	
+8823	軧	1	99.9999219654	di3	
+8824	岍	1	99.9999224822	qian1	name of a mountain
+8825	鉼	1	99.999922999	bing3	
+8826	鞻	1	99.9999240326	lou2	
+8827	颵	1	99.9999245494	xiao1	
+8828	鯘	1	99.9999266165	nei3	
+8829	鳿	1	99.9999271333	yu4	
+8830	龎	1	99.9999276501	pang2	
+8831	睉	1	99.9999281669	zhuai4	
+8832	砤	1	99.9999286837	tuo2	
+8833	礑	1	99.9999292004	dang4	
+8834	窤	1	99.999930234	guan1	
+8835	竈	1	99.9999307508	zao4	
+8836	蕒	1	99.9999317844	mai3	
+8837	説	1	99.9999323011	shui4	
+8838	趌	1	99.9999328179	ji2	
+8839	踄	1	99.9999333347	bu4	
+8840	隣	1	99.9999343683	lin2	
+8841	骿	1	99.9999359186	pian2	
+8842	鼥	1	99.9999364354	ba2	
+8843	碵	1	99.9999369522	tian2	
+8844	竤	1	99.999937469	hong2	
+8845	絒	1	99.9999379858	chou2	
+8846	絓	1	99.9999385026	gua4	
+8847	芼	1	99.9999390194	mao4	
+8848	萢	1	99.9999395361	pao4	
+8849	蓧	1	99.9999400529	you2	
+8850	蔄	1	99.9999405697	man4	
+8851	螦	1	99.9999410865	so	
+8852	詀	1	99.9999416033	zhan1	
+8853	狨	1	99.9999426369	rong2	Hapale jacchus
+8854	錋	1	99.9999431536	beng4	
+8855	鎝	1	99.9999436704	da1	
+8856	鐩	1	99.9999441872	sui4	
+8857	隲	1	99.999944704	zhi4	
+8858	霝	1	99.9999452208	ling2	
+8859	鞟	1	99.9999457376	kuo4	
+8860	礐	1	99.9999462543	hu2	
+8861	禗	1	99.9999467711	si1	
+8862	稡	1	99.9999472879	zu2	
+8863	穽	1	99.9999478047	jing3	
+8864	糮	1	99.9999483215	han3	
+8865	羮	1	99.9999488383	lang2	
+8866	肰	1	99.9999493551	ran2	
+8867	艸	1	99.9999498718	cao3	
+8868	葇	1	99.9999503886	rou2	
+8869	葟	1	99.9999509054	huang2	
+8870	蒪	1	99.9999514222	po4	
+8871	蝑	1	99.999951939	xie4	
+8872	螧	1	99.9999524558	qi2	
+8873	蟅	1	99.9999529726	zhe4	
+8874	蟢	1	99.9999534893	xi3	
+8875	貒	1	99.9999540061	tuan1	
+8876	関	1	99.9999550397	wan1	
+8877	礤	1	99.9999555565	ca3	
+8878	鴙	1	99.99995659	zhi4	
+8879	鵣	1	99.9999576236	lai4	
+8880	盢	1	99.9999602075	xu4	
+8881	眘	1	99.9999607243	shen4	
+8882	礿	1	99.9999617579	yue4	
+8883	祩	1	99.9999622747	zhu4	
+8884	禨	1	99.9999627915	ji1	
+8885	秺	1	99.9999633083	du4	
+8886	穟	1	99.999963825	sui4	
+8887	窫	1	99.9999643418	ya4	
+8888	笎	1	99.9999648586	yuan2	
+8889	篨	1	99.9999653754	chu2	
+8890	籋	1	99.9999658922	mi2	
+8891	緤	1	99.999966409	ye4	
+8892	緵	1	99.9999669258	zong1	
+8893	縚	1	99.9999674425	tao1	
+8894	繿	1	99.9999679593	lan2	
+8895	羙	1	99.9999684761	mei3	
+8896	蘂	1	99.9999689929	rui3	
+8897	蜼	1	99.9999695097	wei3	
+8898	襘	1	99.9999700265	gui4	
+8899	訞	1	99.9999705432	yao1	
+8900	谼	1	99.9999715768	hong2	
+8901	躭	1	99.9999726104	dan1	
+8902	迍	1	99.9999731272	zhun1	
+8903	釿	1	99.999973644	yin3	
+8904	鏸	1	99.9999741607	hui4	
+8905	餟	1	99.9999751943	zhui4	
+8906	餫	1	99.9999757111	yun4	
+8907	驆	1	99.9999767447	bi4	
+8908	鬳	1	99.9999772615	yan4	
+8909	魒	1	99.9999777782	piao1	
+8910	盉	1	99.999978295	he2	
+8911	睱	1	99.9999788118	xia2	
+8912	睻	1	99.9999793286	xuan1	
+8913	磠	1	99.9999798454	lu3	
+8914	絣	1	99.999980879	beng1	
+8915	縀	1	99.9999813957	xia2	
+8916	荙	1	99.9999829461	da2	
+8917	莕	1	99.9999834629	xing4	
+8918	莙	1	99.9999839797	jun1	
+8919	螠	1	99.9999844964	yi4	
+8920	蟧	1	99.9999850132	lao2	
+8921	襌	1	99.99998553	dan1	
+8922	襽	1	99.9999860468	lan2	
+8923	豰	1	99.9999865636	bo2	
+8924	賷	1	99.9999870804	ji1	
+8925	鉽	1	99.9999875972	shi2	
+8926	錧	1	99.9999886307	guan3	
+8927	鍚	1	99.9999891475	yang2	
+8928	鍱	1	99.9999896643	ye4	
+8929	骣	1	99.9999901811	chan3	
+8930	鑪	1	99.9999906979	lu2	
+8931	靷	1	99.9999912147	yin3	
+8932	騊	1	99.9999922482	tao2	
+8933	骔	1	99.999992765	zong1	
+8934	魽	1	99.9999932818	han1	
+8935	魿	1	99.9999937986	lin2	
+8936	鮅	1	99.9999943154	bi4	
+8937	鮇	1	99.9999948321	wei4	
+8938	鮘	1	99.9999958657	dai4	
+8939	鰿	1	99.9999974161	ji4	
+8940	鱀	1	99.9999979329	ji4	
+8941	鱄	1	99.9999984496	tuan2	
+8942	鱓	1	99.9999989664	tuo2	
+8943	鲖	1	99.9999994832	tong2	

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -240,7 +240,7 @@ function loadFrequencyData(){
 		wordfreq[word] = freq;
 	};
 
-	var	readFile = fs.readFileSync(__dirname + '/data/frequencyjunda.txt', 'utf-8');
+	var	readFile = fs.readFileSync(__dirname + '/data/frequency_with_script_variants_removed.txt', 'utf-8');
 	lines = readFile.split(/\r?\n/);
 	var i=0;
 	for(; i<lines.length; i++) {
@@ -484,4 +484,4 @@ exports.getCharacterFrequency = getCharacterFrequency;
 exports.determinePhoneticRegularity = determinePhoneticRegularity;
 exports.getPhoneticSet = getPhoneticSet;
 exports.getCharacterInFrequencyListByPosition = getCharacterInFrequencyListByPosition;
-exports.segment = segmenter.segment.bind(segmenter)
+exports.segment = segmenter.segment.bind(segmenter);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hanzi",
     "author": "Niel de la Rouviere",
     "description": "HanziJS is a Chinese character and NLP module for Chinese language processing for Node.js",
-    "version": "0.7.0",
+    "version": "1.0.0",
     "license": "MIT",
     "main": "index.js",
     "browserify": { "transform": [ "brfs" ] },


### PR DESCRIPTION
When I introduced the `getCharacterInFrequencyListByPosition` in the last version, I noticed some odd behaviour, where if you grabbed the position: 5792, which in the Junda Frequency list would be `認` it returned data for the simplified version at position 213. This is technically the intended behaviour after the change in v0.6.0, since we only have data for simplified characters. However, from the perspective of `getCharacterInFrequencyListByPosition` this was not quite what we'd expect, since you're grabbing a different spot in the list.

I decided to make things a bit cleaner and easier to understand by removing all traditional characters that have simplified variants in the Junda Frequency List. So you won't find `認` anymore, only `认`. There are still traditional characters in the frequency list but these are very uncommonly used. This is dependent on how Junda created their list.

I might look into getting more updated/cleaner frequency data in the future.

This a major version bump since it changes the underlying data that is used.