### PR TITLE
Use prettier as linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./lib/module.js");
+module.exports = require('./lib/module.js');

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -5,244 +5,247 @@ var hanzi = require('./hanzidecomposer.js');
 var phonetic_set_one = {};
 var phonetic_set_two = {};
 
-var Segmenter = require("./segmenter.js").LongestMatchSegmenter;
+var Segmenter = require('./segmenter.js').LongestMatchSegmenter;
 var segmenter = new Segmenter(definitionLookup);
 
-function start(){
-	console.log("Hanzi is compiling dictionary...");
+function start() {
+  console.log('Hanzi is compiling dictionary...');
 
-	//Reading in CCEDICT
+  //Reading in CCEDICT
   var readFile = fs.readFileSync(__dirname + '/data/cedict_ts.u8', 'utf-8');
-	var lines = readFile.split(/\r?\n/);
-	loadIrregularPhonetics();
-	loadFrequencyData();
-	phonetic_set_one = require('./data/phonetic_sets_regularity_one.js').regularity_one;
-	phonetic_set_two = require('./data/phonetic_sets_regularity_two.js').regularity_two;
+  var lines = readFile.split(/\r?\n/);
+  loadIrregularPhonetics();
+  loadFrequencyData();
+  phonetic_set_one = require('./data/phonetic_sets_regularity_one.js')
+    .regularity_one;
+  phonetic_set_two = require('./data/phonetic_sets_regularity_two.js')
+    .regularity_two;
 
-	var STARTING_LINE = 30;
-	for(var i=STARTING_LINE; i<lines.length; i++){
-		var multiplearray = [getElements(i)];
-		while(multiplearray[0].traditional == nextChar(i+1)){
-			multiplearray.push(getElements(i+1));
-			i++;
-		}
+  var STARTING_LINE = 30;
+  for (var i = STARTING_LINE; i < lines.length; i++) {
+    var multiplearray = [getElements(i)];
+    while (multiplearray[0].traditional == nextChar(i + 1)) {
+      multiplearray.push(getElements(i + 1));
+      i++;
+    }
 
-		dictionarysimplified[multiplearray[0].simplified] = multiplearray;
-		dictionarytraditional[multiplearray[0].traditional] = multiplearray;
-	}
+    dictionarysimplified[multiplearray[0].simplified] = multiplearray;
+    dictionarytraditional[multiplearray[0].traditional] = multiplearray;
+  }
 
-	function nextChar(j){
-		if(j<lines.length){
-			var nextcharacter = lines[j].split(" ");
-			var nextcheck = nextcharacter[0];
-			return nextcheck;
-		}
-		return "";
-	}
+  function nextChar(j) {
+    if (j < lines.length) {
+      var nextcharacter = lines[j].split(' ');
+      var nextcheck = nextcharacter[0];
+      return nextcheck;
+    }
+    return '';
+  }
 
-	function getElements(i){
-		var openbracket = lines[i].indexOf('[');
-		var closebracket = lines[i].indexOf(']');
-		var defStart = lines[i].indexOf('/');
-		var defClose = lines[i].lastIndexOf('/');
-		var pinyin = lines[i].substring(openbracket+1, closebracket);
-		var definition = lines[i].substring(defStart+1, defClose);
-		var elements = lines[i].split(" ");
-		var traditional = elements[0];
-		var simplified = elements[1];
-		return {
-			traditional: traditional,
-			simplified: simplified,
-			pinyin: pinyin,
-			definition: definition
-		};
-	}
+  function getElements(i) {
+    var openbracket = lines[i].indexOf('[');
+    var closebracket = lines[i].indexOf(']');
+    var defStart = lines[i].indexOf('/');
+    var defClose = lines[i].lastIndexOf('/');
+    var pinyin = lines[i].substring(openbracket + 1, closebracket);
+    var definition = lines[i].substring(defStart + 1, defClose);
+    var elements = lines[i].split(' ');
+    var traditional = elements[0];
+    var simplified = elements[1];
+    return {
+      traditional: traditional,
+      simplified: simplified,
+      pinyin: pinyin,
+      definition: definition
+    };
+  }
 }
 
-function definitionLookup(word, scripttype){
-	if(scripttype == null){
-		if(determineIfSimplified(word)){
-			return dictionarysimplified[word];
-		}
-		if(!determineIfSimplified(word)){
-			return dictionarytraditional[word];
-		}
-	}
-	else{
-		if(scripttype == "s"){
-			return dictionarysimplified[word];
-		}
-		else{
-			return dictionarytraditional[word];
-		}
-	}
+function definitionLookup(word, scripttype) {
+  if (scripttype == null) {
+    if (determineIfSimplified(word)) {
+      return dictionarysimplified[word];
+    }
+    if (!determineIfSimplified(word)) {
+      return dictionarytraditional[word];
+    }
+  } else {
+    if (scripttype == 's') {
+      return dictionarysimplified[word];
+    } else {
+      return dictionarytraditional[word];
+    }
+  }
 }
 
-function dictionarySearch(character, type){
-	/*--- Types: Only = Just the characters and no alternatives. If not then finds all cases of that character ---*/
-	var search = [];
-	var regexstring = "^(";
+function dictionarySearch(character, type) {
+  /*--- Types: Only = Just the characters and no alternatives. If not then finds all cases of that character ---*/
+  var search = [];
+  var regexstring = '^(';
 
-	if(type == "only"){
-		for(var i=0; i<character.length; i++){
-			if(i < character.length-1){
-				regexstring = regexstring + character.substring(i, i+1) + "|";
-			}
-			else{
-				regexstring = regexstring + character.substring(i, i+1) + ")+$";
-			}
-		}
-	}
-	else{
-		regexstring = "["+character+"]";
-	}
+  if (type == 'only') {
+    for (var i = 0; i < character.length; i++) {
+      if (i < character.length - 1) {
+        regexstring = regexstring + character.substring(i, i + 1) + '|';
+      } else {
+        regexstring = regexstring + character.substring(i, i + 1) + ')+$';
+      }
+    }
+  } else {
+    regexstring = '[' + character + ']';
+  }
 
-	var re = new RegExp(regexstring, 'g');
+  var re = new RegExp(regexstring, 'g');
 
-	//First check for simplified.
-	for(var word in dictionarysimplified){
-		if(dictionarysimplified.hasOwnProperty(word)){
-			if(word.search(re) != -1){
-				search.push(dictionarysimplified[word]);
-			}
-		}
-	}
+  //First check for simplified.
+  for (var word in dictionarysimplified) {
+    if (dictionarysimplified.hasOwnProperty(word)) {
+      if (word.search(re) != -1) {
+        search.push(dictionarysimplified[word]);
+      }
+    }
+  }
 
-	//If there's nothing to be found, then try and look for traditional entries.
-	if(search == ""){
-		for(word in dictionarytraditional){
-			if(dictionarytraditional.hasOwnProperty(word)){
-				if(word.search(re) != -1){
-					search.push(dictionarytraditional[word]);
-				}
-			}
-		}
-	}
+  //If there's nothing to be found, then try and look for traditional entries.
+  if (search == '') {
+    for (word in dictionarytraditional) {
+      if (dictionarytraditional.hasOwnProperty(word)) {
+        if (word.search(re) != -1) {
+          search.push(dictionarytraditional[word]);
+        }
+      }
+    }
+  }
 
-	return search;
+  return search;
 }
 
-function getExamples(character){
-	/*--- Does a dictionary search and finds the most useful example words ---*/
+function getExamples(character) {
+  /*--- Does a dictionary search and finds the most useful example words ---*/
 
-	var isSimplified = determineIfSimplified(character);
+  var isSimplified = determineIfSimplified(character);
 
-	var potentialexamples = dictionarySearch(character);
-	var allfreq = [];
-	var lowfreq = [];
-	var midfreq = [];
-	var highfreq = [];
-	var i = 0;
-	for(; i<potentialexamples.length; i++) { //Create Array of Frequency Points to calculate distributions
-		//It takes the frequency accounts of both scripts into account.
+  var potentialexamples = dictionarySearch(character);
+  var allfreq = [];
+  var lowfreq = [];
+  var midfreq = [];
+  var highfreq = [];
+  var i = 0;
+  for (; i < potentialexamples.length; i++) {
+    //Create Array of Frequency Points to calculate distributions
+    //It takes the frequency accounts of both scripts into account.
 
     var wordsimp = potentialexamples[i][0].simplified;
-		var wordtrad = potentialexamples[i][0].traditional;
+    var wordtrad = potentialexamples[i][0].traditional;
 
 		var totalfrequency = 0;
-		if("undefined" != typeof wordfreq[wordsimp]){
+		if('undefined' != typeof wordfreq[wordsimp]){
 			totalfrequency = totalfrequency + parseInt(wordfreq[wordsimp]);
 		}
-		if("undefined" != typeof wordfreq[wordtrad]){
+		if('undefined' != typeof wordfreq[wordtrad]){
 			totalfrequency = totalfrequency + parseInt(wordfreq[wordtrad]);
 		}
 		allfreq.push(totalfrequency);
-  }
-  //Calculate mean, variance + sd
-	allfreq.sort(function(a,b){return a-b});
+	}
+
+	//Calculate mean, variance + sd
+	allfreq.sort(function(a,b){return a-b;});
 	var mean = calculateMean();
 	var variance = calculateVariance(mean);
 	var sd = Math.sqrt(variance);
 
-	determineFreqCategories();
+  determineFreqCategories();
 
-	//Create frequency categories
-	function determineFreqCategories(){
-		if(mean-sd < 0){
-			var lowrange = 0+(mean/3);
-		}
-		else{
-			var lowrange = mean-sd;
-		}
-		var midrange = [mean+sd, lowrange];
-		var highrange = mean+sd;
+  //Create frequency categories
+  function determineFreqCategories() {
+    if (mean - sd < 0) {
+      var lowrange = 0 + mean / 3;
+    } else {
+      var lowrange = mean - sd;
+    }
+    var midrange = [mean + sd, lowrange];
+    var highrange = mean + sd;
 
-		var i = 0;
-		for(; i<potentialexamples.length; i++){
-			var word = potentialexamples[i][0];
+    var i = 0;
+    for (; i < potentialexamples.length; i++) {
+      var word = potentialexamples[i][0];
 
-			if("undefined" != typeof wordfreq[word.simplified]){
-				pushFrequency(word);
-			}
+      if ('undefined' != typeof wordfreq[word.simplified]) {
+        pushFrequency(word);
+      }
     }
 
     function pushFrequency(word) {
-			if(wordfreq[word.simplified] < lowrange){
-				lowfreq.push(word);
-			}
-			if(wordfreq[word.simplified] > midrange[1] && wordfreq[word.simplified] < midrange[0]){
-				midfreq.push(word);
-			}
-			if(wordfreq[word.simplified] > highrange){
-				highfreq.push(word);
+      if (wordfreq[word.simplified] < lowrange) {
+        lowfreq.push(word);
       }
-		}
-	}
-	var examplewords = [highfreq, midfreq, lowfreq];
-	return examplewords;
+      if (
+        wordfreq[word.simplified] > midrange[1] &&
+        wordfreq[word.simplified] < midrange[0]
+      ) {
+        midfreq.push(word);
+      }
+      if (wordfreq[word.simplified] > highrange) {
+        highfreq.push(word);
+      }
+    }
+  }
+  var examplewords = [highfreq, midfreq, lowfreq];
+  return examplewords;
 
-	function calculateMean(){
-		var total = 0;
-		var i = 0;
-		for(; i<allfreq.length; i++) {
-			total = total + parseInt(allfreq[i], 10);
+  function calculateMean() {
+    var total = 0;
+    var i = 0;
+    for (; i < allfreq.length; i++) {
+      total = total + parseInt(allfreq[i], 10);
     }
     var mean = total / allfreq.length;
-		return mean;
-	}
+    return mean;
+  }
 
-	function calculateVariance(){
-		var total = 0;
-		var i = 0;
-		for(; i<allfreq.length; i++){
-			var localvar = parseInt(allfreq[i], 10) - mean;
-			total = total + localvar*localvar;
-		}
-		var variance = total/allfreq.length;
-		return variance;
-	}
+  function calculateVariance() {
+    var total = 0;
+    var i = 0;
+    for (; i < allfreq.length; i++) {
+      var localvar = parseInt(allfreq[i], 10) - mean;
+      total = total + localvar * localvar;
+    }
+    var variance = total / allfreq.length;
+    return variance;
+  }
 }
 
-function determineIfSimplified(character){
-	if("undefined" != typeof dictionarysimplified[character]){
-		return true;
-	}
-	if("undefined" != typeof dictionarytraditional[character]){
-		return false;
-	}
+function determineIfSimplified(character) {
+  if ('undefined' != typeof dictionarysimplified[character]) {
+    return true;
+  }
+  if ('undefined' != typeof dictionarytraditional[character]) {
+    return false;
+  }
 }
 
 var charfreq = {};
 var characterFrequencyCountIndex = [];
 var wordfreq = {};
-function loadFrequencyData(){
-	console.log("Starting to read frequency data");
+function loadFrequencyData() {
+  console.log('Starting to read frequency data');
 
-	var	readFile = fs.readFileSync(__dirname + '/data/leidenfreqdata.txt', 'utf-8');
-	lines = readFile.split(/\r?\n/);
+	var	readFile = fs.readFileSync(__dirname + '/data/leidenfreqdata.txt', 'utf-8'
+	);lines = readFile.split(/\r?\n/);
 
 	var i=0;
 	for(; i<lines.length; i++) {
-		var splits = lines[i].split(",");
+		var splits = lines[i].split(',');
 		var word = splits[0];
 		var freq = splits[1];
 		wordfreq[word] = freq;
-  }
-  var readFile = fs.readFileSync(__dirname + '/data/frequency_with_script_variants_removed.txt', 'utf-8');
+	}
+
+	var	readFile = fs.readFileSync(__dirname + '/data/frequency_with_script_variants_removed.txt', 'utf-8');
 	lines = readFile.split(/\r?\n/);
 	var i=0;
 	for(; i<lines.length; i++) {
-		var splits = lines[i].split("\t");
+		var splits = lines[i].split('\t');
 		var number = splits[0];
 		var character = splits[1];
 
@@ -253,135 +256,147 @@ function loadFrequencyData(){
 			percentage: splits[3],
 			pinyin: splits[4],
 			meaning: splits[5]
-		}
-	characterFrequencyCountIndex[number] = character;}
-	console.log("Frequency data loaded");
+		};
+
+		characterFrequencyCountIndex[number] = character;
+	}
+	console.log('Frequency data loaded');
 }
 
 var irregularphonetics = {};
-function loadIrregularPhonetics(){
-	var readFile = fs.readFileSync(__dirname + '/data/irregularphonetics.txt', 'utf-8');
-	var lines = readFile.split(/\r?\n/);
-	for(var i=0; i<lines.length; i++){
-		var splits = lines[i].split(":");
-		var character = splits[0];
-		var pinyin = splits[1];
-		irregularphonetics[character]=pinyin;
-	}
+function loadIrregularPhonetics() {
+  var readFile = fs.readFileSync(
+    __dirname + '/data/irregularphonetics.txt',
+    'utf-8'
+  );
+  var lines = readFile.split(/\r?\n/);
+  for (var i = 0; i < lines.length; i++) {
+    var splits = lines[i].split(':');
+    var character = splits[0];
+    var pinyin = splits[1];
+    irregularphonetics[character] = pinyin;
+  }
 }
 
-function getPinyin(character){
-	//These are for components not found in CC-CEDICT.
-	if("undefined" != typeof dictionarysimplified[character]){
-		var i=0;
-		var pinyinarray = [];
-		for(; i<dictionarysimplified[character].length; i++){
-			pinyinarray[i] = dictionarysimplified[character][i].pinyin;
-		}
-		return pinyinarray;
-	}
-	if("undefined" != typeof dictionarytraditional[character]){
-		var i=0;
-		var pinyinarray = [];
-		for(; i<dictionarytraditional[character].length; i++){
-			pinyinarray[i] = dictionarytraditional[character][i].pinyin;
-		}
-		return pinyinarray;
-	}
-	if("undefined" != typeof irregularphonetics[character]){
-		return [irregularphonetics[character]];
-	}
-	if(character.search(/[㇐㇇㇚𤴓𠂇㇒㇑⺊阝㇟⺀㇓㇝𪜋⺁𠮛㇔龶㇃丆㇏⺌⺹⺆㇛㇠㇆⺧⺮龸⺈㇗龴㇕㇈㇖⺤㇎⺺䧹㇂㇉⺪㇀]/g) != -1){
-		return ["_stroke"];
-	}
-	if(isNaN(character)==false){
-		return ["_number"];
-	}
-	return null;
+function getPinyin(character) {
+  //These are for components not found in CC-CEDICT.
+  if ('undefined' != typeof dictionarysimplified[character]) {
+    var i = 0;
+    var pinyinarray = [];
+    for (; i < dictionarysimplified[character].length; i++) {
+      pinyinarray[i] = dictionarysimplified[character][i].pinyin;
+    }
+    return pinyinarray;
+  }
+  if ('undefined' != typeof dictionarytraditional[character]) {
+    var i = 0;
+    var pinyinarray = [];
+    for (; i < dictionarytraditional[character].length; i++) {
+      pinyinarray[i] = dictionarytraditional[character][i].pinyin;
+    }
+    return pinyinarray;
+  }
+  if ('undefined' != typeof irregularphonetics[character]) {
+    return [irregularphonetics[character]];
+  }
+  if (
+    character.search(/[㇐㇇㇚𤴓𠂇㇒㇑⺊阝㇟⺀㇓㇝𪜋⺁𠮛㇔龶㇃丆㇏⺌⺹⺆㇛㇠㇆⺧⺮龸⺈㇗龴㇕㇈㇖⺤㇎⺺䧹㇂㇉⺪㇀]/g) !=
+    -1
+  ) {
+    return ['_stroke'];
+  }
+  if (isNaN(character) == false) {
+    return ['_number'];
+  }
+  return null;
 }
 
-function determinePhoneticRegularity(decomposition){
-	var regularityarray = {};
-	//An object is not passed to this function, create the decomposition object with the character input
-	if('undefined' == typeof decomposition.character){
-		decomposition = hanzi.decompose(decomposition);
-	}
+function determinePhoneticRegularity(decomposition) {
+  var regularityarray = {};
+  //An object is not passed to this function, create the decomposition object with the character input
+  if ('undefined' == typeof decomposition.character) {
+    decomposition = hanzi.decompose(decomposition);
+  }
 
-	//Get all possible pronunciations for character
-	var charpinyin = getPinyin(decomposition.character);
-	if(charpinyin == null){
-		return regularityarray = null;
-	}
+  //Get all possible pronunciations for character
+  var charpinyin = getPinyin(decomposition.character);
+  if (charpinyin == null) {
+    return (regularityarray = null);
+  }
 
-	var phoneticpinyin = [];
+  var phoneticpinyin = [];
 
-	//Determine phonetic regularity for components on level 1 decomposition
-	for(var k=0; k<decomposition.components1.length; k++){
-		phoneticpinyin = getPinyin(decomposition.components1[k]); //Get the pinyin of the component
+  //Determine phonetic regularity for components on level 1 decomposition
+  for (var k = 0; k < decomposition.components1.length; k++) {
+    phoneticpinyin = getPinyin(decomposition.components1[k]); //Get the pinyin of the component
 
-		var i=0;
-		for(; i<charpinyin.length; i++){ //Compare it with all the possible pronunciations of the character
-			//Init Object
-			if("undefined" == typeof regularityarray[charpinyin[i]]){ //If the object store has no character pinyin stored yet, create the point
-				regularityarray[charpinyin[i]] = {
-					character: decomposition.character,
-					component: [],
-					phoneticpinyin: [],
-					regularity: []
-				};
-			}
+    var i = 0;
+    for (; i < charpinyin.length; i++) {
+      //Compare it with all the possible pronunciations of the character
+      //Init Object
+      if ('undefined' == typeof regularityarray[charpinyin[i]]) {
+        //If the object store has no character pinyin stored yet, create the point
+        regularityarray[charpinyin[i]] = {
+          character: decomposition.character,
+          component: [],
+          phoneticpinyin: [],
+          regularity: []
+        };
+      }
 
 			if(phoneticpinyin == null){ //If the component has no pronunciation found, nullify the regularity computation
 				regularityarray[charpinyin[i]].phoneticpinyin.push(null);
-				regularityarray[charpinyin[i]].component.push(decomposition.components1[k]);
-				regularityarray[charpinyin[i]].regularity.push(null);
+				regularityarray[charpinyin[i]].component.push(decomposition.components1[k]
+				);regularityarray[charpinyin[i]].regularity.push(null);
 			}
 			else{ //Compare the character pinyin to all possible phonetic pinyin pronunciations
 				var j=0;
 				for(; j<phoneticpinyin.length; j++){
 					regularityarray[charpinyin[i]].phoneticpinyin.push(phoneticpinyin[j]);
-					regularityarray[charpinyin[i]].component.push(decomposition.components1[k]);
-          regularityarray[charpinyin[i]].regularity.push(getRegularityScale(charpinyin[i], phoneticpinyin[j]));
-				}
+					regularityarray[charpinyin[i]].component.push(decomposition.components1[k]
+					);regularityarray[charpinyin[i]].regularity.push(getRegularityScale(charpinyin[i], phoneticpinyin[j])
+				);
 			}
-    }
-  }
+		}
+	}}
 
-	for(var k=0; k<decomposition.components2.length; k++){
-		phoneticpinyin = getPinyin(decomposition.components2[k]); //Get the pinyin of the component
+  for (var k = 0; k < decomposition.components2.length; k++) {
+    phoneticpinyin = getPinyin(decomposition.components2[k]); //Get the pinyin of the component
 
-		var i=0;
-		for(; i<charpinyin.length; i++){ //Compare it with all the possible pronunciations of the character
-			//Init Object
-			if("undefined" == typeof regularityarray[charpinyin[i]]){ //If the object store has no character pinyin stored yet, create the point
-				regularityarray[charpinyin[i]] = {
-					character: decomposition.character,
-					component: [],
-					phoneticpinyin: [],
-					regularity: []
-				};
-			}
+    var i = 0;
+    for (; i < charpinyin.length; i++) {
+      //Compare it with all the possible pronunciations of the character
+      //Init Object
+      if ('undefined' == typeof regularityarray[charpinyin[i]]) {
+        //If the object store has no character pinyin stored yet, create the point
+        regularityarray[charpinyin[i]] = {
+          character: decomposition.character,
+          component: [],
+          phoneticpinyin: [],
+          regularity: []
+        };
+      }
 
 			if(phoneticpinyin == null){ //If the component has no pronunciation found, nullify the regularity computation
 				regularityarray[charpinyin[i]].phoneticpinyin.push(null);
-				regularityarray[charpinyin[i]].component.push(decomposition.components2[k]);
-				regularityarray[charpinyin[i]].regularity.push(null);
+				regularityarray[charpinyin[i]].component.push(decomposition.components2[k]
+				);regularityarray[charpinyin[i]].regularity.push(null);
 			}
 			else{ //Compare the character pinyin to all possible phonetic pinyin pronunciations
 				var j=0;
 				for(; j<phoneticpinyin.length; j++){
 					regularityarray[charpinyin[i]].phoneticpinyin.push(phoneticpinyin[j]);
-					regularityarray[charpinyin[i]].component.push(decomposition.components2[k]);
-          regularityarray[charpinyin[i]].regularity.push(getRegularityScale(charpinyin[i], phoneticpinyin[j]));
+					regularityarray[charpinyin[i]].component.push(decomposition.components2[k]
+					);regularityarray[charpinyin[i]].regularity.push(getRegularityScale(charpinyin[i], phoneticpinyin[j]));
 				}
 			}
-    }
-  }
-  return regularityarray;
+		}
+	}
+	return regularityarray;
 }
 
-function getCharacterFrequency(character){
-	var dictEntry = definitionLookup(character);
+function getCharacterFrequency(character) {
+  var dictEntry = definitionLookup(character);
 
 	// Check if this character has a lookup
 	if(dictEntry && dictEntry[0]){
@@ -407,86 +422,88 @@ function getCharacterFrequency(character){
 		// In the unlikely case that we don't have a dictionary entry
 		// but it exists in the frequency list
 		return charfreq[character];
-	}
-	else {
+
+	}else {
 		return 'Character not found';
 	}
 }
 
 function getCharacterInFrequencyListByPosition(position) {
-	return getCharacterFrequency(characterFrequencyCountIndex[position]);
+  return getCharacterFrequency(characterFrequencyCountIndex[position]);
 }
 
 //Helper Functions
-function getRegularityScale(charpinyin, phoneticpinyin){
-	if(charpinyin == null || phoneticpinyin == null){
-		return null;
-	}
-	var regularity = 0;
-	charpinyin = new PinyinSyllable(charpinyin.toLowerCase());
-	phoneticpinyin = new PinyinSyllable(phoneticpinyin.toLowerCase());
+function getRegularityScale(charpinyin, phoneticpinyin) {
+  if (charpinyin == null || phoneticpinyin == null) {
+    return null;
+  }
+  var regularity = 0;
+  charpinyin = new PinyinSyllable(charpinyin.toLowerCase());
+  phoneticpinyin = new PinyinSyllable(phoneticpinyin.toLowerCase());
 
-	// Regularity Scale: 1 = Exact Match (with tone), 2 = Syllable Match (without tone)
-	// 3 = Similar in Initial, 4 = Similar in Final, 0 = No regularity
+  // Regularity Scale: 1 = Exact Match (with tone), 2 = Syllable Match (without tone)
+  // 3 = Similar in Initial, 4 = Similar in Final, 0 = No regularity
 
-	//First test for Scale 1 & 2
-	if(charpinyin.syllable() == phoneticpinyin.syllable()){
-		regularity = 2;
-		if(charpinyin.raw_syllable == phoneticpinyin.raw_syllable){
-			regularity = 1;
-		}
-	}
+  //First test for Scale 1 & 2
+  if (charpinyin.syllable() == phoneticpinyin.syllable()) {
+    regularity = 2;
+    if (charpinyin.raw_syllable == phoneticpinyin.raw_syllable) {
+      regularity = 1;
+    }
+  }
 
-	//If still no regularity found, test for initial & final regularity (scale 3 & 4)
-	if(regularity == 0){
-		if(charpinyin.final() == phoneticpinyin.final()){
-			regularity = 4;
-		}
-		else{
-			if(charpinyin.initial() == phoneticpinyin.initial()){
-				regularity = 3;
-			}
-		}
-	}
+  //If still no regularity found, test for initial & final regularity (scale 3 & 4)
+  if (regularity == 0) {
+    if (charpinyin.final() == phoneticpinyin.final()) {
+      regularity = 4;
+    } else {
+      if (charpinyin.initial() == phoneticpinyin.initial()) {
+        regularity = 3;
+      }
+    }
+  }
 
-	return regularity;
+  return regularity;
 }
 
-function getPhoneticSet(regularity_scale){
-	switch(regularity_scale){
-		case 1: return phonetic_set_one; break;
-		case 2: return phonetic_set_two; break;
+function getPhoneticSet(regularity_scale) {
+  switch (regularity_scale) {
+    case 1:
+      return phonetic_set_one;
+      break;
+    case 2:
+      return phonetic_set_two;
+      break;
     default:
   }
 }
 
-function PinyinSyllable(raw_syllable){
-	this.raw_syllable = raw_syllable;
+function PinyinSyllable(raw_syllable) {
+  this.raw_syllable = raw_syllable;
 }
 
 //Methods
-PinyinSyllable.prototype.syllable = function(){
-	// Returns Pinyin sans tone
-	return this.raw_syllable.substring(0, this.raw_syllable.length-1);
+PinyinSyllable.prototype.syllable = function() {
+  // Returns Pinyin sans tone
+  return this.raw_syllable.substring(0, this.raw_syllable.length - 1);
 };
 
-PinyinSyllable.prototype.initial = function(){
-	//Returns the initial of pinyin syllable
-	var initial = "";
-	if(this.raw_syllable.substring(1,2) == "h"){
-		//Take into zh, ch, sh
-		initial = this.raw_syllable.substring(0,2);
-	}
-	else{
-		initial = this.raw_syllable.substring(0,1);
-	}
-	return initial;
+PinyinSyllable.prototype.initial = function() {
+  //Returns the initial of pinyin syllable
+  var initial = '';
+  if (this.raw_syllable.substring(1, 2) == 'h') {
+    //Take into zh, ch, sh
+    initial = this.raw_syllable.substring(0, 2);
+  } else {
+    initial = this.raw_syllable.substring(0, 1);
+  }
+  return initial;
 };
 
-PinyinSyllable.prototype.final = function(){
-	var syllable = this.syllable();
-	var rhyme = syllable.replace(this.initial(),"");
-	return rhyme;
+PinyinSyllable.prototype.final = function() {
+  var syllable = this.syllable();
+  var rhyme = syllable.replace(this.initial(), '');
+  return rhyme;
 };
 
 exports.start = start;
@@ -497,5 +514,5 @@ exports.getPinyin = getPinyin;
 exports.getCharacterFrequency = getCharacterFrequency;
 exports.determinePhoneticRegularity = determinePhoneticRegularity;
 exports.getPhoneticSet = getPhoneticSet;
-exports.getCharacterInFrequencyListByPosition = getCharacterInFrequencyListByPosition;exports.segment = segmenter.segment.bind(segmenter)
-;
+exports.getCharacterInFrequencyListByPosition = getCharacterInFrequencyListByPosition;
+exports.segment = segmenter.segment.bind(segmenter);

--- a/lib/hanzidecomposer.js
+++ b/lib/hanzidecomposer.js
@@ -4,170 +4,187 @@ var radicals = {};
 var characterswithcomponent = {};
 var noglyph = 'No glyph available';
 
-function start(){
-	var i=0;
-	var lines = [];
+function start() {
+  var i = 0;
+  var lines = [];
 
-	console.log("Hanzi is compiling data...");
+  console.log('Hanzi is compiling data...');
 
-	//Reading in charData - Decomposition Database
+  //Reading in charData - Decomposition Database
   var readFile = fs.readFileSync(__dirname + '/data/cjk-decomp.txt', 'utf-8');
-	lines = readFile.split(/\r?\n/);
+  lines = readFile.split(/\r?\n/);
 
-	for(i=0;i<lines.length; i++){
-		var colonsplit = lines[i].split(':');
-		var character = colonsplit[0];
-		var decomposition = colonsplit[1];
-		var openbracket = decomposition.indexOf('(');
-		var closebracket = decomposition.indexOf(')');
-		var typeOfDecomposition = decomposition.substring(0, openbracket);
-		var components = decomposition.substring(openbracket+1, closebracket).split(",");
-		characters[character] = {
-			typeOfDecomposition: typeOfDecomposition,
-			components: components
-		};
-	}
+  for (i = 0; i < lines.length; i++) {
+    var colonsplit = lines[i].split(':');
+    var character = colonsplit[0];
+    var decomposition = colonsplit[1];
+    var openbracket = decomposition.indexOf('(');
+    var closebracket = decomposition.indexOf(')');
+    var typeOfDecomposition = decomposition.substring(0, openbracket);
+    var components = decomposition
+      .substring(openbracket + 1, closebracket)
+      .split(',');
+    characters[character] = {
+      typeOfDecomposition: typeOfDecomposition,
+      components: components
+    };
+  }
 
-	//Reading in radical list
+  //Reading in radical list
   radicals = require('./data/radicalListWithMeaning').radicalListWithMeaning;
 
-	//Compile Components into an object array for easy lookup
-	compileAllComponents();
+  //Compile Components into an object array for easy lookup
+  compileAllComponents();
 }
 
-function compileAllComponents(){
-  var readFile = fs.readFileSync(__dirname+'/data/frequencyjunda.txt', 'utf-8');
+function compileAllComponents() {
+  var readFile = fs.readFileSync(
+    __dirname + '/data/frequencyjunda.txt',
+    'utf-8'
+  );
   var lines = readFile.split(/\r?\n/);
 
-  for(var i=0; i<lines.length;i++){
+  for (var i = 0; i < lines.length; i++) {
     var split = lines[i].split('\t');
     var character = split[1];
     var decomposition = decompose(character);
     var j = 0;
-    for(;j<decomposition.components1.length; j++){
+    for (; j < decomposition.components1.length; j++) {
       var component = decomposition.components1[j];
-      if('undefined' == typeof characterswithcomponent[component]){
-        if(component != noglyph){
+      if ('undefined' == typeof characterswithcomponent[component]) {
+        if (component != noglyph) {
           characterswithcomponent[component] = [];
           characterswithcomponent[component].push(character);
         }
-      }
-      else if(component != noglyph) characterswithcomponent[component].push(character);
+      } else if (component != noglyph)
+        characterswithcomponent[component].push(character);
     }
 
-    var j=0;
-    for(;j<decomposition.components2.length; j++){
+    var j = 0;
+    for (; j < decomposition.components2.length; j++) {
       var component = decomposition.components2[j];
-      if('undefined' == typeof characterswithcomponent[component]){
-        if(component != noglyph && component.search(/[一丨丶⺀丿乙⺃乚⺄亅丷]/g) == -1){
+      if ('undefined' == typeof characterswithcomponent[component]) {
+        if (component != noglyph && component.search(/[一丨丶⺀丿乙⺃乚⺄亅丷]/g) == -1) {
           characterswithcomponent[component] = [];
-          if(unique(characterswithcomponent[component], character)) characterswithcomponent[component].push(character);
+          if (unique(characterswithcomponent[component], character))
+            characterswithcomponent[component].push(character);
         }
-      }
-      else if(component != noglyph && component.search(/[一丨丶⺀丿乙⺃乚⺄亅丷]/g) == -1){
-        if(unique(characterswithcomponent[component], character)) characterswithcomponent[component].push(character);
+      } else if (
+        component != noglyph &&
+        component.search(/[一丨丶⺀丿乙⺃乚⺄亅丷]/g) == -1
+      ) {
+        if (unique(characterswithcomponent[component], character))
+          characterswithcomponent[component].push(character);
       }
     }
   }
   console.log('Done compiling');
 }
 
-function unique(array_list, token){
-	var unique = true;
-	var i=0;
-	for(;i<array_list.length;i++){
-		if(array_list[i] == token) unique = false;
-	}
-	return unique;
+function unique(array_list, token) {
+  var unique = true;
+  var i = 0;
+  for (; i < array_list.length; i++) {
+    if (array_list[i] == token) unique = false;
+  }
+  return unique;
 }
 
-var decomposeMany = function(characterstring, typeOfDecomposition){
-	var decomposearray = {};
+var decomposeMany = function(characterstring, typeOfDecomposition) {
+  var decomposearray = {};
 
-	// remove spaces from input string
-	characterstring = characterstring.replace(/\s/g,'');
-	if(characterstring == null || characterstring == ''){return "Invalid Input";}
+  // remove spaces from input string
+  characterstring = characterstring.replace(/\s/g, '');
+  if (characterstring == null || characterstring == '') {
+    return 'Invalid Input';
+  }
 
-	for(var i=0; i<characterstring.length; i++){
-		var onechar = characterstring.substring(i, i+1);
+  for (var i = 0; i < characterstring.length; i++) {
+    var onechar = characterstring.substring(i, i + 1);
 
-		// don't decompose the same character more than once
-		if (decomposearray[onechar]) continue;
+    // don't decompose the same character more than once
+    if (decomposearray[onechar]) continue;
 
-		decomposearray[onechar] = decompose(onechar, typeOfDecomposition);
-	}
-	return decomposearray;
+    decomposearray[onechar] = decompose(onechar, typeOfDecomposition);
+  }
+  return decomposearray;
 };
 
-var decompose = function(character, typeOfDecomposition){
-	character = character.replace(/\s/g,'');
-	if(isMessy(character)){return "Invalid Input";}
-	var object;
+var decompose = function(character, typeOfDecomposition) {
+  character = character.replace(/\s/g, '');
+  if (isMessy(character)) {
+    return 'Invalid Input';
+  }
+  var object;
 
-	/*-- Type of Decomposition: 1 = Only 2 components， 2 = Radical, 3 = Graphical) --*/
-	if(typeOfDecomposition == null){
-		object = {"character": character, "components1": onceDecompose(character), "components2": radicalDecomposition(character), "components3": graphicalDecomposition(character)};
-	}
-	else if(typeOfDecomposition == 1){
-		object = {"character": character, "components": onceDecompose(character)};
-	}
-	else if(typeOfDecomposition == 2){
-		object = {"character": character, "components": radicalDecomposition(character)};
-	}
-	else if(typeOfDecomposition == 3){
-		object = {"character": character, "components":  graphicalDecomposition(character)};
-	} else {
-		return;
-	}
-	var string = JSON.stringify(object);
-	var jsonoutput = JSON.parse(string);
-	return jsonoutput;
+  /*-- Type of Decomposition: 1 = Only 2 components， 2 = Radical, 3 = Graphical) --*/
+  if (typeOfDecomposition == null) {
+    object = {
+      character: character,
+      components1: onceDecompose(character),
+      components2: radicalDecomposition(character),
+      components3: graphicalDecomposition(character)
+    };
+  } else if (typeOfDecomposition == 1) {
+    object = {character: character, components: onceDecompose(character)};
+  } else if (typeOfDecomposition == 2) {
+    object = {
+      character: character,
+      components: radicalDecomposition(character)
+    };
+  } else if (typeOfDecomposition == 3) {
+    object = {
+      character: character,
+      components: graphicalDecomposition(character)
+    };
+  } else {
+    return;
+  }
+  var string = JSON.stringify(object);
+  var jsonoutput = JSON.parse(string);
+  return jsonoutput;
 
-	//Functions to help with Decomposition
+  //Functions to help with Decomposition
 
-	function onceDecompose(character){
-		var components = getComponents(character);
-		return replaceNumbers(components);
-	}
+  function onceDecompose(character) {
+    var components = getComponents(character);
+    return replaceNumbers(components);
+  }
 
-	function radicalDecomposition(character){
-		var final_array = [];
-		if(isRadical(character)){
-			final_array.push(character);
-		}
-		else{
-			var components = getComponents(character);
-			if(components.length==2){
-				for(var j=0; j<2; j++){
-					final_array = final_array.concat(radicalDecomposition(components[j]));
-				}
-			}
-			else{
-				final_array.push(character);
-			}
-		}
-		return replaceNumbers(final_array);
-	}
+  function radicalDecomposition(character) {
+    var final_array = [];
+    if (isRadical(character)) {
+      final_array.push(character);
+    } else {
+      var components = getComponents(character);
+      if (components.length == 2) {
+        for (var j = 0; j < 2; j++) {
+          final_array = final_array.concat(radicalDecomposition(components[j]));
+        }
+      } else {
+        final_array.push(character);
+      }
+    }
+    return replaceNumbers(final_array);
+  }
 
-	function graphicalDecomposition(character){
-		var final_array = [];
-		var components = getComponents(character);
-		if(components.length == 2){
-			for(var j=0; j<2; j++){
-				final_array = final_array.concat(graphicalDecomposition(components[j]));
-			}
-		}
-		else{
-			if(isNaN(character)){
-				final_array.push(character);
-			}
-			else{
-				final_array = final_array.concat(resolveNumber(character));
-			}
-		}
+  function graphicalDecomposition(character) {
+    var final_array = [];
+    var components = getComponents(character);
+    if (components.length == 2) {
+      for (var j = 0; j < 2; j++) {
+        final_array = final_array.concat(graphicalDecomposition(components[j]));
+      }
+    } else {
+      if (isNaN(character)) {
+        final_array.push(character);
+      } else {
+        final_array = final_array.concat(resolveNumber(character));
+      }
+    }
 
-		return final_array;
-	}
+    return final_array;
+  }
 };
 
 function replaceNumbers(characters){
@@ -177,10 +194,11 @@ function replaceNumbers(characters){
 			finalreview.push(characters[i]);
 		}
 		else{
-			finalreview.push("No glyph available");
+			finalreview.push('No glyph available');
 		}
-  }
-  return finalreview;
+	}
+
+	return finalreview;
 }
 
 function resolveNumber(number){
@@ -194,77 +212,78 @@ function resolveNumber(number){
 		else{
 			numberscleared = numberscleared.concat(resolveNumber(components[i]));
 		}
+	}
+
+	return numberscleared;
+}
+
+function getCharactersWithComponent(component) {
+  if ('undefined' != typeof radicals[component]) {
+    var components = findSameMeaningRadicals(component);
+    var characters = [];
+    var i = 0;
+    for (; i < components.length; i++) {
+      if ('undefined' != typeof characterswithcomponent[components[i]])
+        characters = characters.concat(characterswithcomponent[components[i]]);
+    }
+    return characters;
+  } else {
+    if ('undefined' != typeof characterswithcomponent[component])
+      return characterswithcomponent[component];
+    else return component + ' not found';
   }
-  return numberscleared;
 }
 
-function getCharactersWithComponent(component){
-	if('undefined' != typeof radicals[component]){
-		var components = findSameMeaningRadicals(component);
-		var characters = [];
-		var i=0;
-		for(;i<components.length;i++){
-			if('undefined' != typeof characterswithcomponent[components[i]]) characters = characters.concat(characterswithcomponent[components[i]]);
-		}
-		return characters;
-	}
-	else{
-		if('undefined' != typeof characterswithcomponent[component]) return characterswithcomponent[component];
-		else return component+' not found';
-	}
+function findSameMeaningRadicals(radical) {
+  var same_radicals = [];
+  var meaning = radicals[radical];
+  for (var radical in radicals) {
+    if (radicals.hasOwnProperty(radical)) {
+      if (radicals[radical] == meaning) same_radicals.push(radical);
+    }
+  }
+  return same_radicals;
 }
 
-function findSameMeaningRadicals(radical){
-	var same_radicals = [];
-	var meaning = radicals[radical];
-	for(var radical in radicals){
-	  if(radicals.hasOwnProperty(radical)){
-	  	if(radicals[radical] == meaning) same_radicals.push(radical);
-	  }
-	}
-	return same_radicals;
+function isRadical(character) {
+  var isRad = false;
+  if ('undefined' != typeof radicals[character]) {
+    isRad = true;
+  }
+  return isRad;
 }
 
-function isRadical(character){
-		var isRad = false;
-		if("undefined" != typeof radicals[character]){
-			isRad = true;
-		}
-		return isRad;
+function getComponents(character) {
+  if (ifComponentExists(character)) {
+    if (characters[character].typeOfDecomposition == 'c') {
+      return character;
+    } else {
+      return characters[character].components;
+    }
+  } else {
+    return character;
+  }
 }
 
-function getComponents(character){
-	if(ifComponentExists(character)){
-		if(characters[character].typeOfDecomposition == 'c'){
-			return character;
-		}
-		else{
-			return characters[character].components;
-		}
-	}
-	else{
-		return character;
-	}
+function getRadicalMeaning(radical) {
+  if (isRadical(radical)) {
+    return radicals[radical];
+  } else {
+    return 'N/A';
+  }
 }
 
-function getRadicalMeaning(radical){
-	if(isRadical(radical)){
-		return radicals[radical];
-	}
-	else{
-		return "N/A";
-	}
+function ifComponentExists(component) {
+  return 'undefined' != typeof characters[component];
 }
 
-function ifComponentExists(component){
-	return "undefined" != typeof characters[component];
-}
-
-function isMessy(character){
-	//If no input is sent
-	if(character == null || character == ""){return true;}
-	//If it's not a Chinese character
-	return "undefined" == typeof getComponents(character);
+function isMessy(character) {
+  //If no input is sent
+  if (character == null || character == '') {
+    return true;
+  }
+  //If it's not a Chinese character
+  return 'undefined' == typeof getComponents(character);
 }
 
 exports.start = start;

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,9 +1,9 @@
-var hanzi = require("./hanzidecomposer.js");
-var dict = require("./dictionary.js");
+var hanzi = require('./hanzidecomposer.js');
+var dict = require('./dictionary.js');
 
-function start(){
-	hanzi.start();
-	dict.start();
+function start() {
+  hanzi.start();
+  dict.start();
 }
 
 exports.start = start;
@@ -20,4 +20,5 @@ exports.determinePhoneticRegularity = dict.determinePhoneticRegularity;
 exports.getRadicalMeaning = hanzi.getRadicalMeaning;
 exports.getCharactersWithComponent = hanzi.getCharactersWithComponent;
 exports.getPhoneticSet = dict.getPhoneticSet;
-exports.getCharacterInFrequencyListByPosition = dict.getCharacterInFrequencyListByPosition;
+exports.getCharacterInFrequencyListByPosition =
+  dict.getCharacterInFrequencyListByPosition;

--- a/lib/segmenter.js
+++ b/lib/segmenter.js
@@ -1,45 +1,44 @@
 var LongestMatchSegmenter;
 
 LongestMatchSegmenter = (function() {
-    function LongestMatchSegmenter(dict) {
-        // dict should be a function that takes a chinese string as the
-        // first param and returns something falsey if item is not in dict
-        this.dict = dict;
+  function LongestMatchSegmenter(dict) {
+    // dict should be a function that takes a chinese string as the
+    // first param and returns something falsey if item is not in dict
+    this.dict = dict;
+  }
+
+  LongestMatchSegmenter.prototype.getLongestMatch = function(input_str) {
+    var i, max_word_len, slice;
+    max_word_len = 8;
+    i = max_word_len > input_str.length ? max_word_len : input_str.length;
+    while (i >= 0) {
+      slice = input_str.substr(0, i);
+      if (this.dict(slice)) {
+        return slice;
+      }
+      i--;
     }
+    // no match found, return undefined
+    return undefined;
+  };
 
-    LongestMatchSegmenter.prototype.getLongestMatch = function(input_str) {
-        var i, max_word_len, slice;
-        max_word_len = 8;
-        i = (max_word_len > input_str.length ? max_word_len : input_str.length);
-        while (i >= 0) {
-            slice = input_str.substr(0, i);
-            if (this.dict(slice)) {
-                return slice;
-            }
-            i--;
-        }
-        // no match found, return undefined
-        return undefined;
-    };
+  LongestMatchSegmenter.prototype.segment = function(input_str) {
+    var seg, segments;
+    segments = [];
+    // loop through the input_str, slicing off each longestMatch and
+    // appending it to the segments array
+    while (input_str.length > 0) {
+      seg = this.getLongestMatch(input_str);
+      if (!seg) {
+        seg = input_str.substr(0, 1);
+      }
+      input_str = input_str.slice(seg.length);
+      segments.push(seg);
+    }
+    return segments;
+  };
 
-    LongestMatchSegmenter.prototype.segment = function(input_str) {
-        var seg, segments;
-        segments = [];
-        // loop through the input_str, slicing off each longestMatch and
-        // appending it to the segments array
-        while (input_str.length > 0) {
-            seg = this.getLongestMatch(input_str);
-            if (!seg) {
-                seg = input_str.substr(0, 1);
-            }
-            input_str = input_str.slice(seg.length);
-            segments.push(seg);
-        }
-        return segments;
-    };
-
-    return LongestMatchSegmenter;
-
+  return LongestMatchSegmenter;
 })();
 
 exports.LongestMatchSegmenter = LongestMatchSegmenter;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "hanzi",
   "author": "Niel de la Rouviere",
-  "description": "HanziJS is a Chinese character and NLP module for Chinese language processing for Node.js",
+  "description":
+    "HanziJS is a Chinese character and NLP module for Chinese language processing for Node.js",
   "version": "1.1.0",
-    "license": "MIT",
+  "license": "MIT",
   "main": "index.js",
-  "browserify": { "transform": [ "brfs" ] },
+  "browserify": {
+    "transform": ["brfs"]
+  },
   "browser": {
     "coffee-script": false
   },
@@ -18,12 +21,22 @@
     "testEnvironment": "node"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "{index.js,*.json,lib/*.js,test/*.js}": ["prettier --write", "git add"]
+  },
+  "prettier": {
+    "bracketSpacing": false,
+    "singleQuote": true
   },
   "devDependencies": {
+    "brfs": "~1.2.0",
+    "husky": "^0.14.3",
     "jest-cli": "^20.0.0",
-    "brfs": "~1.2.0"
+    "lint-staged": "^4.2.2",
+    "prettier": "^1.7.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/test/decomposer.js
+++ b/test/decomposer.js
@@ -3,7 +3,7 @@ const hanzi = require('../index.js');
 
 hanzi.start();
 
-describe('hanzidecomposer', function(){
+describe('hanzidecomposer', function() {
   it('checks if component exists', function() {
     assert(hanzi.ifComponentExists('爱'));
   });
@@ -12,24 +12,31 @@ describe('hanzidecomposer', function(){
   });
 
   it('detects invalid input', function() {
-    assert.deepEqual(hanzi.decompose('a'), {"character":"a","components1":["a"],"components2":["a"],"components3":["a"]});
+    assert.deepEqual(hanzi.decompose('a'), {
+      character: 'a',
+      components1: ['a'],
+      components2: ['a'],
+      components3: ['a']
+    });
   });
 
   it("gets a character's pinyin", function() {
     assert.deepEqual(hanzi.getPinyin('的'), ['de5', 'di2', 'di4']);
   });
 
-  it("gets a radical's meaning", function()  {
-    assert(hanzi.getRadicalMeaning('氵'), "water");
+  it("gets a radical's meaning", function() {
+    assert(hanzi.getRadicalMeaning('氵'), 'water');
     assert(hanzi.getRadicalMeaning('爫'), 'claw/talon');
     assert(hanzi.getRadicalMeaning('冖'), 'cover');
     assert(hanzi.getRadicalMeaning('𠂇'), 'left hand');
     assert(hanzi.getRadicalMeaning('又'), 'right hand');
     assert(hanzi.getRadicalMeaning('心'), 'heart');
-    assert(hanzi.getRadicalMeaning('夂'), 'go');});
+    assert(hanzi.getRadicalMeaning('夂'), 'go');
+  });
 
-  it("gets character frequency data for simplified character", function() {
-    assert.deepEqual(hanzi.getCharacterFrequency('热'), { number: '606',
+  it('gets character frequency data for simplified character', function() {
+    assert.deepEqual(hanzi.getCharacterFrequency('热'), {
+      number: '606',
       character: '热',
       count: '67051',
       percentage: '79.8453694124',
@@ -43,114 +50,279 @@ describe('hanzidecomposer', function(){
       count: '411866',
       percentage: '38.1712637099',
       pinyin: 'hao3/hao4',
-      meaning: 'good/well, be fond of',
+      meaning: 'good/well, be fond of'
     });
   });
 
-  it("gets character frequency data for traditional character", function() {
-    assert.deepEqual(hanzi.getCharacterFrequency('熱'), { number: '606',
+  it('gets character frequency data for traditional character', function() {
+    assert.deepEqual(hanzi.getCharacterFrequency('熱'), {
+      number: '606',
       character: '热',
       count: '67051',
       percentage: '79.8453694124',
       pinyin: 're4',
-      meaning: 'heat/to heat up/fervent/hot (of weather)/warm up' });
+      meaning: 'heat/to heat up/fervent/hot (of weather)/warm up'
+    });
   });
 
-  it("gets character frequency data for simplified character with a previously different traditional frequency count", function() {
-    assert.deepEqual(hanzi.getCharacterFrequency('认'), { number: '213',
+  it('gets character frequency data for simplified character with a previously different traditional frequency count', function() {
+    assert.deepEqual(hanzi.getCharacterFrequency('认'), {
+      number: '213',
       character: '认',
       count: '191866',
       percentage: '57.0890429779',
       pinyin: 'ren4',
-      meaning: 'to recognize/to know/to admit' });
+      meaning: 'to recognize/to know/to admit'
+    });
   });
 
-  it("gets character frequency data for traditional character with a previously different traditional frequency count", function() {
-    assert.deepEqual(hanzi.getCharacterFrequency('認'), { number: '213',
+  it('gets character frequency data for traditional character with a previously different traditional frequency count', function() {
+    assert.deepEqual(hanzi.getCharacterFrequency('認'), {
+      number: '213',
       character: '认',
       count: '191866',
       percentage: '57.0890429779',
       pinyin: 'ren4',
-      meaning: 'to recognize/to know/to admit' });
+      meaning: 'to recognize/to know/to admit'
+    });
   });
 
-  it("gets character by position in frequency list", function() {
-    assert.deepEqual(hanzi.getCharacterInFrequencyListByPosition(111), { number: '111',
+  it('gets character by position in frequency list', function() {
+    assert.deepEqual(hanzi.getCharacterInFrequencyListByPosition(111), {
+      number: '111',
       character: '机',
       count: '339823',
       percentage: '43.7756134862',
       pinyin: 'ji1',
-      meaning: 'machine/opportunity/secret' });
+      meaning: 'machine/opportunity/secret'
+    });
   });
 
   it("gets a traditional character by position in frequency list that doesn't have a simplified variant", function() {
-    assert.deepEqual(hanzi.getCharacterInFrequencyListByPosition(6649), { number: '6649',
+    assert.deepEqual(hanzi.getCharacterInFrequencyListByPosition(6649), {
+      number: '6649',
       character: '貙',
       count: '13',
       percentage: '99.9947045027',
       pinyin: 'chu1',
-      meaning: '' });
+      meaning: ''
+    });
   });
 
-  it("gets all characters with a given component", function(){
-    assert.deepEqual(hanzi.getCharactersWithComponent('囗'), [ '国','因','西','回','口','四','团','图','围','困','恩','固','烟','园','窗','圆','惯','圈','贯','衰','菌','傻','姻','咽','嗯','囚','捆','茵','粤','瑙','圃','囱','涸','媲','锢','胭','泗','蓑','囤','囿','泅','摁','囡','帼','氤','蝈','邋','蓖','崮','囫','囟','掼','圜','囵','驷','阃','鬣','囹','痼','圄','卣','掴','腦','榱','篦','硇','涠','洇','總','鱲','囝','貔','圉','溷','缞','鲴','悃','铟','腘','骢','躐','謴','璁','蒽','骃','鯝','镴','硱','鬛','逌','睏','秵','絪','駰','麕','螕','裀','稛','縕','糰','箇','膕','綑','臘','箘','聰','蔥','驄','薀','祻','繌','圊','罆','謥','貫','鏆','銦','蒕','簑','碅','薗','釦','稇','蜠','蠟','醞' ])
+  it('gets all characters with a given component', function() {
+    assert.deepEqual(hanzi.getCharactersWithComponent('囗'), [
+      '国',
+      '因',
+      '西',
+      '回',
+      '口',
+      '四',
+      '团',
+      '图',
+      '围',
+      '困',
+      '恩',
+      '固',
+      '烟',
+      '园',
+      '窗',
+      '圆',
+      '惯',
+      '圈',
+      '贯',
+      '衰',
+      '菌',
+      '傻',
+      '姻',
+      '咽',
+      '嗯',
+      '囚',
+      '捆',
+      '茵',
+      '粤',
+      '瑙',
+      '圃',
+      '囱',
+      '涸',
+      '媲',
+      '锢',
+      '胭',
+      '泗',
+      '蓑',
+      '囤',
+      '囿',
+      '泅',
+      '摁',
+      '囡',
+      '帼',
+      '氤',
+      '蝈',
+      '邋',
+      '蓖',
+      '崮',
+      '囫',
+      '囟',
+      '掼',
+      '圜',
+      '囵',
+      '驷',
+      '阃',
+      '鬣',
+      '囹',
+      '痼',
+      '圄',
+      '卣',
+      '掴',
+      '腦',
+      '榱',
+      '篦',
+      '硇',
+      '涠',
+      '洇',
+      '總',
+      '鱲',
+      '囝',
+      '貔',
+      '圉',
+      '溷',
+      '缞',
+      '鲴',
+      '悃',
+      '铟',
+      '腘',
+      '骢',
+      '躐',
+      '謴',
+      '璁',
+      '蒽',
+      '骃',
+      '鯝',
+      '镴',
+      '硱',
+      '鬛',
+      '逌',
+      '睏',
+      '秵',
+      '絪',
+      '駰',
+      '麕',
+      '螕',
+      '裀',
+      '稛',
+      '縕',
+      '糰',
+      '箇',
+      '膕',
+      '綑',
+      '臘',
+      '箘',
+      '聰',
+      '蔥',
+      '驄',
+      '薀',
+      '祻',
+      '繌',
+      '圊',
+      '罆',
+      '謥',
+      '貫',
+      '鏆',
+      '銦',
+      '蒕',
+      '簑',
+      '碅',
+      '薗',
+      '釦',
+      '稇',
+      '蜠',
+      '蠟',
+      '醞'
+    ]);
   });
 
-  it("determines phonetic regularity", function(){
+  it('determines phonetic regularity', function() {
     var expected = {
       di1: {
         character: '低',
-        component: [ '亻', '氐', '氐', '亻', '氏', '氏', '丶', '丶' ],
-        phoneticpinyin: [ 'ren2', 'di1', 'di3', 'ren2', 'shi4', 'zhi1', 'dian3', 'zhu3' ],
-        regularity: [ 0, 1, 2, 0, 4, 4, 3, 0 ]
+        component: ['亻', '氐', '氐', '亻', '氏', '氏', '丶', '丶'],
+        phoneticpinyin: [
+          'ren2',
+          'di1',
+          'di3',
+          'ren2',
+          'shi4',
+          'zhi1',
+          'dian3',
+          'zhu3'
+        ],
+        regularity: [0, 1, 2, 0, 4, 4, 3, 0]
       }
     };
     assert.deepEqual(hanzi.determinePhoneticRegularity('低'), expected);
   });
 
-  it('should once decompose simplified character', function(){
-    assert.deepEqual(hanzi.decompose('爱').components1, ['No glyph available', '友']);
+  it('should once decompose simplified character', function() {
+    assert.deepEqual(hanzi.decompose('爱').components1, [
+      'No glyph available',
+      '友'
+    ]);
   });
-  it('should radical decompose simplified character', function(){
+  it('should radical decompose simplified character', function() {
     assert.deepEqual(hanzi.decompose('爱').components2, ['爫', '冖', '𠂇', '又']);
   });
-  it('should graphical decompose simplified character', function(){
-    assert.deepEqual(hanzi.decompose('爱').components3, ['爫', '冖', '𠂇', '㇇', '㇏']);
+  it('should graphical decompose simplified character', function() {
+    assert.deepEqual(hanzi.decompose('爱').components3, [
+      '爫',
+      '冖',
+      '𠂇',
+      '㇇',
+      '㇏'
+    ]);
   });
 
-  it('should once decompose traditional character', function(){
-    assert.deepEqual(hanzi.decompose('愛').components1, ['No glyph available','夂']);
+  it('should once decompose traditional character', function() {
+    assert.deepEqual(hanzi.decompose('愛').components1, [
+      'No glyph available',
+      '夂'
+    ]);
   });
-  it('should radical decompose traditional character', function(){
-    assert.deepEqual(hanzi.decompose('愛').components2, ['爫','冖','心','夂']);
+  it('should radical decompose traditional character', function() {
+    assert.deepEqual(hanzi.decompose('愛').components2, ['爫', '冖', '心', '夂']);
   });
-  it('should graphical decompose traditional character', function(){
-    assert.deepEqual(hanzi.decompose('愛').components3, ['爫','冖','𠁼','㇃','㇇','㇏','㇒']);
+  it('should graphical decompose traditional character', function() {
+    assert.deepEqual(hanzi.decompose('愛').components3, [
+      '爫',
+      '冖',
+      '𠁼',
+      '㇃',
+      '㇇',
+      '㇏',
+      '㇒'
+    ]);
   });
 });
 
 describe('decomposeMany', () => {
   it('returns three characters', () => {
     assert.deepEqual(hanzi.decomposeMany('和挂爱'), {
-        和: {
-          character: '和',
-          components1: ['禾', '口'],
-          components2: ['禾', '口'],
-          components3: ['㇒', '一', '丨', '八', '口'],
-        },
-        挂: {
-          character: '挂',
-          components1: ['扌', '圭'],
-          components2: ['扌', '圭'],
-          components3: ['亅', '二', '圭'],
-        },
-        爱: {
-          character: '爱',
-          components1: ['No glyph available', '友'],
-          components2: ['爫', '冖', '𠂇', '又'],
-          components3: ['爫', '冖', '𠂇', '㇇', '㇏'],
-        },
+      和: {
+        character: '和',
+        components1: ['禾', '口'],
+        components2: ['禾', '口'],
+        components3: ['㇒', '一', '丨', '八', '口']
       },
-    );
+      挂: {
+        character: '挂',
+        components1: ['扌', '圭'],
+        components2: ['扌', '圭'],
+        components3: ['亅', '二', '圭']
+      },
+      爱: {
+        character: '爱',
+        components1: ['No glyph available', '友'],
+        components2: ['爫', '冖', '𠂇', '又'],
+        components3: ['爫', '冖', '𠂇', '㇇', '㇏']
+      }
+    });
   });
 });

--- a/test/dictionary.js
+++ b/test/dictionary.js
@@ -5,31 +5,37 @@ hanzi.start();
 
 describe('hanzidictionary', function() {
   it('should look up a definition', function() {
-    var expected = [{
-      traditional: '愛',
-      simplified: '爱',
-      pinyin: 'ai4',
-      definition: 'to love/affection/to be fond of/to like'
-    }];
+    var expected = [
+      {
+        traditional: '愛',
+        simplified: '爱',
+        pinyin: 'ai4',
+        definition: 'to love/affection/to be fond of/to like'
+      }
+    ];
     assert.deepEqual(hanzi.definitionLookup('爱'), expected);
     assert.deepEqual(hanzi.definitionLookup('愛'), expected);
   });
   it('should look up a simplified definition with simplified character', function() {
-    var expected = [{
-      traditional: '愛',
-      simplified: '爱',
-      pinyin: 'ai4',
-      definition: 'to love/affection/to be fond of/to like'
-    }];
+    var expected = [
+      {
+        traditional: '愛',
+        simplified: '爱',
+        pinyin: 'ai4',
+        definition: 'to love/affection/to be fond of/to like'
+      }
+    ];
     assert.deepEqual(hanzi.definitionLookup('爱', 's'), expected);
   });
   it('should look up a traditional definition with traditional character', function() {
-    var expected = [{
-      traditional: '愛',
-      simplified: '爱',
-      pinyin: 'ai4',
-      definition: 'to love/affection/to be fond of/to like'
-    }];
+    var expected = [
+      {
+        traditional: '愛',
+        simplified: '爱',
+        pinyin: 'ai4',
+        definition: 'to love/affection/to be fond of/to like'
+      }
+    ];
     assert.deepEqual(hanzi.definitionLookup('愛', 't'), expected);
   });
   it('should fail looking up a simplified definition with a traditional character', function() {
@@ -39,27 +45,31 @@ describe('hanzidictionary', function() {
     assert.deepEqual(hanzi.definitionLookup('爱', 't'), undefined);
   });
   it('should look up a definition with multiple characters', function() {
-    var expected = [{
-      traditional: '最後',
-      simplified: '最后',
-      pinyin: 'zui4 hou4',
-      definition: 'final/last/finally/ultimate'
-    }];
+    var expected = [
+      {
+        traditional: '最後',
+        simplified: '最后',
+        pinyin: 'zui4 hou4',
+        definition: 'final/last/finally/ultimate'
+      }
+    ];
     assert.deepEqual(hanzi.definitionLookup('最后'), expected);
   });
 
   it('should look up a definition with multiple meanings with a common character', function() {
-    var expected = [{
-      traditional: '和',
-      simplified: '和',
-      pinyin: 'He2',
-      definition: 'surname He/Japanese (food, clothes etc)'
-    },
+    var expected = [
+      {
+        traditional: '和',
+        simplified: '和',
+        pinyin: 'He2',
+        definition: 'surname He/Japanese (food, clothes etc)'
+      },
       {
         traditional: '和',
         simplified: '和',
         pinyin: 'he2',
-        definition: 'and/together with/with/sum/union/peace/harmony/Taiwan pr. [han4] when it means "and"'
+        definition:
+          'and/together with/with/sum/union/peace/harmony/Taiwan pr. [han4] when it means "and"'
       },
       {
         traditional: '和',
@@ -84,23 +94,26 @@ describe('hanzidictionary', function() {
         simplified: '和',
         pinyin: 'huo4',
         definition: 'to mix together/to blend'
-      }];
+      }
+    ];
     assert.deepEqual(hanzi.definitionLookup('和'), expected);
   });
 
   it('should look up a definition with multiple meanings with a more obscure character', function() {
-    var expected = [{
-      traditional: '糺',
-      simplified: '糺',
-      pinyin: 'jiu1',
-      definition: 'archaic variant of 糾|纠[jiu1]'
-    },
+    var expected = [
+      {
+        traditional: '糺',
+        simplified: '糺',
+        pinyin: 'jiu1',
+        definition: 'archaic variant of 糾|纠[jiu1]'
+      },
       {
         traditional: '糺',
         simplified: '糺',
         pinyin: 'jiu3',
         definition: 'army (used during the Liao, Jin and Yuan dynasties)'
-      }];
+      }
+    ];
     assert.deepEqual(hanzi.definitionLookup('糺'), expected);
   });
 
@@ -110,448 +123,598 @@ describe('hanzidictionary', function() {
 
   it('should do a dictionary search with a common character', function() {
     var expected = [
-      [{
-        traditional: '六方最密堆積',
-        simplified: '六方最密堆积',
-        pinyin: 'liu4 fang1 zui4 mi4 dui1 ji1',
-        definition: 'hexagonal close-packed (HCP) (math)'
-      }],
-      [{
-        traditional: '帕累托最優',
-        simplified: '帕累托最优',
-        pinyin: 'Pa4 lei4 tuo1 zui4 you1',
-        definition: 'Pareto efficiency (economics)/Pareto optimality'
-      }],
-      [{
-        traditional: '放射性最強點',
-        simplified: '放射性最强点',
-        pinyin: 'fang4 she4 xing4 zui4 qiang2 dian3',
-        definition: 'radioactive hot spot'
-      }],
-      [{
-        traditional: '最',
-        simplified: '最',
-        pinyin: 'zui4',
-        definition: 'most/the most/-est (superlative suffix)'
-      }],
-      [{
-        traditional: '最低潮',
-        simplified: '最低潮',
-        pinyin: 'zui4 di1 chao2',
-        definition: 'lit. low tide/fig. the lowest point (e.g. of a relationship)'
-      }],
-      [{
-        traditional: '最低谷',
-        simplified: '最低谷',
-        pinyin: 'zui4 di1 gu3',
-        definition: 'lowest point/nadir'
-      }],
-      [{
-        traditional: '最低限度',
-        simplified: '最低限度',
-        pinyin: 'zui4 di1 xian4 du4',
-        definition: 'minimum'
-      }],
-      [{
-        traditional: '最低限度理論',
-        simplified: '最低限度理论',
-        pinyin: 'zui4 di1 xian4 du4 li3 lun4',
-        definition: 'minimalist theory'
-      }],
-      [{
-        traditional: '最低音',
-        simplified: '最低音',
-        pinyin: 'zui4 di1 yin1',
-        definition: 'lowest voice/lowest pitch/lowest note'
-      }],
-      [{
-        traditional: '最低點',
-        simplified: '最低点',
-        pinyin: 'zui4 di1 dian3',
-        definition: 'lowest point/minimum (point)'
-      }],
-      [{
-        traditional: '最佳',
-        simplified: '最佳',
-        pinyin: 'zui4 jia1',
-        definition: 'optimum/optimal/peak/best (athlete, movie etc)'
-      }],
-      [{
-        traditional: '最佳利益',
-        simplified: '最佳利益',
-        pinyin: 'zui4 jia1 li4 yi4',
-        definition: 'best interests'
-      }],
-      [{
-        traditional: '最佳化',
-        simplified: '最佳化',
-        pinyin: 'zui4 jia1 hua4',
-        definition: 'optimization (math.)'
-      }],
-      [{
-        traditional: '最優',
-        simplified: '最优',
-        pinyin: 'zui4 you1',
-        definition: 'optimal/optimum'
-      }],
-      [{
-        traditional: '最優化',
-        simplified: '最优化',
-        pinyin: 'zui4 you1 hua4',
-        definition: 'optimization (math.)'
-      }],
-      [{
-        traditional: '最先',
-        simplified: '最先',
-        pinyin: 'zui4 xian1',
-        definition: '(the) very first'
-      }],
-      [{
-        traditional: '最初',
-        simplified: '最初',
-        pinyin: 'zui4 chu1',
-        definition: 'first/primary/initial'
-      }],
-      [{
-        traditional: '最善',
-        simplified: '最善',
-        pinyin: 'zui4 shan4',
-        definition: 'optimal/the best'
-      }],
-      [{
-        traditional: '最喜愛',
-        simplified: '最喜爱',
-        pinyin: 'zui4 xi3 ai4',
-        definition: 'favorite'
-      }],
-      [{
-        traditional: '最大公因子',
-        simplified: '最大公因子',
-        pinyin: 'zui4 da4 gong1 yin1 zi3',
-        definition: 'highest common factor HCF/greatest common divisor GCD'
-      }],
-      [{
-        traditional: '最大公約數',
-        simplified: '最大公约数',
-        pinyin: 'zui4 da4 gong1 yue1 shu4',
-        definition: 'highest common factor HCF/greatest common divisor GCD'
-      }],
-      [{
-        traditional: '最大化',
-        simplified: '最大化',
-        pinyin: 'zui4 da4 hua4',
-        definition: 'to maximize'
-      }],
-      [{
-        traditional: '最大速率',
-        simplified: '最大速率',
-        pinyin: 'zui4 da4 su4 lu:4',
-        definition: 'maximum speed/maximum velocity'
-      }],
-      [{
-        traditional: '最好',
-        simplified: '最好',
-        pinyin: 'zui4 hao3',
-        definition: 'best/(you) had better (do what we suggest)'
-      }],
-      [{
-        traditional: '最密堆積',
-        simplified: '最密堆积',
-        pinyin: 'zui4 mi4 dui1 ji1',
-        definition: 'close-packing of spheres (math)'
-      }],
-      [{
-        traditional: '最小二乘',
-        simplified: '最小二乘',
-        pinyin: 'zui4 xiao3 er4 cheng2',
-        definition: 'least square (estimate)'
-      }],
-      [{
-        traditional: '最小值',
-        simplified: '最小值',
-        pinyin: 'zui4 xiao3 zhi2',
-        definition: 'least value/minimum'
-      }],
-      [{
-        traditional: '最小公倍數',
-        simplified: '最小公倍数',
-        pinyin: 'zui4 xiao3 gong1 bei4 shu4',
-        definition: 'least common multiple'
-      }],
-      [{
-        traditional: '最小公分母',
-        simplified: '最小公分母',
-        pinyin: 'zui4 xiao3 gong1 fen1 mu3',
-        definition: 'lowest common denominator'
-      }],
-      [{
-        traditional: '最小化',
-        simplified: '最小化',
-        pinyin: 'zui4 xiao3 hua4',
-        definition: 'minimize (computing)'
-      }],
-      [{
-        traditional: '最差',
-        simplified: '最差',
-        pinyin: 'zui4 cha1',
-        definition: 'least/worst/the least/the worst'
-      }],
-      [{
-        traditional: '最年長',
-        simplified: '最年长',
-        pinyin: 'zui4 nian2 zhang3',
-        definition: 'eldest'
-      }],
-      [{
-        traditional: '最後',
-        simplified: '最后',
-        pinyin: 'zui4 hou4',
-        definition: 'final/last/finally/ultimate'
-      }],
-      [{
-        traditional: '最後一天',
-        simplified: '最后一天',
-        pinyin: 'zui4 hou4 yi1 tian1',
-        definition: 'final day'
-      }],
-      [{
-        traditional: '最後晚餐',
-        simplified: '最后晚餐',
-        pinyin: 'zui4 hou4 wan3 can1',
-        definition: 'the Last Supper (in the biblical Passion story)'
-      }],
-      [{
-        traditional: '最後更新',
-        simplified: '最后更新',
-        pinyin: 'zui4 hou4 geng1 xin1',
-        definition: 'latest update/most recent update'
-      }],
-      [{
-        traditional: '最後期限',
-        simplified: '最后期限',
-        pinyin: 'zui4 hou4 qi1 xian4',
-        definition: 'deadline/final time limit (for project)'
-      }],
-      [{
-        traditional: '最後的晚餐',
-        simplified: '最后的晚餐',
-        pinyin: 'zui4 hou4 de5 wan3 can1',
-        definition: 'the Last Supper (in the Christian Passion story)'
-      }],
-      [{
-        traditional: '最後通牒',
-        simplified: '最后通牒',
-        pinyin: 'zui4 hou4 tong1 die2',
-        definition: 'ultimatum'
-      }],
-      [{
-        traditional: '最惠國',
-        simplified: '最惠国',
-        pinyin: 'zui4 hui4 guo2',
-        definition: 'most-favored nation (trade status)'
-      }],
-      [{
-        traditional: '最惠國待遇',
-        simplified: '最惠国待遇',
-        pinyin: 'zui4 hui4 guo2 dai4 yu4',
-        definition: 'most favored nation'
-      }],
-      [{
-        traditional: '最新',
-        simplified: '最新',
-        pinyin: 'zui4 xin1',
-        definition: 'latest/newest'
-      }],
-      [{
-        traditional: '最為',
-        simplified: '最为',
-        pinyin: 'zui4 wei2',
-        definition: 'the most'
-      }],
-      [{
-        traditional: '最牛',
-        simplified: '最牛',
-        pinyin: 'zui4 niu2',
-        definition: 'tough as nails'
-      }],
-      [{
-        traditional: '最終',
-        simplified: '最终',
-        pinyin: 'zui4 zhong1',
-        definition: 'final/ultimate'
-      }],
-      [{
-        traditional: '最終幻想',
-        simplified: '最终幻想',
-        pinyin: 'Zui4 zhong1 Huan4 xiang3',
-        definition: 'Final Fantasy (video game)'
-      }],
-      [{
-        traditional: '最近',
-        simplified: '最近',
-        pinyin: 'zui4 jin4',
-        definition: 'recent/recently/these days/latest/soon/nearest (of locations)/shortest (of routes)'
-      }],
-      [{
-        traditional: '最近幾年',
-        simplified: '最近几年',
-        pinyin: 'zui4 jin4 ji3 nian2',
-        definition: 'the last few years/last several years/recent years'
-      }],
-      [{
-        traditional: '最遠',
-        simplified: '最远',
-        pinyin: 'zui4 yuan3',
-        definition: 'furthest/most distant/at maximum distance'
-      }],
-      [{
-        traditional: '最高人民檢察院',
-        simplified: '最高人民检察院',
-        pinyin: 'Zui4 gao1 Ren2 min2 Jian3 cha2 yuan4',
-        definition: 'PRC Supreme People\'s Procuratorate (prosecutor\'s office)'
-      }],
-      [{
-        traditional: '最高人民法院',
-        simplified: '最高人民法院',
-        pinyin: 'Zui4 gao1 Ren2 min2 Fa3 yuan4',
-        definition: 'Supreme People\'s Court (PRC)'
-      }],
-      [{
-        traditional: '最高工資限額',
-        simplified: '最高工资限额',
-        pinyin: 'zui4 gao1 gong1 zi1 xian4 e2',
-        definition: 'wage ceiling'
-      }],
-      [{
-        traditional: '最高法院',
-        simplified: '最高法院',
-        pinyin: 'zui4 gao1 fa3 yuan4',
-        definition: 'supreme court'
-      }],
-      [{
-        traditional: '最高等',
-        simplified: '最高等',
-        pinyin: 'zui4 gao1 deng3',
-        definition: 'highest level/top class'
-      }],
-      [{
-        traditional: '最高限額',
-        simplified: '最高限额',
-        pinyin: 'zui4 gao1 xian4 e2',
-        definition: 'maximum amount/ceiling/upper limit/quota'
-      }],
-      [{
-        traditional: '最高音',
-        simplified: '最高音',
-        pinyin: 'zui4 gao1 yin1',
-        definition: 'highest voice/highest pitch/highest note'
-      }],
-      [{
-        traditional: '歷來最低點',
-        simplified: '历来最低点',
-        pinyin: 'li4 lai2 zui4 di1 dian3',
-        definition: 'all time low (point)'
-      }],
-      [{
-        traditional: '真聲最高音',
-        simplified: '真声最高音',
-        pinyin: 'zhen1 sheng1 zui4 gao1 yin1',
-        definition: 'highest true (non-falsetto) voice'
-      }],
-      [{
-        traditional: '美國最高法院',
-        simplified: '美国最高法院',
-        pinyin: 'Mei3 guo2 Zui4 gao1 Fa3 yuan4',
-        definition: 'Supreme Court of the United States'
-      }],
-      [{
-        traditional: '蘇聯最高蘇維埃',
-        simplified: '苏联最高苏维埃',
-        pinyin: 'Su1 lian2 Zui4 gao1 Su1 wei2 ai1',
-        definition: 'Supreme Soviet'
-      }],
-      [{
-        traditional: '誰笑到最後，誰笑得最好',
-        simplified: '谁笑到最后，谁笑得最好',
-        pinyin: 'shei2 xiao4 dao4 zui4 hou4 , shei2 xiao4 de2 zui4 hao3',
-        definition: 'He laughs best who laughs last.'
-      }],
-      [{
-        traditional: '誰笑在最後，誰笑得最好',
-        simplified: '谁笑在最后，谁笑得最好',
-        pinyin: 'shei2 xiao4 zai4 zui4 hou4 , shei2 xiao4 de2 zui4 hao3',
-        definition: 'He laughs best who laughs last.'
-      }],
-      [{
-        traditional: '面心立方最密堆積',
-        simplified: '面心立方最密堆积',
-        pinyin: 'mian4 xin1 li4 fang1 zui4 mi4 dui1 ji1',
-        definition: 'face-centered cubic (FCC) (math)'
-      }]];
+      [
+        {
+          traditional: '六方最密堆積',
+          simplified: '六方最密堆积',
+          pinyin: 'liu4 fang1 zui4 mi4 dui1 ji1',
+          definition: 'hexagonal close-packed (HCP) (math)'
+        }
+      ],
+      [
+        {
+          traditional: '帕累托最優',
+          simplified: '帕累托最优',
+          pinyin: 'Pa4 lei4 tuo1 zui4 you1',
+          definition: 'Pareto efficiency (economics)/Pareto optimality'
+        }
+      ],
+      [
+        {
+          traditional: '放射性最強點',
+          simplified: '放射性最强点',
+          pinyin: 'fang4 she4 xing4 zui4 qiang2 dian3',
+          definition: 'radioactive hot spot'
+        }
+      ],
+      [
+        {
+          traditional: '最',
+          simplified: '最',
+          pinyin: 'zui4',
+          definition: 'most/the most/-est (superlative suffix)'
+        }
+      ],
+      [
+        {
+          traditional: '最低潮',
+          simplified: '最低潮',
+          pinyin: 'zui4 di1 chao2',
+          definition:
+            'lit. low tide/fig. the lowest point (e.g. of a relationship)'
+        }
+      ],
+      [
+        {
+          traditional: '最低谷',
+          simplified: '最低谷',
+          pinyin: 'zui4 di1 gu3',
+          definition: 'lowest point/nadir'
+        }
+      ],
+      [
+        {
+          traditional: '最低限度',
+          simplified: '最低限度',
+          pinyin: 'zui4 di1 xian4 du4',
+          definition: 'minimum'
+        }
+      ],
+      [
+        {
+          traditional: '最低限度理論',
+          simplified: '最低限度理论',
+          pinyin: 'zui4 di1 xian4 du4 li3 lun4',
+          definition: 'minimalist theory'
+        }
+      ],
+      [
+        {
+          traditional: '最低音',
+          simplified: '最低音',
+          pinyin: 'zui4 di1 yin1',
+          definition: 'lowest voice/lowest pitch/lowest note'
+        }
+      ],
+      [
+        {
+          traditional: '最低點',
+          simplified: '最低点',
+          pinyin: 'zui4 di1 dian3',
+          definition: 'lowest point/minimum (point)'
+        }
+      ],
+      [
+        {
+          traditional: '最佳',
+          simplified: '最佳',
+          pinyin: 'zui4 jia1',
+          definition: 'optimum/optimal/peak/best (athlete, movie etc)'
+        }
+      ],
+      [
+        {
+          traditional: '最佳利益',
+          simplified: '最佳利益',
+          pinyin: 'zui4 jia1 li4 yi4',
+          definition: 'best interests'
+        }
+      ],
+      [
+        {
+          traditional: '最佳化',
+          simplified: '最佳化',
+          pinyin: 'zui4 jia1 hua4',
+          definition: 'optimization (math.)'
+        }
+      ],
+      [
+        {
+          traditional: '最優',
+          simplified: '最优',
+          pinyin: 'zui4 you1',
+          definition: 'optimal/optimum'
+        }
+      ],
+      [
+        {
+          traditional: '最優化',
+          simplified: '最优化',
+          pinyin: 'zui4 you1 hua4',
+          definition: 'optimization (math.)'
+        }
+      ],
+      [
+        {
+          traditional: '最先',
+          simplified: '最先',
+          pinyin: 'zui4 xian1',
+          definition: '(the) very first'
+        }
+      ],
+      [
+        {
+          traditional: '最初',
+          simplified: '最初',
+          pinyin: 'zui4 chu1',
+          definition: 'first/primary/initial'
+        }
+      ],
+      [
+        {
+          traditional: '最善',
+          simplified: '最善',
+          pinyin: 'zui4 shan4',
+          definition: 'optimal/the best'
+        }
+      ],
+      [
+        {
+          traditional: '最喜愛',
+          simplified: '最喜爱',
+          pinyin: 'zui4 xi3 ai4',
+          definition: 'favorite'
+        }
+      ],
+      [
+        {
+          traditional: '最大公因子',
+          simplified: '最大公因子',
+          pinyin: 'zui4 da4 gong1 yin1 zi3',
+          definition: 'highest common factor HCF/greatest common divisor GCD'
+        }
+      ],
+      [
+        {
+          traditional: '最大公約數',
+          simplified: '最大公约数',
+          pinyin: 'zui4 da4 gong1 yue1 shu4',
+          definition: 'highest common factor HCF/greatest common divisor GCD'
+        }
+      ],
+      [
+        {
+          traditional: '最大化',
+          simplified: '最大化',
+          pinyin: 'zui4 da4 hua4',
+          definition: 'to maximize'
+        }
+      ],
+      [
+        {
+          traditional: '最大速率',
+          simplified: '最大速率',
+          pinyin: 'zui4 da4 su4 lu:4',
+          definition: 'maximum speed/maximum velocity'
+        }
+      ],
+      [
+        {
+          traditional: '最好',
+          simplified: '最好',
+          pinyin: 'zui4 hao3',
+          definition: 'best/(you) had better (do what we suggest)'
+        }
+      ],
+      [
+        {
+          traditional: '最密堆積',
+          simplified: '最密堆积',
+          pinyin: 'zui4 mi4 dui1 ji1',
+          definition: 'close-packing of spheres (math)'
+        }
+      ],
+      [
+        {
+          traditional: '最小二乘',
+          simplified: '最小二乘',
+          pinyin: 'zui4 xiao3 er4 cheng2',
+          definition: 'least square (estimate)'
+        }
+      ],
+      [
+        {
+          traditional: '最小值',
+          simplified: '最小值',
+          pinyin: 'zui4 xiao3 zhi2',
+          definition: 'least value/minimum'
+        }
+      ],
+      [
+        {
+          traditional: '最小公倍數',
+          simplified: '最小公倍数',
+          pinyin: 'zui4 xiao3 gong1 bei4 shu4',
+          definition: 'least common multiple'
+        }
+      ],
+      [
+        {
+          traditional: '最小公分母',
+          simplified: '最小公分母',
+          pinyin: 'zui4 xiao3 gong1 fen1 mu3',
+          definition: 'lowest common denominator'
+        }
+      ],
+      [
+        {
+          traditional: '最小化',
+          simplified: '最小化',
+          pinyin: 'zui4 xiao3 hua4',
+          definition: 'minimize (computing)'
+        }
+      ],
+      [
+        {
+          traditional: '最差',
+          simplified: '最差',
+          pinyin: 'zui4 cha1',
+          definition: 'least/worst/the least/the worst'
+        }
+      ],
+      [
+        {
+          traditional: '最年長',
+          simplified: '最年长',
+          pinyin: 'zui4 nian2 zhang3',
+          definition: 'eldest'
+        }
+      ],
+      [
+        {
+          traditional: '最後',
+          simplified: '最后',
+          pinyin: 'zui4 hou4',
+          definition: 'final/last/finally/ultimate'
+        }
+      ],
+      [
+        {
+          traditional: '最後一天',
+          simplified: '最后一天',
+          pinyin: 'zui4 hou4 yi1 tian1',
+          definition: 'final day'
+        }
+      ],
+      [
+        {
+          traditional: '最後晚餐',
+          simplified: '最后晚餐',
+          pinyin: 'zui4 hou4 wan3 can1',
+          definition: 'the Last Supper (in the biblical Passion story)'
+        }
+      ],
+      [
+        {
+          traditional: '最後更新',
+          simplified: '最后更新',
+          pinyin: 'zui4 hou4 geng1 xin1',
+          definition: 'latest update/most recent update'
+        }
+      ],
+      [
+        {
+          traditional: '最後期限',
+          simplified: '最后期限',
+          pinyin: 'zui4 hou4 qi1 xian4',
+          definition: 'deadline/final time limit (for project)'
+        }
+      ],
+      [
+        {
+          traditional: '最後的晚餐',
+          simplified: '最后的晚餐',
+          pinyin: 'zui4 hou4 de5 wan3 can1',
+          definition: 'the Last Supper (in the Christian Passion story)'
+        }
+      ],
+      [
+        {
+          traditional: '最後通牒',
+          simplified: '最后通牒',
+          pinyin: 'zui4 hou4 tong1 die2',
+          definition: 'ultimatum'
+        }
+      ],
+      [
+        {
+          traditional: '最惠國',
+          simplified: '最惠国',
+          pinyin: 'zui4 hui4 guo2',
+          definition: 'most-favored nation (trade status)'
+        }
+      ],
+      [
+        {
+          traditional: '最惠國待遇',
+          simplified: '最惠国待遇',
+          pinyin: 'zui4 hui4 guo2 dai4 yu4',
+          definition: 'most favored nation'
+        }
+      ],
+      [
+        {
+          traditional: '最新',
+          simplified: '最新',
+          pinyin: 'zui4 xin1',
+          definition: 'latest/newest'
+        }
+      ],
+      [
+        {
+          traditional: '最為',
+          simplified: '最为',
+          pinyin: 'zui4 wei2',
+          definition: 'the most'
+        }
+      ],
+      [
+        {
+          traditional: '最牛',
+          simplified: '最牛',
+          pinyin: 'zui4 niu2',
+          definition: 'tough as nails'
+        }
+      ],
+      [
+        {
+          traditional: '最終',
+          simplified: '最终',
+          pinyin: 'zui4 zhong1',
+          definition: 'final/ultimate'
+        }
+      ],
+      [
+        {
+          traditional: '最終幻想',
+          simplified: '最终幻想',
+          pinyin: 'Zui4 zhong1 Huan4 xiang3',
+          definition: 'Final Fantasy (video game)'
+        }
+      ],
+      [
+        {
+          traditional: '最近',
+          simplified: '最近',
+          pinyin: 'zui4 jin4',
+          definition:
+            'recent/recently/these days/latest/soon/nearest (of locations)/shortest (of routes)'
+        }
+      ],
+      [
+        {
+          traditional: '最近幾年',
+          simplified: '最近几年',
+          pinyin: 'zui4 jin4 ji3 nian2',
+          definition: 'the last few years/last several years/recent years'
+        }
+      ],
+      [
+        {
+          traditional: '最遠',
+          simplified: '最远',
+          pinyin: 'zui4 yuan3',
+          definition: 'furthest/most distant/at maximum distance'
+        }
+      ],
+      [
+        {
+          traditional: '最高人民檢察院',
+          simplified: '最高人民检察院',
+          pinyin: 'Zui4 gao1 Ren2 min2 Jian3 cha2 yuan4',
+          definition: "PRC Supreme People's Procuratorate (prosecutor's office)"
+        }
+      ],
+      [
+        {
+          traditional: '最高人民法院',
+          simplified: '最高人民法院',
+          pinyin: 'Zui4 gao1 Ren2 min2 Fa3 yuan4',
+          definition: "Supreme People's Court (PRC)"
+        }
+      ],
+      [
+        {
+          traditional: '最高工資限額',
+          simplified: '最高工资限额',
+          pinyin: 'zui4 gao1 gong1 zi1 xian4 e2',
+          definition: 'wage ceiling'
+        }
+      ],
+      [
+        {
+          traditional: '最高法院',
+          simplified: '最高法院',
+          pinyin: 'zui4 gao1 fa3 yuan4',
+          definition: 'supreme court'
+        }
+      ],
+      [
+        {
+          traditional: '最高等',
+          simplified: '最高等',
+          pinyin: 'zui4 gao1 deng3',
+          definition: 'highest level/top class'
+        }
+      ],
+      [
+        {
+          traditional: '最高限額',
+          simplified: '最高限额',
+          pinyin: 'zui4 gao1 xian4 e2',
+          definition: 'maximum amount/ceiling/upper limit/quota'
+        }
+      ],
+      [
+        {
+          traditional: '最高音',
+          simplified: '最高音',
+          pinyin: 'zui4 gao1 yin1',
+          definition: 'highest voice/highest pitch/highest note'
+        }
+      ],
+      [
+        {
+          traditional: '歷來最低點',
+          simplified: '历来最低点',
+          pinyin: 'li4 lai2 zui4 di1 dian3',
+          definition: 'all time low (point)'
+        }
+      ],
+      [
+        {
+          traditional: '真聲最高音',
+          simplified: '真声最高音',
+          pinyin: 'zhen1 sheng1 zui4 gao1 yin1',
+          definition: 'highest true (non-falsetto) voice'
+        }
+      ],
+      [
+        {
+          traditional: '美國最高法院',
+          simplified: '美国最高法院',
+          pinyin: 'Mei3 guo2 Zui4 gao1 Fa3 yuan4',
+          definition: 'Supreme Court of the United States'
+        }
+      ],
+      [
+        {
+          traditional: '蘇聯最高蘇維埃',
+          simplified: '苏联最高苏维埃',
+          pinyin: 'Su1 lian2 Zui4 gao1 Su1 wei2 ai1',
+          definition: 'Supreme Soviet'
+        }
+      ],
+      [
+        {
+          traditional: '誰笑到最後，誰笑得最好',
+          simplified: '谁笑到最后，谁笑得最好',
+          pinyin: 'shei2 xiao4 dao4 zui4 hou4 , shei2 xiao4 de2 zui4 hao3',
+          definition: 'He laughs best who laughs last.'
+        }
+      ],
+      [
+        {
+          traditional: '誰笑在最後，誰笑得最好',
+          simplified: '谁笑在最后，谁笑得最好',
+          pinyin: 'shei2 xiao4 zai4 zui4 hou4 , shei2 xiao4 de2 zui4 hao3',
+          definition: 'He laughs best who laughs last.'
+        }
+      ],
+      [
+        {
+          traditional: '面心立方最密堆積',
+          simplified: '面心立方最密堆积',
+          pinyin: 'mian4 xin1 li4 fang1 zui4 mi4 dui1 ji1',
+          definition: 'face-centered cubic (FCC) (math)'
+        }
+      ]
+    ];
     assert.deepEqual(hanzi.dictionarySearch('最'), expected);
   });
 
   it('should do a dictionary search and return words with only that entry', function() {
     var expected = [
-      [{
-        traditional: '爸',
-        simplified: '爸',
-        pinyin: 'ba4',
-        definition: 'father/dad/pa/papa'
-      }],
-      [{
-        traditional: '爸爸',
-        simplified: '爸爸',
-        pinyin: 'ba4 ba5',
-        definition: '(informal) father/CL:個|个[ge4],位[wei4]'
-      }]
+      [
+        {
+          traditional: '爸',
+          simplified: '爸',
+          pinyin: 'ba4',
+          definition: 'father/dad/pa/papa'
+        }
+      ],
+      [
+        {
+          traditional: '爸爸',
+          simplified: '爸爸',
+          pinyin: 'ba4 ba5',
+          definition: '(informal) father/CL:個|个[ge4],位[wei4]'
+        }
+      ]
     ];
     assert.deepEqual(hanzi.dictionarySearch('爸', 'only'), expected);
   });
 
   it('should now do a dictionary search with the same character and ignore the only condition', function() {
-    var expected = [[{
-      traditional: '兔爸',
-      simplified: '兔爸',
-      pinyin: 'tu4 ba4',
-      definition: 'toolbar (in computer software) (loanword)'
-    }],
-      [{
-        traditional: '爸',
-        simplified: '爸',
-        pinyin: 'ba4',
-        definition: 'father/dad/pa/papa'
-      }],
-      [{
-        traditional: '爸爸',
-        simplified: '爸爸',
-        pinyin: 'ba4 ba5',
-        definition: '(informal) father/CL:個|个[ge4],位[wei4]'
-      }],
-      [{
-        traditional: '老爸',
-        simplified: '老爸',
-        pinyin: 'lao3 ba4',
-        definition: 'father/dad'
-      }],
-      [{
-        traditional: '親爸',
-        simplified: '亲爸',
-        pinyin: 'qin1 ba4',
-        definition: 'one\'s own father/biological father'
-      }],
-      [{
-        traditional: '阿爸',
-        simplified: '阿爸',
-        pinyin: 'A1 ba4',
-        definition: 'Abba (Aramaic word father)/by ext. God the Father in Christian gospel'
-      }],
-      [{
-        traditional: '阿爸父',
-        simplified: '阿爸父',
-        pinyin: 'A1 ba4 fu4',
-        definition: 'Abba (Aramaic word father)/by ext. God the Father in Christian gospel'
-      }]
+    var expected = [
+      [
+        {
+          traditional: '兔爸',
+          simplified: '兔爸',
+          pinyin: 'tu4 ba4',
+          definition: 'toolbar (in computer software) (loanword)'
+        }
+      ],
+      [
+        {
+          traditional: '爸',
+          simplified: '爸',
+          pinyin: 'ba4',
+          definition: 'father/dad/pa/papa'
+        }
+      ],
+      [
+        {
+          traditional: '爸爸',
+          simplified: '爸爸',
+          pinyin: 'ba4 ba5',
+          definition: '(informal) father/CL:個|个[ge4],位[wei4]'
+        }
+      ],
+      [
+        {
+          traditional: '老爸',
+          simplified: '老爸',
+          pinyin: 'lao3 ba4',
+          definition: 'father/dad'
+        }
+      ],
+      [
+        {
+          traditional: '親爸',
+          simplified: '亲爸',
+          pinyin: 'qin1 ba4',
+          definition: "one's own father/biological father"
+        }
+      ],
+      [
+        {
+          traditional: '阿爸',
+          simplified: '阿爸',
+          pinyin: 'A1 ba4',
+          definition:
+            'Abba (Aramaic word father)/by ext. God the Father in Christian gospel'
+        }
+      ],
+      [
+        {
+          traditional: '阿爸父',
+          simplified: '阿爸父',
+          pinyin: 'A1 ba4 fu4',
+          definition:
+            'Abba (Aramaic word father)/by ext. God the Father in Christian gospel'
+        }
+      ]
     ];
     assert.deepEqual(hanzi.dictionarySearch('爸'), expected);
   });

--- a/test/get_examples.js
+++ b/test/get_examples.js
@@ -12,27 +12,27 @@ describe('getExamples', () => {
         traditional: '可愛',
         simplified: '可爱',
         pinyin: 'ke3 ai4',
-        definition: 'adorable/cute/lovely',
+        definition: 'adorable/cute/lovely'
       },
       {
         traditional: '愛',
         simplified: '爱',
         pinyin: 'ai4',
-        definition: 'to love/affection/to be fond of/to like',
+        definition: 'to love/affection/to be fond of/to like'
       },
       {
         traditional: '愛情',
         simplified: '爱情',
         pinyin: 'ai4 qing2',
-        definition: 'romance/love (romantic)/CL:個|个[ge4],份[fen4]',
+        definition: 'romance/love (romantic)/CL:個|个[ge4],份[fen4]'
       },
       {
         traditional: '親愛',
         simplified: '亲爱',
         pinyin: 'qin1 ai4',
-        definition: 'dear/beloved/darling',
-      }],
-    );
+        definition: 'dear/beloved/darling'
+      }
+    ]);
   });
 
   it('traditional', () => {
@@ -44,26 +44,26 @@ describe('getExamples', () => {
         traditional: '可愛',
         simplified: '可爱',
         pinyin: 'ke3 ai4',
-        definition: 'adorable/cute/lovely',
+        definition: 'adorable/cute/lovely'
       },
       {
         traditional: '愛',
         simplified: '爱',
         pinyin: 'ai4',
-        definition: 'to love/affection/to be fond of/to like',
+        definition: 'to love/affection/to be fond of/to like'
       },
       {
         traditional: '愛情',
         simplified: '爱情',
         pinyin: 'ai4 qing2',
-        definition: 'romance/love (romantic)/CL:個|个[ge4],份[fen4]',
+        definition: 'romance/love (romantic)/CL:個|个[ge4],份[fen4]'
       },
       {
         traditional: '親愛',
         simplified: '亲爱',
         pinyin: 'qin1 ai4',
-        definition: 'dear/beloved/darling',
-      }],
-    );
+        definition: 'dear/beloved/darling'
+      }
+    ]);
   });
 });


### PR DESCRIPTION
This npm module is really helpful for ensuring that all contributors
maintain the same style guide. Prettier auto-formats all code on commit
so that all commit automatically adhere to the the style guide

The config ignores files in the dict and data directory and does not auto-format them. (see the discussion on #33)

More info about prettier at https://github.com/prettier/prettier

I would love to merge this PR in so that future pull requests do not include many style changes

