### PR TITLE
Bug/better type checking

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,3 +30,4 @@ v2.1.1 - Fix bug where 参 failed to lookup in dictionary.
 v2.1.2 - Fix bug where 了 failed to return all the correct dictionary entries.
 v2.1.3 - Small internal change to keep Hanzi node 4 compatible
 v2.1.4 - Fixes a small boundary issue in how word frequency categories were calculated. Thanks mkmoisen!
+v2.1.5 - Better type checking in dictionarySearch function that could cause bugs

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -147,7 +147,7 @@ function dictionarySearch(character, type) {
   }
 
   //If there's nothing to be found, then try and look for traditional entries.
-  if (search == '') {
+  if (search.length == 0) {
     for (word in dictionarytraditional) {
       if (dictionarytraditional.hasOwnProperty(word)) {
         if (word.search(re) != -1) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Niel de la Rouviere",
   "description":
     "HanziJS is a Chinese character and NLP module for Chinese language processing for Node.js",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "MIT",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
While building the HanziCraft react-native app, I noticed this line in the dictionarySearch was causing issues. It was evaluated as true by the react-native environment, which was bizarre. However, in theory the type checking done here was not very neat, so I changed it and fixed the bugs I was seeing. Still not sure why the non-empty search array == '' returned true in that environment. But that's probably going deep into different compilers/transpilers etc.