### PR TITLE
Add exact lookup type for dictionarySearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Searches the dictionary based on input. Search type changes what data it returns
 Search type paramaters:
 
 *   'only' - this parameter returns only entries with the characters specfied. This is a means to find all compounds words with the characters specified.
+*   'exact' - this parameter returns entries that exactly match the characters specfied. 
 *   null - returns all occurences of the character.
 
 ```javascript
@@ -182,6 +183,13 @@ console.log(hanzi.dictionarySearch('雪'));
       definition: 'to take revenge and erase humiliation (idiom)' } ],
 
 [....] //Truncated for display purposes
+
+console.log(hanzi.dictionarySearch('小孩', 'exact'));
+
+[ { traditional: '小孩',
+    simplified: '小孩',
+    pinyin: "xiao3 hai2",
+    definition: 'child/CL:個|个[ge4]' } ]
 
 console.log(hanzi.dictionarySearch('心的小孩真', 'only'));
 

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -118,8 +118,11 @@ function definitionLookup(word, scripttype) {
   }
 }
 
+// types:
+//  only - Just the characters and no alternatives. 
+//  exact - Just the characters and no alternatives.
+//  else - finds all cases of that character 
 function dictionarySearch(character, type) {
-  /*--- Types: Only = Just the characters and no alternatives. If not then finds all cases of that character ---*/
   var search = [];
   var regexstring = '^(';
 
@@ -131,6 +134,8 @@ function dictionarySearch(character, type) {
         regexstring = regexstring + character.substring(i, i + 1) + ')+$';
       }
     }
+  } else if (type == 'exact') {
+    regexstring = `^${character}$`;
   } else {
     regexstring = '[' + character + ']';
   }

--- a/lib/dictionary.js
+++ b/lib/dictionary.js
@@ -121,7 +121,7 @@ function definitionLookup(word, scripttype) {
 // types:
 //  only - Just the characters and no alternatives. 
 //  exact - Just the characters and no alternatives.
-//  else - finds all cases of that character 
+//  null - finds all cases of that character 
 function dictionarySearch(character, type) {
   var search = [];
   var regexstring = '^(';

--- a/test/dictionary.js
+++ b/test/dictionary.js
@@ -699,6 +699,14 @@ describe('hanzidictionary', function() {
     assert.deepEqual(hanzi.dictionarySearch('爸', 'only'), expected);
   });
 
+  it('should do a dictionary search and return exact matches by passing the exact type', function() {
+    const results = hanzi.dictionarySearch('小孩', 'exact')[0]
+
+    assert.deepEqual(results.length, 1);
+    assert.deepEqual(results[0].traditional, '小孩');
+  });
+
+
   it('should now do a dictionary search with the same character and ignore the only condition', function() {
     var expected = [
       [


### PR DESCRIPTION
For my purposes, I needed a more exact lookup functionality.

For example: 
    
`console.log(hanzi.dictionarySearch('小孩', 'only'))` gave 
 
![image](https://user-images.githubusercontent.com/634562/75623113-fe034480-5b5b-11ea-8c03-d4cf2f68f013.png)

`console.log(hanzi.dictionarySearch('小孩'))` gave

![image](https://user-images.githubusercontent.com/634562/75623118-052a5280-5b5c-11ea-989e-49861b70d318.png)

But now this `console.log(hanzi.dictionarySearch('小孩', 'exact'))` gives 

![image](https://user-images.githubusercontent.com/634562/75623129-1d01d680-5b5c-11ea-836e-68f8ae27700d.png)
